### PR TITLE
Add tests for TTSSanitizer and ToolExecutor modules

### DIFF
--- a/DochiTests/ViewModels/TTSSanitizationTests.swift
+++ b/DochiTests/ViewModels/TTSSanitizationTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class TTSSanitizationTests: XCTestCase {
+
+    // MARK: - Code Blocks
+
+    func testCodeBlockReturnsEmpty() {
+        let result = TTSSanitizer.sanitize("```swift\nlet x = 1\n```")
+
+        XCTAssertEqual(result, "")
+    }
+
+    // MARK: - Markdown Links
+
+    func testImageMarkdownRemoved() {
+        let result = TTSSanitizer.sanitize("Here is an image ![alt](https://example.com/img.png)")
+
+        XCTAssertFalse(result.contains("!["))
+        XCTAssertFalse(result.contains("https://"))
+    }
+
+    func testLinkMarkdownKeepsText() {
+        let result = TTSSanitizer.sanitize("Visit [Google](https://google.com) now")
+
+        XCTAssertTrue(result.contains("Google"))
+        XCTAssertFalse(result.contains("https://"))
+    }
+
+    // MARK: - Inline Code
+
+    func testInlineCodeStripped() {
+        let result = TTSSanitizer.sanitize("Use `print()` to debug")
+
+        XCTAssertTrue(result.contains("print()"))
+        XCTAssertFalse(result.contains("`"))
+    }
+
+    // MARK: - Bold and Italic
+
+    func testBoldStripped() {
+        let result = TTSSanitizer.sanitize("This is **bold** text")
+
+        XCTAssertTrue(result.contains("bold"))
+        XCTAssertFalse(result.contains("**"))
+    }
+
+    func testItalicStripped() {
+        let result = TTSSanitizer.sanitize("This is *italic* text")
+
+        XCTAssertTrue(result.contains("italic"))
+    }
+
+    // MARK: - Headers
+
+    func testHeaderStripped() {
+        let result = TTSSanitizer.sanitize("## Section Title")
+
+        XCTAssertTrue(result.contains("Section Title"))
+        XCTAssertFalse(result.contains("#"))
+    }
+
+    // MARK: - Special Characters
+
+    func testColonReplacedWithComma() {
+        let result = TTSSanitizer.sanitize("Time: 3pm")
+
+        XCTAssertTrue(result.contains(","))
+        XCTAssertFalse(result.contains(":"))
+    }
+
+    // MARK: - Whitespace
+
+    func testMultipleSpacesCollapsed() {
+        let result = TTSSanitizer.sanitize("Hello    world")
+
+        XCTAssertEqual(result, "Hello world")
+    }
+
+    func testTrimsWhitespace() {
+        let result = TTSSanitizer.sanitize("  Hello  ")
+
+        XCTAssertEqual(result, "Hello")
+    }
+
+    // MARK: - List Items
+
+    func testBulletListStripped() {
+        let result = TTSSanitizer.sanitize("- Item one")
+
+        XCTAssertEqual(result, "Item one")
+    }
+
+    // MARK: - Blockquote
+
+    func testBlockquoteStripped() {
+        let result = TTSSanitizer.sanitize("> Quote text")
+
+        XCTAssertTrue(result.contains("Quote text"))
+        XCTAssertFalse(result.contains(">"))
+    }
+
+    // MARK: - Horizontal Rule
+
+    func testHorizontalRuleRemoved() {
+        let result = TTSSanitizer.sanitize("---")
+
+        XCTAssertEqual(result, "")
+    }
+
+    // MARK: - Plain Text
+
+    func testPlainTextUnchanged() {
+        let result = TTSSanitizer.sanitize("안녕하세요")
+
+        XCTAssertEqual(result, "안녕하세요")
+    }
+
+    func testEmptyStringReturnsEmpty() {
+        let result = TTSSanitizer.sanitize("")
+
+        XCTAssertEqual(result, "")
+    }
+}

--- a/DochiTests/ViewModels/ToolExecutorTests.swift
+++ b/DochiTests/ViewModels/ToolExecutorTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class ToolExecutorTests: XCTestCase {
+
+    // MARK: - extractImageURLs
+
+    func testExtractImageURLsFromMarkdown() {
+        let content = "Here is an image ![photo](https://example.com/image.png) and text"
+
+        let urls = ToolExecutor.extractImageURLs(from: content)
+
+        XCTAssertEqual(urls.count, 1)
+        XCTAssertEqual(urls.first?.absoluteString, "https://example.com/image.png")
+    }
+
+    func testExtractMultipleImageURLs() {
+        let content = "![a](https://example.com/1.png) and ![b](https://example.com/2.png)"
+
+        let urls = ToolExecutor.extractImageURLs(from: content)
+
+        XCTAssertEqual(urls.count, 2)
+    }
+
+    func testExtractImageURLsNoImages() {
+        let content = "Just plain text with no images"
+
+        let urls = ToolExecutor.extractImageURLs(from: content)
+
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    func testExtractImageURLsIgnoresRegularLinks() {
+        let content = "Visit [Google](https://google.com)"
+
+        let urls = ToolExecutor.extractImageURLs(from: content)
+
+        XCTAssertTrue(urls.isEmpty)
+    }
+
+    func testExtractImageURLsEmptyAlt() {
+        let content = "![](https://example.com/image.png)"
+
+        let urls = ToolExecutor.extractImageURLs(from: content)
+
+        XCTAssertEqual(urls.count, 1)
+    }
+
+    func testExtractImageURLsEmptyString() {
+        let urls = ToolExecutor.extractImageURLs(from: "")
+
+        XCTAssertTrue(urls.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Add 21 new tests for extracted ViewModel modules (TTSSanitizer, ToolExecutor)
- Total test count: 48 → 102 (including PR #24's 33 tests for KeychainService, AppSettings, BuiltInToolService)

## New test files

### TTSSanitizationTests (15 tests)
- Code block removal (returns empty)
- Image markdown removal
- Link text preservation (strips URL)
- Inline code stripping
- Bold/italic stripping
- Header stripping
- Colon-to-comma replacement
- Whitespace collapsing and trimming
- Bullet list stripping
- Blockquote stripping
- Horizontal rule removal
- Plain text passthrough
- Empty string handling

### ToolExecutorTests (6 tests)
- Single/multiple image URL extraction from markdown
- No images returns empty
- Regular links (non-image) ignored
- Empty alt text handling
- Empty string handling

## Test plan
- [x] `xcodebuild test` — 102 tests, 0 failures
- [x] All existing tests pass

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)