### PR TITLE
Split DochiViewModel into focused modules (259 lines)

### DIFF
--- a/Dochi/ViewModels/ConversationManager.swift
+++ b/Dochi/ViewModels/ConversationManager.swift
@@ -1,0 +1,88 @@
+import Foundation
+import os
+
+/// 대화 히스토리 CRUD 및 요약 관리
+@MainActor
+final class ConversationManager {
+    private weak var vm: DochiViewModel?
+    private let conversationService: ConversationServiceProtocol
+
+    init(viewModel: DochiViewModel, conversationService: ConversationServiceProtocol) {
+        self.vm = viewModel
+        self.conversationService = conversationService
+    }
+
+    func loadAll() {
+        guard let vm else { return }
+        vm.conversations = conversationService.list()
+    }
+
+    func load(_ conversation: Conversation) {
+        guard let vm else { return }
+        if !vm.messages.isEmpty {
+            let sessionMessages = vm.messages
+            let sessionUserId = vm.currentUserId
+            Task {
+                await vm.contextAnalyzer.saveAndAnalyzeConversation(sessionMessages, userId: sessionUserId)
+            }
+        }
+
+        vm.currentConversationId = conversation.id
+        vm.messages = conversation.messages
+    }
+
+    func delete(id: UUID) {
+        guard let vm else { return }
+        conversationService.delete(id: id)
+        vm.conversations.removeAll { $0.id == id }
+
+        if vm.currentConversationId == id {
+            vm.currentConversationId = nil
+            vm.messages.removeAll()
+        }
+    }
+
+    func save(title: String, summary: String?, userId: UUID?, messages: [Message]) {
+        guard let vm else { return }
+        let id = vm.currentConversationId ?? UUID()
+        let now = Date()
+
+        let conversation = Conversation(
+            id: id,
+            title: title,
+            messages: messages,
+            createdAt: vm.conversations.first(where: { $0.id == id })?.createdAt ?? now,
+            updatedAt: now,
+            userId: userId?.uuidString,
+            summary: summary
+        )
+
+        conversationService.save(conversation)
+        loadAll()
+        Log.app.info("대화 저장됨: \(title)")
+    }
+
+    func buildRecentSummaries(for userId: UUID?, limit: Int) -> String? {
+        let allConversations = conversationService.list()
+        let userIdString = userId?.uuidString
+
+        let relevant: [Conversation]
+        if let userIdString {
+            relevant = allConversations.filter { $0.userId == userIdString && $0.summary != nil }
+        } else {
+            relevant = allConversations.filter { $0.summary != nil }
+        }
+
+        let recent = relevant.prefix(limit)
+        guard !recent.isEmpty else { return nil }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M/d"
+
+        return recent.map { conv in
+            let date = formatter.string(from: conv.updatedAt)
+            return "- [\(date)] \(conv.summary ?? conv.title)"
+        }.joined(separator: "\n")
+    }
+}

--- a/Dochi/ViewModels/DochiViewModel+Callbacks.swift
+++ b/Dochi/ViewModels/DochiViewModel+Callbacks.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Combine
+import os
+
+/// 서비스 콜백 및 Combine 바인딩 설정
+extension DochiViewModel {
+    func setupCallbacks() {
+        speechService.onWakeWordDetected = { [weak self] transcript in
+            guard let self else { return }
+            self.isSessionActive = true
+            self.state = .listening
+            self.sessionManager.identifyUserFromTranscript(transcript)
+            Log.app.info("세션 시작 (사용자: \(self.currentUserName ?? Constants.Session.unknownUserLabel))")
+        }
+
+        speechService.onQueryCaptured = { [weak self] query in
+            guard let self else { return }
+
+            if self.isAskingToEndSession {
+                self.isAskingToEndSession = false
+                self.sessionManager.handleEndSessionResponse(query)
+                return
+            }
+
+            if self.isSessionActive && self.sessionManager.isEndSessionRequest(query) {
+                self.sessionManager.confirmAndEndSession()
+                return
+            }
+
+            self.handleQuery(query)
+        }
+
+        speechService.onListeningCancelled = { [weak self] in
+            guard let self, self.state == .listening else { return }
+            Log.app.info("리스닝 취소 — 상태 리셋")
+            self.state = .idle
+            self.sessionManager.startWakeWordIfNeeded()
+        }
+
+        speechService.onSilenceTimeout = { [weak self] in
+            guard let self, self.isSessionActive else { return }
+
+            if self.isAskingToEndSession {
+                self.isAskingToEndSession = false
+                self.sessionManager.endSession()
+                return
+            }
+
+            if self.autoEndSession {
+                self.sessionManager.askToEndSession()
+            } else {
+                self.sessionManager.startContinuousListening()
+            }
+        }
+
+        llmService.onSentenceReady = { [weak self] sentence in
+            guard let self else { return }
+            if self.supertonicService.state == .ready || self.supertonicService.state == .synthesizing || self.supertonicService.state == .playing {
+                if self.state != .speaking {
+                    self.speechService.stopListening()
+                    self.speechService.stopWakeWordDetection()
+                }
+                self.state = .speaking
+                self.supertonicService.speed = self.settings.ttsSpeed
+                self.supertonicService.diffusionSteps = self.settings.ttsDiffusionSteps
+                let cleaned = TTSSanitizer.sanitize(sentence)
+                guard !cleaned.isEmpty else { return }
+                self.supertonicService.enqueueSentence(cleaned, voice: self.settings.supertonicVoice)
+            }
+        }
+
+        llmService.onResponseComplete = { [weak self] response in
+            guard let self else { return }
+            self.messages.append(Message(role: .assistant, content: response))
+            self.sessionManager.recoverIfTTSDidNotPlay()
+        }
+
+        llmService.onToolCallsReceived = { [weak self] toolCalls in
+            guard let self else { return }
+            Task {
+                await self.toolExecutor.executeToolLoop(toolCalls: toolCalls)
+            }
+        }
+
+        supertonicService.onSpeakingComplete = { [weak self] in
+            guard let self else { return }
+            self.state = .idle
+
+            Task {
+                // Task 취소 시 에코 방지 딜레이 스킵은 의도된 동작
+                try? await Task.sleep(for: .milliseconds(Constants.Timing.echoPreventionDelayMs))
+                guard self.state == .idle else { return }
+
+                if self.isSessionActive {
+                    self.sessionManager.startContinuousListening()
+                } else {
+                    self.sessionManager.startWakeWordIfNeeded()
+                }
+            }
+        }
+
+        builtInToolService.onAlarmFired = { [weak self] message in
+            guard let self else { return }
+            Log.app.info("알람 발동: \(message), 현재 상태: \(String(describing: self.state)), TTS 상태: \(String(describing: self.supertonicService.state))")
+            if self.state == .speaking {
+                self.supertonicService.stopPlayback()
+            }
+            if self.state == .listening {
+                self.speechService.stopListening()
+            }
+            self.state = .speaking
+            self.supertonicService.speed = self.settings.ttsSpeed
+            self.supertonicService.diffusionSteps = self.settings.ttsDiffusionSteps
+            self.supertonicService.speak("알람이에요! \(message)", voice: self.settings.supertonicVoice)
+        }
+
+        supertonicService.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] ttsState in
+                guard let self, ttsState == .ready, self.state == .idle else { return }
+                self.sessionManager.startWakeWordIfNeeded()
+            }
+            .store(in: &cancellables)
+    }
+
+    func setupChangeForwarding() {
+        speechService.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+        llmService.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+        supertonicService.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
+    }
+
+    func setupProfileCallback() {
+        builtInToolService.profileTool.onUserIdentified = { [weak self] profile in
+            guard let self else { return }
+            self.currentUserId = profile.id
+            self.currentUserName = profile.name
+            Log.app.info("사용자 설정됨 (tool): \(profile.name)")
+        }
+    }
+
+    func setupLLMCallbacks() {
+        llmService.onResponseComplete = { [weak self] response in
+            guard let self else { return }
+            self.messages.append(Message(role: .assistant, content: response))
+            self.sessionManager.recoverIfTTSDidNotPlay()
+        }
+
+        llmService.onToolCallsReceived = { [weak self] toolCalls in
+            guard let self else { return }
+            Task {
+                await self.toolExecutor.executeToolLoop(toolCalls: toolCalls)
+            }
+        }
+    }
+}

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -30,13 +30,12 @@ final class DochiViewModel: ObservableObject {
 
     // Dependencies
     let contextService: ContextServiceProtocol
-    private let conversationService: ConversationServiceProtocol
 
     // Tool loop 관련
     @Published var currentToolExecution: String?
     var toolLoopMessages: [Message] = []
 
-    private var cancellables = Set<AnyCancellable>()
+    var cancellables = Set<AnyCancellable>()
     // 연속 대화 모드
     @Published var isSessionActive: Bool = false
     @Published var autoEndSession: Bool = true
@@ -50,6 +49,11 @@ final class DochiViewModel: ObservableObject {
     private(set) lazy var sessionManager = SessionManager(viewModel: self)
     private(set) lazy var toolExecutor = ToolExecutor(viewModel: self)
     private(set) lazy var contextAnalyzer = ContextAnalyzer(viewModel: self)
+    private(set) lazy var conversationManager = ConversationManager(
+        viewModel: self, conversationService: conversationService
+    )
+
+    private let conversationService: ConversationServiceProtocol
 
     var isConnected: Bool {
         supertonicService.state == .ready || state != .idle
@@ -75,152 +79,7 @@ final class DochiViewModel: ObservableObject {
         setupCallbacks()
         setupChangeForwarding()
         setupProfileCallback()
-        loadConversations()
-    }
-
-    // MARK: - Callbacks
-
-    private func setupCallbacks() {
-        speechService.onWakeWordDetected = { [weak self] transcript in
-            guard let self else { return }
-            self.isSessionActive = true
-            self.state = .listening
-            self.sessionManager.identifyUserFromTranscript(transcript)
-            Log.app.info("세션 시작 (사용자: \(self.currentUserName ?? Constants.Session.unknownUserLabel))")
-        }
-
-        speechService.onQueryCaptured = { [weak self] query in
-            guard let self else { return }
-
-            if self.isAskingToEndSession {
-                self.isAskingToEndSession = false
-                self.sessionManager.handleEndSessionResponse(query)
-                return
-            }
-
-            if self.isSessionActive && self.sessionManager.isEndSessionRequest(query) {
-                self.sessionManager.confirmAndEndSession()
-                return
-            }
-
-            self.handleQuery(query)
-        }
-
-        speechService.onListeningCancelled = { [weak self] in
-            guard let self, self.state == .listening else { return }
-            Log.app.info("리스닝 취소 — 상태 리셋")
-            self.state = .idle
-            self.sessionManager.startWakeWordIfNeeded()
-        }
-
-        speechService.onSilenceTimeout = { [weak self] in
-            guard let self, self.isSessionActive else { return }
-
-            if self.isAskingToEndSession {
-                self.isAskingToEndSession = false
-                self.sessionManager.endSession()
-                return
-            }
-
-            if self.autoEndSession {
-                self.sessionManager.askToEndSession()
-            } else {
-                self.sessionManager.startContinuousListening()
-            }
-        }
-
-        llmService.onSentenceReady = { [weak self] sentence in
-            guard let self else { return }
-            if self.supertonicService.state == .ready || self.supertonicService.state == .synthesizing || self.supertonicService.state == .playing {
-                if self.state != .speaking {
-                    self.speechService.stopListening()
-                    self.speechService.stopWakeWordDetection()
-                }
-                self.state = .speaking
-                self.supertonicService.speed = self.settings.ttsSpeed
-                self.supertonicService.diffusionSteps = self.settings.ttsDiffusionSteps
-                let cleaned = Self.sanitizeForTTS(sentence)
-                guard !cleaned.isEmpty else { return }
-                self.supertonicService.enqueueSentence(cleaned, voice: self.settings.supertonicVoice)
-            }
-        }
-
-        llmService.onResponseComplete = { [weak self] response in
-            guard let self else { return }
-            self.messages.append(Message(role: .assistant, content: response))
-            self.sessionManager.recoverIfTTSDidNotPlay()
-        }
-
-        llmService.onToolCallsReceived = { [weak self] toolCalls in
-            guard let self else { return }
-            Task {
-                await self.toolExecutor.executeToolLoop(toolCalls: toolCalls)
-            }
-        }
-
-        supertonicService.onSpeakingComplete = { [weak self] in
-            guard let self else { return }
-            self.state = .idle
-
-            Task {
-                // Task 취소 시 에코 방지 딜레이 스킵은 의도된 동작
-                try? await Task.sleep(for: .milliseconds(Constants.Timing.echoPreventionDelayMs))
-                guard self.state == .idle else { return }
-
-                if self.isSessionActive {
-                    self.sessionManager.startContinuousListening()
-                } else {
-                    self.sessionManager.startWakeWordIfNeeded()
-                }
-            }
-        }
-
-        builtInToolService.onAlarmFired = { [weak self] message in
-            guard let self else { return }
-            Log.app.info("알람 발동: \(message), 현재 상태: \(String(describing: self.state)), TTS 상태: \(String(describing: self.supertonicService.state))")
-            if self.state == .speaking {
-                self.supertonicService.stopPlayback()
-            }
-            if self.state == .listening {
-                self.speechService.stopListening()
-            }
-            self.state = .speaking
-            self.supertonicService.speed = self.settings.ttsSpeed
-            self.supertonicService.diffusionSteps = self.settings.ttsDiffusionSteps
-            self.supertonicService.speak("알람이에요! \(message)", voice: self.settings.supertonicVoice)
-        }
-
-        supertonicService.$state
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] ttsState in
-                guard let self, ttsState == .ready, self.state == .idle else { return }
-                self.sessionManager.startWakeWordIfNeeded()
-            }
-            .store(in: &cancellables)
-    }
-
-    private func setupChangeForwarding() {
-        speechService.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.objectWillChange.send() }
-            .store(in: &cancellables)
-        llmService.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.objectWillChange.send() }
-            .store(in: &cancellables)
-        supertonicService.objectWillChange
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.objectWillChange.send() }
-            .store(in: &cancellables)
-    }
-
-    private func setupProfileCallback() {
-        builtInToolService.profileTool.onUserIdentified = { [weak self] profile in
-            guard let self else { return }
-            self.currentUserId = profile.id
-            self.currentUserName = profile.name
-            Log.app.info("사용자 설정됨 (tool): \(profile.name)")
-        }
+        conversationManager.loadAll()
     }
 
     // MARK: - Wake Word (forwarding to SessionManager)
@@ -299,7 +158,7 @@ final class DochiViewModel: ObservableObject {
             currentUserId: currentUserId
         )
 
-        let recentSummaries = buildRecentSummaries(for: currentUserId, limit: 5)
+        let recentSummaries = conversationManager.buildRecentSummaries(for: currentUserId, limit: 5)
 
         let systemPrompt = settings.buildInstructions(
             currentUserName: currentUserName,
@@ -325,49 +184,6 @@ final class DochiViewModel: ObservableObject {
             tools: tools,
             toolResults: toolResults
         )
-    }
-
-    func setupLLMCallbacks() {
-        llmService.onResponseComplete = { [weak self] response in
-            guard let self else { return }
-            self.messages.append(Message(role: .assistant, content: response))
-            self.sessionManager.recoverIfTTSDidNotPlay()
-        }
-
-        llmService.onToolCallsReceived = { [weak self] toolCalls in
-            guard let self else { return }
-            Task {
-                await self.toolExecutor.executeToolLoop(toolCalls: toolCalls)
-            }
-        }
-    }
-
-    // MARK: - TTS Sanitization
-
-    /// 마크다운 서식 기호를 제거하여 TTS에 적합한 텍스트로 변환
-    static func sanitizeForTTS(_ text: String) -> String {
-        var s = text
-
-        if s.hasPrefix("```") { return "" }
-
-        s = s.replacingOccurrences(of: #"!\[[^\]]*\]\([^)]*\)"#, with: "", options: .regularExpression)
-        s = s.replacingOccurrences(of: #"\[([^\]]*)\]\([^)]*\)"#, with: "$1", options: .regularExpression)
-        s = s.replacingOccurrences(of: #"`([^`]*)`"#, with: "$1", options: .regularExpression)
-
-        s = s.replacingOccurrences(of: #"\*{1,3}([^*]+)\*{1,3}"#, with: "$1", options: .regularExpression)
-        s = s.replacingOccurrences(of: #"_{1,3}([^_]+)_{1,3}"#, with: "$1", options: .regularExpression)
-
-        s = s.replacingOccurrences(of: #"^#{1,6}\s*"#, with: "", options: .regularExpression)
-        s = s.replacingOccurrences(of: #"^[-*+]\s+"#, with: "", options: .regularExpression)
-        s = s.replacingOccurrences(of: #"^>\s*"#, with: "", options: .regularExpression)
-        s = s.replacingOccurrences(of: #"^[-*_]{3,}$"#, with: "", options: .regularExpression)
-
-        s = s.replacingOccurrences(of: "*", with: "")
-        s = s.replacingOccurrences(of: ":", with: ",")
-
-        s = s.replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
-
-        return s.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Push-to-Talk
@@ -415,6 +231,8 @@ final class DochiViewModel: ObservableObject {
         sessionManager.startWakeWordIfNeeded()
     }
 
+    // MARK: - Conversation (forwarding to ConversationManager)
+
     func clearConversation() {
         if !messages.isEmpty {
             let sessionMessages = messages
@@ -427,77 +245,15 @@ final class DochiViewModel: ObservableObject {
         currentConversationId = nil
     }
 
-    // MARK: - Conversation History
-
-    private func loadConversations() {
-        conversations = conversationService.list()
-    }
-
     func loadConversation(_ conversation: Conversation) {
-        if !messages.isEmpty {
-            let sessionMessages = messages
-            let sessionUserId = currentUserId
-            Task {
-                await contextAnalyzer.saveAndAnalyzeConversation(sessionMessages, userId: sessionUserId)
-            }
-        }
-
-        currentConversationId = conversation.id
-        messages = conversation.messages
+        conversationManager.load(conversation)
     }
 
     func deleteConversation(id: UUID) {
-        conversationService.delete(id: id)
-        conversations.removeAll { $0.id == id }
-
-        if currentConversationId == id {
-            currentConversationId = nil
-            messages.removeAll()
-        }
+        conversationManager.delete(id: id)
     }
 
     func saveConversationWithTitle(_ title: String, summary: String?, userId: UUID?, messages: [Message]) {
-        let id = currentConversationId ?? UUID()
-        let now = Date()
-
-        let conversation = Conversation(
-            id: id,
-            title: title,
-            messages: messages,
-            createdAt: conversations.first(where: { $0.id == id })?.createdAt ?? now,
-            updatedAt: now,
-            userId: userId?.uuidString,
-            summary: summary
-        )
-
-        conversationService.save(conversation)
-        loadConversations()
-        Log.app.info("대화 저장됨: \(title)")
-    }
-
-    // MARK: - Helpers
-
-    private func buildRecentSummaries(for userId: UUID?, limit: Int) -> String? {
-        let allConversations = conversationService.list()
-        let userIdString = userId?.uuidString
-
-        let relevant: [Conversation]
-        if let userIdString {
-            relevant = allConversations.filter { $0.userId == userIdString && $0.summary != nil }
-        } else {
-            relevant = allConversations.filter { $0.summary != nil }
-        }
-
-        let recent = relevant.prefix(limit)
-        guard !recent.isEmpty else { return nil }
-
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "M/d"
-
-        return recent.map { conv in
-            let date = formatter.string(from: conv.updatedAt)
-            return "- [\(date)] \(conv.summary ?? conv.title)"
-        }.joined(separator: "\n")
+        conversationManager.save(title: title, summary: summary, userId: userId, messages: messages)
     }
 }

--- a/Dochi/ViewModels/TTSSanitizer.swift
+++ b/Dochi/ViewModels/TTSSanitizer.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// 마크다운 서식 기호를 제거하여 TTS에 적합한 텍스트로 변환
+enum TTSSanitizer {
+    static func sanitize(_ text: String) -> String {
+        var s = text
+
+        if s.hasPrefix("```") { return "" }
+
+        s = s.replacingOccurrences(of: #"!\[[^\]]*\]\([^)]*\)"#, with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"\[([^\]]*)\]\([^)]*\)"#, with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"`([^`]*)`"#, with: "$1", options: .regularExpression)
+
+        s = s.replacingOccurrences(of: #"\*{1,3}([^*]+)\*{1,3}"#, with: "$1", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"_{1,3}([^_]+)_{1,3}"#, with: "$1", options: .regularExpression)
+
+        s = s.replacingOccurrences(of: #"^#{1,6}\s*"#, with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"^[-*+]\s+"#, with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"^>\s*"#, with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: #"^[-*_]{3,}$"#, with: "", options: .regularExpression)
+
+        s = s.replacingOccurrences(of: "*", with: "")
+        s = s.replacingOccurrences(of: ":", with: ",")
+
+        s = s.replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+
+        return s.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
## Summary
- Reduce DochiViewModel.swift from 503 lines to **259 lines** (well under the 300-line target)
- Extract 3 additional modules: ConversationManager, DochiViewModel+Callbacks, TTSSanitizer
- All existing functionality preserved with forwarding methods for view compatibility

## Module breakdown

| Module | Lines | Responsibility |
|--------|-------|----------------|
| `DochiViewModel.swift` | 259 | Coordinator, state management, public API |
| `DochiViewModel+Callbacks.swift` | 164 | Service callback wiring, Combine bindings |
| `SessionManager.swift` | 175 | Wake word, session lifecycle, user identification |
| `ToolExecutor.swift` | 132 | Tool execution loop, image URL extraction |
| `ContextAnalyzer.swift` | 266 | Conversation analysis, memory, compression |
| `ConversationManager.swift` | 88 | Conversation history CRUD, recent summaries |
| `TTSSanitizer.swift` | 29 | Markdown-to-speech text sanitization |

## Test plan
- [x] `xcodebuild build` succeeds
- [x] All 48 existing tests pass
- [x] DochiViewModel under 300 lines

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)