### PR TITLE
Review all try? patterns: convert or document intent

### DIFF
--- a/Dochi/Models/Message.swift
+++ b/Dochi/Models/Message.swift
@@ -75,6 +75,7 @@ private struct CodableToolCall: Codable {
     init(from toolCall: ToolCall) {
         self.id = toolCall.id
         self.name = toolCall.name
+        // arguments는 이미 유효한 딕셔너리 — 직렬화 실패 시 빈 객체로 폴백
         self.argumentsJSON = (try? String(data: JSONSerialization.data(withJSONObject: toolCall.arguments), encoding: .utf8)) ?? "{}"
     }
 

--- a/Dochi/Models/ToolCall.swift
+++ b/Dochi/Models/ToolCall.swift
@@ -13,12 +13,14 @@ struct ToolCall: Identifiable, @unchecked Sendable {
         self.id = id
         self.name = name
         self.arguments = arguments
+        // arguments는 이미 유효한 딕셔너리 — 직렬화 실패는 사실상 불가
         self.argumentsData = (try? JSONSerialization.data(withJSONObject: arguments)) ?? Data()
     }
 
     init(id: String, name: String, argumentsJSON: String) {
         self.id = id
         self.name = name
+        // 외부에서 받은 JSON 문자열 파싱 — 잘못된 형식이면 빈 딕셔너리로 폴백
         if let data = argumentsJSON.data(using: .utf8),
            let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             self.arguments = parsed

--- a/Dochi/Services/ChangelogService.swift
+++ b/Dochi/Services/ChangelogService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// 버전 변경 감지 및 changelog 관리 서비스
 final class ChangelogService {
@@ -50,11 +51,15 @@ final class ChangelogService {
 
     /// Changelog 내용 로드
     func loadChangelog() -> String {
-        guard let url = bundle.url(forResource: "CHANGELOG", withExtension: "md"),
-              let content = try? String(contentsOf: url, encoding: .utf8) else {
+        guard let url = bundle.url(forResource: "CHANGELOG", withExtension: "md") else {
             return "Changelog를 불러올 수 없습니다."
         }
-        return content
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            Log.storage.warning("CHANGELOG.md 읽기 실패: \(error, privacy: .public)")
+            return "Changelog를 불러올 수 없습니다."
+        }
     }
 
     /// 현재 버전의 변경사항만 추출

--- a/Dochi/Services/ContextService.swift
+++ b/Dochi/Services/ContextService.swift
@@ -181,8 +181,12 @@ final class ContextService: ContextServiceProtocol {
     // MARK: - Profiles (사용자 프로필)
 
     func loadProfiles() -> [UserProfile] {
-        guard let data = try? Data(contentsOf: profilesFileURL) else {
+        let data: Data
+        do {
+            data = try Data(contentsOf: profilesFileURL)
+        } catch {
             // 파일 없으면 프로필 미설정 상태 (정상)
+            Log.storage.debug("profiles.json 없음 (미설정 상태): \(error, privacy: .public)")
             return []
         }
         do {

--- a/Dochi/Services/LLMService.swift
+++ b/Dochi/Services/LLMService.swift
@@ -158,6 +158,7 @@ final class LLMService: ObservableObject {
                             "type": "function",
                             "function": [
                                 "name": tc.name,
+                                // JSON 직렬화 실패 시 빈 객체로 폴백 — arguments는 이미 유효한 딕셔너리
                                 "arguments": (try? String(data: JSONSerialization.data(withJSONObject: tc.arguments), encoding: .utf8)) ?? "{}"
                             ]
                         ] as [String: Any]
@@ -324,6 +325,7 @@ final class LLMService: ObservableObject {
 
             if payload == "[DONE]" { break }
 
+            // SSE 스트림의 개별 줄 파싱 실패는 무시하고 다음 줄 처리
             guard let data = payload.data(using: .utf8),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
             else { continue }

--- a/Dochi/ViewModels/ContextAnalyzer.swift
+++ b/Dochi/ViewModels/ContextAnalyzer.swift
@@ -96,6 +96,7 @@ final class ContextAnalyzer {
             let response = try await callLLMSimple(provider: provider, apiKey: apiKey, prompt: prompt)
             let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
 
+            // LLM 응답이 JSON이 아닐 수 있음 — 파싱 실패 시 기본 제목 사용
             if let jsonData = trimmed.data(using: .utf8),
                let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] {
 

--- a/Dochi/Views/ConversationView.swift
+++ b/Dochi/Views/ConversationView.swift
@@ -489,6 +489,7 @@ struct MessageBubbleView: View {
     // ![image](url) 패턴에서 URL 추출
     private var imageURLsFromContent: [URL] {
         let pattern = #"!\[.*?\]\((.*?)\)"#
+        // 컴파일 타임 상수 패턴 — 실패 불가
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
         let range = NSRange(message.content.startIndex..., in: message.content)
         let matches = regex.matches(in: message.content, range: range)
@@ -501,6 +502,7 @@ struct MessageBubbleView: View {
     // 마크다운 이미지 태그를 제거한 텍스트
     private var textWithoutImages: String {
         let pattern = #"\n*!\[.*?\]\(.*?\)\n*"#
+        // 컴파일 타임 상수 패턴 — 실패 불가
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return message.content }
         let range = NSRange(message.content.startIndex..., in: message.content)
         return regex.stringByReplacingMatches(in: message.content, range: range, withTemplate: "")

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import os
 
 struct SettingsView: View {
     @EnvironmentObject var viewModel: DochiViewModel
@@ -277,7 +278,11 @@ struct SettingsView: View {
                                     viewModel.settings.updateMCPServer(updated)
                                     if enabled {
                                         Task {
-                                            try? await viewModel.mcpService.connect(config: updated)
+                                            do {
+                                                try await viewModel.mcpService.connect(config: updated)
+                                            } catch {
+                                                Log.mcp.error("MCP 서버 연결 실패 (\(updated.name, privacy: .public)): \(error, privacy: .public)")
+                                            }
                                         }
                                     } else {
                                         Task {
@@ -379,7 +384,11 @@ struct SettingsView: View {
                 viewModel.settings.addMCPServer(config)
                 if config.isEnabled {
                     Task {
-                        try? await viewModel.mcpService.connect(config: config)
+                        do {
+                            try await viewModel.mcpService.connect(config: config)
+                        } catch {
+                            Log.mcp.error("MCP 서버 연결 실패 (\(config.name, privacy: .public)): \(error, privacy: .public)")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Convert 4 silent `try?` patterns to `do/catch` with appropriate logging
- Add intent comments to 11 remaining intentional `try?` patterns
- Every `try?` in the codebase now has either error handling or a comment explaining why it's safe to ignore

## Changes

### Converted to do/catch + logging
| File | Pattern | Log level |
|------|---------|-----------|
| `ContextService.swift` | `Data(contentsOf: profilesFileURL)` | `.debug` (file not found is normal) |
| `ChangelogService.swift` | `String(contentsOf: url)` | `.warning` (bundled file should exist) |
| `SettingsView.swift` (2 sites) | `mcpService.connect(config:)` | `.error` (connection failure) |

### Documented with intent comments
| Category | Count | Rationale |
|----------|-------|-----------|
| `Task.sleep` | 3 | Cancellation is expected behavior (echo prevention, polling, playback) |
| `JSONSerialization` | 5 | Valid data with appropriate fallbacks (`"{}"`, `Data()`, empty dict) |
| `NSRegularExpression` | 3 | Compile-time constant patterns that cannot fail |

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)