### PR TITLE
매직 넘버 및 하드코딩 문자열을 Constants로 추출

### DIFF
--- a/Dochi/Models/Constants.swift
+++ b/Dochi/Models/Constants.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+enum Constants {
+    // MARK: - Timing
+
+    enum Timing {
+        /// TTS 재생 완료 후 에코 방지 딜레이 (밀리초)
+        static let echoPreventionDelayMs: UInt64 = 400
+        /// TTS 완료 대기 폴링 간격 (밀리초)
+        static let ttsCompletionPollMs: UInt64 = 100
+    }
+
+    // MARK: - LLM
+
+    enum LLM {
+        static let anthropicAPIVersion = "2023-06-01"
+        static let anthropicMaxTokens = 4096
+        /// 경량 분석용 모델 (대화 요약, 컨텍스트 압축 등)
+        static let simpleAnalysisModel = "claude-haiku-4-5-20251001"
+        /// 경량 분석 요청 시 최대 토큰 수
+        static let simpleAnalysisMaxTokens = 300
+        /// OpenAI 경량 분석용 모델
+        static let openaiSimpleModel = "gpt-4.1-nano"
+        /// Z.AI 경량 분석용 모델
+        static let zaiSimpleModel = "glm-4.7"
+    }
+
+    // MARK: - Session
+
+    enum Session {
+        /// 종료 질문에 대한 긍정 응답 키워드
+        static let endKeywords = [
+            "응", "어", "예", "네", "그래", "종료", "끝", "됐어", "괜찮아",
+            "ㅇㅇ", "웅", "yes", "yeah", "ok", "okay"
+        ]
+        /// 사용자가 직접 세션 종료를 요청하는 트리거
+        static let endTriggers = [
+            "대화종료", "대화끝", "세션종료", "세션끝",
+            "그만할게", "그만하자", "이만할게", "이만하자",
+            "끝내자", "끝낼게", "종료해", "종료할게",
+            "잘가", "잘있어", "바이바이", "bye", "goodbye"
+        ]
+        static let askEndMessage = "대화를 종료할까요?"
+        static let endConfirmMessage = "네, 대화를 종료할게요. 다음에 또 불러주세요!"
+        static let unknownUserLabel = "미확인"
+    }
+
+    // MARK: - Defaults
+
+    enum Defaults {
+        static let wakeWord = "도치야"
+        static let supertonicVoice = "F1"
+        static let ttsSpeed: Float = 1.15
+        static let ttsDiffusionSteps = 10
+        static let chatFontSize: Double = 14.0
+        static let sttSilenceTimeout: Double = 1.0
+        static let contextMaxSize = 15360
+    }
+}

--- a/Dochi/Models/Settings.swift
+++ b/Dochi/Models/Settings.swift
@@ -102,22 +102,22 @@ final class AppSettings: ObservableObject {
         Self.migrateToFileBasedContext(defaults: defaults, contextService: contextService)
 
         self.wakeWordEnabled = defaults.bool(forKey: Keys.wakeWordEnabled)
-        self.wakeWord = defaults.string(forKey: Keys.wakeWord) ?? "도치야"
+        self.wakeWord = defaults.string(forKey: Keys.wakeWord) ?? Constants.Defaults.wakeWord
 
         let providerRaw = defaults.string(forKey: Keys.llmProvider) ?? LLMProvider.openai.rawValue
         let provider = LLMProvider(rawValue: providerRaw) ?? .openai
         self.llmProvider = provider
         self.llmModel = defaults.string(forKey: Keys.llmModel) ?? provider.models.first ?? ""
 
-        let voiceRaw = defaults.string(forKey: Keys.supertonicVoice) ?? SupertonicVoice.F1.rawValue
+        let voiceRaw = defaults.string(forKey: Keys.supertonicVoice) ?? Constants.Defaults.supertonicVoice
         self.supertonicVoice = SupertonicVoice(rawValue: voiceRaw) ?? .F1
-        self.ttsSpeed = defaults.object(forKey: Keys.ttsSpeed) as? Float ?? 1.15
-        self.ttsDiffusionSteps = defaults.object(forKey: Keys.ttsDiffusionSteps) as? Int ?? 10
+        self.ttsSpeed = defaults.object(forKey: Keys.ttsSpeed) as? Float ?? Constants.Defaults.ttsSpeed
+        self.ttsDiffusionSteps = defaults.object(forKey: Keys.ttsDiffusionSteps) as? Int ?? Constants.Defaults.ttsDiffusionSteps
 
-        self.chatFontSize = defaults.object(forKey: Keys.chatFontSize) as? Double ?? 14.0
-        self.sttSilenceTimeout = defaults.object(forKey: Keys.sttSilenceTimeout) as? Double ?? 1.0
+        self.chatFontSize = defaults.object(forKey: Keys.chatFontSize) as? Double ?? Constants.Defaults.chatFontSize
+        self.sttSilenceTimeout = defaults.object(forKey: Keys.sttSilenceTimeout) as? Double ?? Constants.Defaults.sttSilenceTimeout
         self.contextAutoCompress = defaults.object(forKey: Keys.contextAutoCompress) as? Bool ?? true
-        self.contextMaxSize = defaults.object(forKey: Keys.contextMaxSize) as? Int ?? 15360
+        self.contextMaxSize = defaults.object(forKey: Keys.contextMaxSize) as? Int ?? Constants.Defaults.contextMaxSize
 
         // MCP servers
         if let data = defaults.data(forKey: Keys.mcpServers),

--- a/Dochi/Services/LLMService.swift
+++ b/Dochi/Services/LLMService.swift
@@ -100,7 +100,7 @@ final class LLMService: ObservableObject {
 
         case .anthropic:
             request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+            request.setValue(Constants.LLM.anthropicAPIVersion, forHTTPHeaderField: "anthropic-version")
             let body = buildAnthropicBody(
                 messages: messages,
                 systemPrompt: systemPrompt,
@@ -271,7 +271,7 @@ final class LLMService: ObservableObject {
             "model": model,
             "messages": apiMessages,
             "stream": true,
-            "max_tokens": 4096,
+            "max_tokens": Constants.LLM.anthropicMaxTokens,
         ]
 
         if !systemPrompt.isEmpty {


### PR DESCRIPTION
## Summary
- `Dochi/Models/Constants.swift` 생성: `Timing`, `LLM`, `Session`, `Defaults` 카테고리별 enum 구조
- `DochiViewModel.swift`: 에코 방지 딜레이(400ms), TTS 폴링(100ms), 세션 종료 키워드/트리거, 종료 메시지, 경량 분석 모델/토큰 상수 교체
- `LLMService.swift`: Anthropic API 버전(`2023-06-01`), max_tokens(`4096`) 상수 교체
- `Settings.swift`: 기본 웨이크워드(`도치야`), TTS/UI 기본값 상수 교체

## Test plan
- [x] `xcodebuild build` 성공
- [x] 기존 테스트 48개 전체 통과
- [ ] 앱 실행 후 연속 대화 세션 종료 흐름 수동 확인

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)