### PR TITLE
Expand test coverage: KeychainService, AppSettings, BuiltInToolService

### DIFF
--- a/Dochi/Models/Settings.swift
+++ b/Dochi/Models/Settings.swift
@@ -5,52 +5,52 @@ import os
 @MainActor
 final class AppSettings: ObservableObject {
     @Published var wakeWordEnabled: Bool {
-        didSet { UserDefaults.standard.set(wakeWordEnabled, forKey: Keys.wakeWordEnabled) }
+        didSet { defaults.set(wakeWordEnabled, forKey: Keys.wakeWordEnabled) }
     }
     @Published var wakeWord: String {
-        didSet { UserDefaults.standard.set(wakeWord, forKey: Keys.wakeWord) }
+        didSet { defaults.set(wakeWord, forKey: Keys.wakeWord) }
     }
 
     // LLM settings
     @Published var llmProvider: LLMProvider {
         didSet {
-            UserDefaults.standard.set(llmProvider.rawValue, forKey: Keys.llmProvider)
+            defaults.set(llmProvider.rawValue, forKey: Keys.llmProvider)
             if !llmProvider.models.contains(llmModel) {
                 llmModel = llmProvider.models.first ?? ""
             }
         }
     }
     @Published var llmModel: String {
-        didSet { UserDefaults.standard.set(llmModel, forKey: Keys.llmModel) }
+        didSet { defaults.set(llmModel, forKey: Keys.llmModel) }
     }
 
     // TTS settings
     @Published var supertonicVoice: SupertonicVoice {
-        didSet { UserDefaults.standard.set(supertonicVoice.rawValue, forKey: Keys.supertonicVoice) }
+        didSet { defaults.set(supertonicVoice.rawValue, forKey: Keys.supertonicVoice) }
     }
     @Published var ttsSpeed: Float {
-        didSet { UserDefaults.standard.set(ttsSpeed, forKey: Keys.ttsSpeed) }
+        didSet { defaults.set(ttsSpeed, forKey: Keys.ttsSpeed) }
     }
     @Published var ttsDiffusionSteps: Int {
-        didSet { UserDefaults.standard.set(ttsDiffusionSteps, forKey: Keys.ttsDiffusionSteps) }
+        didSet { defaults.set(ttsDiffusionSteps, forKey: Keys.ttsDiffusionSteps) }
     }
 
     // Display settings
     @Published var chatFontSize: Double {
-        didSet { UserDefaults.standard.set(chatFontSize, forKey: Keys.chatFontSize) }
+        didSet { defaults.set(chatFontSize, forKey: Keys.chatFontSize) }
     }
 
     // STT settings
     @Published var sttSilenceTimeout: Double {
-        didSet { UserDefaults.standard.set(sttSilenceTimeout, forKey: Keys.sttSilenceTimeout) }
+        didSet { defaults.set(sttSilenceTimeout, forKey: Keys.sttSilenceTimeout) }
     }
 
     // Memory compression
     @Published var contextAutoCompress: Bool {
-        didSet { UserDefaults.standard.set(contextAutoCompress, forKey: Keys.contextAutoCompress) }
+        didSet { defaults.set(contextAutoCompress, forKey: Keys.contextAutoCompress) }
     }
     @Published var contextMaxSize: Int {
-        didSet { UserDefaults.standard.set(contextMaxSize, forKey: Keys.contextMaxSize) }
+        didSet { defaults.set(contextMaxSize, forKey: Keys.contextMaxSize) }
     }
 
     // MCP servers
@@ -62,9 +62,9 @@ final class AppSettings: ObservableObject {
     @Published var defaultUserId: UUID? {
         didSet {
             if let id = defaultUserId {
-                UserDefaults.standard.set(id.uuidString, forKey: Keys.defaultUserId)
+                defaults.set(id.uuidString, forKey: Keys.defaultUserId)
             } else {
-                UserDefaults.standard.removeObject(forKey: Keys.defaultUserId)
+                defaults.removeObject(forKey: Keys.defaultUserId)
             }
         }
     }
@@ -89,15 +89,16 @@ final class AppSettings: ObservableObject {
 
     private let keychainService: KeychainServiceProtocol
     let contextService: ContextServiceProtocol
+    private let defaults: UserDefaults
 
     init(
         keychainService: KeychainServiceProtocol = KeychainService(),
-        contextService: ContextServiceProtocol = ContextService()
+        contextService: ContextServiceProtocol = ContextService(),
+        defaults: UserDefaults = .standard
     ) {
         self.keychainService = keychainService
         self.contextService = contextService
-
-        let defaults = UserDefaults.standard
+        self.defaults = defaults
 
         // 마이그레이션
         Self.migrateToFileBasedContext(defaults: defaults, contextService: contextService)
@@ -146,7 +147,7 @@ final class AppSettings: ObservableObject {
     private func saveMCPServers() {
         do {
             let data = try JSONEncoder().encode(mcpServers)
-            UserDefaults.standard.set(data, forKey: Keys.mcpServers)
+            defaults.set(data, forKey: Keys.mcpServers)
         } catch {
             Log.storage.error("MCP 서버 설정 저장 실패: \(error, privacy: .public)")
         }

--- a/DochiTests/Mocks/MockContextService.swift
+++ b/DochiTests/Mocks/MockContextService.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import Dochi
 
-final class MockContextService: ContextServiceProtocol {
+final class MockContextService: ContextServiceProtocol, @unchecked Sendable {
     var systemContent: String = ""
     var memoryContent: String = ""
     var familyMemoryContent: String = ""

--- a/DochiTests/Mocks/MockKeychainService.swift
+++ b/DochiTests/Mocks/MockKeychainService.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import Dochi
 
-final class MockKeychainService: KeychainServiceProtocol {
+final class MockKeychainService: KeychainServiceProtocol, @unchecked Sendable {
     var storage: [String: String] = [:]
 
     func save(account: String, value: String) {

--- a/DochiTests/Models/AppSettingsTests.swift
+++ b/DochiTests/Models/AppSettingsTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class AppSettingsTests: XCTestCase {
+    var mockKeychain: MockKeychainService!
+    var mockContext: MockContextService!
+    var sut: AppSettings!
+
+    static let suiteName = "com.dochi.tests.settings"
+
+    override func setUp() {
+        let defaults = UserDefaults(suiteName: Self.suiteName)!
+        defaults.removePersistentDomain(forName: Self.suiteName)
+
+        mockKeychain = MockKeychainService()
+        mockContext = MockContextService()
+        sut = AppSettings(keychainService: mockKeychain, contextService: mockContext, defaults: defaults)
+    }
+
+    override func tearDown() {
+        UserDefaults().removePersistentDomain(forName: Self.suiteName)
+        sut = nil
+        mockKeychain = nil
+        mockContext = nil
+    }
+
+    // MARK: - Default Values
+
+    func testDefaultWakeWord() {
+        XCTAssertEqual(sut.wakeWord, Constants.Defaults.wakeWord)
+    }
+
+    func testDefaultTTSSpeed() {
+        XCTAssertEqual(sut.ttsSpeed, Constants.Defaults.ttsSpeed)
+    }
+
+    func testDefaultChatFontSize() {
+        XCTAssertEqual(sut.chatFontSize, Constants.Defaults.chatFontSize)
+    }
+
+    func testDefaultContextMaxSize() {
+        XCTAssertEqual(sut.contextMaxSize, Constants.Defaults.contextMaxSize)
+    }
+
+    func testDefaultContextAutoCompress() {
+        XCTAssertTrue(sut.contextAutoCompress)
+    }
+
+    // MARK: - API Keys
+
+    func testApiKeyStorage() {
+        sut.apiKey = "sk-test-key"
+
+        XCTAssertEqual(sut.apiKey, "sk-test-key")
+        XCTAssertEqual(mockKeychain.storage["openai"], "sk-test-key")
+    }
+
+    func testAnthropicApiKeyStorage() {
+        sut.anthropicApiKey = "sk-ant-key"
+
+        XCTAssertEqual(sut.anthropicApiKey, "sk-ant-key")
+        XCTAssertEqual(mockKeychain.storage["anthropic"], "sk-ant-key")
+    }
+
+    func testApiKeyForProvider() {
+        mockKeychain.storage["openai"] = "sk-openai"
+        mockKeychain.storage["anthropic"] = "sk-anthropic"
+        mockKeychain.storage["zai"] = "sk-zai"
+
+        XCTAssertEqual(sut.apiKey(for: .openai), "sk-openai")
+        XCTAssertEqual(sut.apiKey(for: .anthropic), "sk-anthropic")
+        XCTAssertEqual(sut.apiKey(for: .zai), "sk-zai")
+    }
+
+    func testApiKeyReturnsEmptyWhenNotSet() {
+        XCTAssertEqual(sut.apiKey(for: .openai), "")
+    }
+
+    // MARK: - MCP Server Management
+
+    func testAddMCPServer() {
+        let config = MCPServerConfig(name: "Test Server", command: "npx", arguments: ["-y", "@test/server"])
+
+        sut.addMCPServer(config)
+
+        XCTAssertEqual(sut.mcpServers.count, 1)
+        XCTAssertEqual(sut.mcpServers.first?.name, "Test Server")
+    }
+
+    func testRemoveMCPServer() {
+        let config = MCPServerConfig(name: "Test", command: "cmd", arguments: [])
+        sut.addMCPServer(config)
+
+        sut.removeMCPServer(id: config.id)
+
+        XCTAssertTrue(sut.mcpServers.isEmpty)
+    }
+
+    func testUpdateMCPServer() {
+        var config = MCPServerConfig(name: "Old Name", command: "cmd", arguments: [])
+        sut.addMCPServer(config)
+
+        config.name = "New Name"
+        sut.updateMCPServer(config)
+
+        XCTAssertEqual(sut.mcpServers.first?.name, "New Name")
+    }
+
+    // MARK: - Build Instructions
+
+    func testBuildInstructionsWithSystemPrompt() {
+        mockContext.systemContent = "You are a helpful assistant."
+
+        let instructions = sut.buildInstructions()
+
+        XCTAssertTrue(instructions.contains("You are a helpful assistant."))
+    }
+
+    func testBuildInstructionsIncludesCurrentTime() {
+        let instructions = sut.buildInstructions()
+
+        XCTAssertTrue(instructions.contains("현재 시각"))
+    }
+
+    func testBuildInstructionsWithMemory() {
+        mockContext.memoryContent = "User likes cats."
+
+        let instructions = sut.buildInstructions()
+
+        XCTAssertTrue(instructions.contains("User likes cats."))
+    }
+
+    func testBuildInstructionsWithProfiles() {
+        let profile = UserProfile(name: "Alice", aliases: ["앨리스"])
+        mockContext.profiles = [profile]
+
+        let instructions = sut.buildInstructions(
+            currentUserName: "Alice",
+            currentUserId: profile.id,
+            recentSummaries: nil
+        )
+
+        XCTAssertTrue(instructions.contains("Alice"))
+    }
+}

--- a/DochiTests/Services/BuiltInToolServiceTests.swift
+++ b/DochiTests/Services/BuiltInToolServiceTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class BuiltInToolServiceTests: XCTestCase {
+    var sut: BuiltInToolService!
+
+    override func setUp() {
+        sut = BuiltInToolService()
+    }
+
+    override func tearDown() {
+        sut = nil
+    }
+
+    // MARK: - Available Tools
+
+    func testDefaultToolsIncludeReminders() {
+        let toolNames = sut.availableTools.map(\.name)
+
+        XCTAssertTrue(toolNames.contains(where: { $0.contains("reminder") }))
+    }
+
+    func testDefaultToolsIncludeAlarm() {
+        let toolNames = sut.availableTools.map(\.name)
+
+        XCTAssertTrue(toolNames.contains(where: { $0.contains("alarm") }))
+    }
+
+    func testWebSearchNotAvailableWithoutApiKey() {
+        let toolNames = sut.availableTools.map(\.name)
+
+        XCTAssertFalse(toolNames.contains("web_search"))
+    }
+
+    func testWebSearchAvailableWithApiKey() {
+        sut.configure(tavilyApiKey: "tvly-test", falaiApiKey: "")
+
+        let toolNames = sut.availableTools.map(\.name)
+
+        XCTAssertTrue(toolNames.contains("web_search"))
+    }
+
+    func testImageGenerationNotAvailableWithoutApiKey() {
+        let toolNames = sut.availableTools.map(\.name)
+
+        XCTAssertFalse(toolNames.contains("generate_image"))
+    }
+
+    func testImageGenerationAvailableWithApiKey() {
+        sut.configure(tavilyApiKey: "", falaiApiKey: "fal-test")
+
+        let toolNames = sut.availableTools.map(\.name)
+
+        XCTAssertTrue(toolNames.contains("generate_image"))
+    }
+
+    func testMemoryToolNotAvailableWithoutProfiles() {
+        let toolNames = sut.availableTools.map(\.name)
+
+        XCTAssertFalse(toolNames.contains("save_memory"))
+    }
+
+    func testMemoryToolAvailableWithContext() {
+        let mockContext = MockContextService()
+        sut.configureUserContext(contextService: mockContext, currentUserId: UUID())
+
+        let toolNames = sut.availableTools.map(\.name)
+
+        XCTAssertTrue(toolNames.contains("save_memory"))
+    }
+
+    // MARK: - Tool Routing
+
+    func testCallUnknownToolThrowsError() async {
+        do {
+            _ = try await sut.callTool(name: "nonexistent_tool", arguments: [:])
+            XCTFail("Should have thrown")
+        } catch let error as BuiltInToolError {
+            if case .unknownTool(let name) = error {
+                XCTAssertEqual(name, "nonexistent_tool")
+            } else {
+                XCTFail("Wrong error type: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Configure
+
+    func testConfigureSetsApiKeys() {
+        sut.configure(tavilyApiKey: "tvly-key", falaiApiKey: "fal-key")
+
+        XCTAssertEqual(sut.webSearchTool.apiKey, "tvly-key")
+        XCTAssertEqual(sut.imageGenerationTool.apiKey, "fal-key")
+    }
+}

--- a/DochiTests/Services/KeychainServiceTests.swift
+++ b/DochiTests/Services/KeychainServiceTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Dochi
+
+final class KeychainServiceTests: XCTestCase {
+    var sut: KeychainService!
+    var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        sut = KeychainService(baseDirectory: tempDir)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        sut = nil
+        tempDir = nil
+    }
+
+    func testSaveAndLoad() {
+        sut.save(account: "openai", value: "sk-test-123")
+
+        let loaded = sut.load(account: "openai")
+
+        XCTAssertEqual(loaded, "sk-test-123")
+    }
+
+    func testLoadNonExistentKeyReturnsNil() {
+        let loaded = sut.load(account: "nonexistent")
+
+        XCTAssertNil(loaded)
+    }
+
+    func testDeleteKey() {
+        sut.save(account: "openai", value: "sk-test-123")
+
+        sut.delete(account: "openai")
+        let loaded = sut.load(account: "openai")
+
+        XCTAssertNil(loaded)
+    }
+
+    func testUpdateExistingKey() {
+        sut.save(account: "openai", value: "sk-old")
+
+        sut.save(account: "openai", value: "sk-new")
+        let loaded = sut.load(account: "openai")
+
+        XCTAssertEqual(loaded, "sk-new")
+    }
+
+    func testMultipleAccounts() {
+        sut.save(account: "openai", value: "sk-openai")
+        sut.save(account: "anthropic", value: "sk-anthropic")
+
+        XCTAssertEqual(sut.load(account: "openai"), "sk-openai")
+        XCTAssertEqual(sut.load(account: "anthropic"), "sk-anthropic")
+    }
+
+    func testSaveEmptyValue() {
+        sut.save(account: "openai", value: "")
+
+        let loaded = sut.load(account: "openai")
+
+        XCTAssertEqual(loaded, "")
+    }
+
+    func testDeleteNonExistentKeyDoesNotCrash() {
+        sut.delete(account: "nonexistent")
+        // Should not crash
+    }
+}


### PR DESCRIPTION
## Summary
- Add 33 new tests (48 → 81 total) for KeychainService, AppSettings, and BuiltInToolService
- Make `AppSettings` testable by injecting `UserDefaults` via `defaults` parameter (default: `.standard`)
- Add `@unchecked Sendable` to `MockContextService` and `MockKeychainService` for Swift concurrency compatibility

## Test breakdown
- **KeychainServiceTests** (7 tests): save/load, delete, update, multiple accounts, empty value, nonexistent key
- **AppSettingsTests** (16 tests): default values, API key storage/retrieval, MCP server CRUD, buildInstructions variants
- **BuiltInToolServiceTests** (10 tests): tool availability with/without API keys, unknown tool error routing, configure

## Changes to production code
- `Settings.swift`: Added injectable `defaults: UserDefaults` parameter; replaced all `UserDefaults.standard` references with stored `defaults` property

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)