### PR TITLE
silent try? 제거 및 에러 핸들링 강화

### DIFF
--- a/Dochi/Services/BuiltInTools/RemindersTool.swift
+++ b/Dochi/Services/BuiltInTools/RemindersTool.swift
@@ -261,8 +261,12 @@ final class RemindersTool: BuiltInTool {
                 for r in reminders {
                     if let rTitle = r.title, rTitle.localizedCaseInsensitiveContains(title) {
                         r.isCompleted = true
-                        try? self.eventStore.save(r, commit: true)
-                        count += 1
+                        do {
+                            try self.eventStore.save(r, commit: true)
+                            count += 1
+                        } catch {
+                            Log.tool.error("리마인더 완료 처리 실패 '\(rTitle, privacy: .public)': \(error, privacy: .public)")
+                        }
                     }
                 }
                 continuation.resume(returning: count)

--- a/Dochi/Services/KeychainService.swift
+++ b/Dochi/Services/KeychainService.swift
@@ -17,7 +17,11 @@ final class KeychainService: KeychainServiceProtocol {
                 .appendingPathComponent("Dochi", isDirectory: true)
             self.storageDir = dir
         }
-        try? fileManager.createDirectory(at: storageDir, withIntermediateDirectories: true)
+        do {
+            try fileManager.createDirectory(at: storageDir, withIntermediateDirectories: true)
+        } catch {
+            Log.storage.error("키 저장소 디렉토리 생성 실패: \(error, privacy: .public)")
+        }
     }
 
     private func fileURL(account: String) -> URL {
@@ -35,7 +39,12 @@ final class KeychainService: KeychainServiceProtocol {
 
     func load(account: String) -> String? {
         let url = fileURL(account: account)
-        return try? String(contentsOf: url, encoding: .utf8)
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            // 키가 아직 저장되지 않은 경우 정상 (파일 없음)
+            return nil
+        }
     }
 
     func delete(account: String) {

--- a/Dochi/Services/SupertonicService.swift
+++ b/Dochi/Services/SupertonicService.swift
@@ -34,7 +34,11 @@ final class SupertonicService: ObservableObject {
     private static let modelDir: URL = {
         let dir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("Dochi/supertonic", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            Log.tts.error("TTS 모델 디렉토리 생성 실패: \(error, privacy: .public)")
+        }
         return dir
     }()
 
@@ -149,6 +153,7 @@ final class SupertonicService: ObservableObject {
                 // 큐에서 다음 문장 꺼내기
                 guard !self.sentenceQueue.isEmpty else {
                     // 큐 비었으면 대기 후 재확인 (LLM이 아직 스트리밍 중일 수 있음)
+                    // Task.sleep 취소는 정상 흐름 (stopPlayback 등)
                     try? await Task.sleep(for: .milliseconds(100))
 
                     // 다시 확인 — 여전히 비었고 LLM 스트리밍도 끝났으면 종료

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -169,6 +169,7 @@ final class DochiViewModel: ObservableObject {
             self.state = .idle
 
             Task {
+                // Task 취소 시 에코 방지 딜레이 스킵은 의도된 동작
                 try? await Task.sleep(for: .milliseconds(Constants.Timing.echoPreventionDelayMs))
                 guard self.state == .idle else { return }
 
@@ -546,7 +547,10 @@ final class DochiViewModel: ObservableObject {
 
     private func extractImageURLs(from content: String) -> [URL] {
         let pattern = #"!\[.*?\]\((.*?)\)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            Log.app.error("이미지 URL 정규식 컴파일 실패")
+            return []
+        }
         let range = NSRange(content.startIndex..., in: content)
         let matches = regex.matches(in: content, range: range)
         return matches.compactMap { match in
@@ -702,6 +706,7 @@ final class DochiViewModel: ObservableObject {
 
         Task {
             while supertonicService.state == .playing || supertonicService.state == .synthesizing {
+                // 폴링 대기 — 취소 시 즉시 종료 처리됨
                 try? await Task.sleep(for: .milliseconds(Constants.Timing.ttsCompletionPollMs))
             }
             endSession()

--- a/Dochi/Views/ConversationView.swift
+++ b/Dochi/Views/ConversationView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 
 struct ConversationView: View {
     @EnvironmentObject var viewModel: DochiViewModel
@@ -649,7 +650,11 @@ struct ImagePreviewView: View {
         panel.nameFieldStringValue = url.lastPathComponent
         panel.begin { result in
             if result == .OK, let destURL = panel.url {
-                try? FileManager.default.copyItem(at: url, to: destURL)
+                do {
+                    try FileManager.default.copyItem(at: url, to: destURL)
+                } catch {
+                    Log.storage.error("이미지 저장 실패: \(error, privacy: .public)")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- `try?` 패턴을 `do/catch` + `Log.*` 로깅으로 변환 (8개 파일, ~20개 패턴)
- 적절한 로그 레벨 사용: `.error` (쓰기 실패), `.warning` (읽기/파싱 실패), `.debug` (파일 미존재 등 예상 가능한 경우)
- 의도적인 `try?` (Task.sleep 취소 등)에는 주석으로 의도 명시
- 남은 `try?`는 정적 패턴 regex, JSON 직렬화 폴백 등 의도적인 경우만

## Changed Files
- `ContextService.swift`: init 디렉토리 생성, loadSystem/Memory/FamilyMemory/UserMemory, memorySize
- `ConversationService.swift`: init 디렉토리 생성, list(), load()
- `KeychainService.swift`: init 디렉토리 생성, load()
- `SupertonicService.swift`: modelDir 디렉토리 생성
- `Settings.swift`: MCP 서버 설정 encode/decode
- `ConversationView.swift`: 이미지 파일 복사
- `RemindersTool.swift`: 리마인더 완료 처리
- `DochiViewModel.swift`: regex 컴파일, Task.sleep 의도 주석

## Test plan
- [x] `xcodebuild build` 성공
- [x] 기존 테스트 48개 전체 통과
- [ ] 앱 실행 후 로그 출력 확인 (`log show --predicate 'subsystem == "com.dochi.app"'`)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)