### PR TITLE
Add cloud context sync with write-through and pull-on-launch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ Dochi/
 │   ├── SoundService.swift
 │   ├── ChangelogService.swift
 │   ├── SupabaseService.swift
+│   ├── CloudContextService.swift
 │   └── Supertonic/           # TTS helpers
 └── Resources/
     └── CHANGELOG.md

--- a/Dochi/DochiApp.swift
+++ b/Dochi/DochiApp.swift
@@ -2,13 +2,20 @@ import SwiftUI
 
 @main
 struct DochiApp: App {
-    @StateObject private var settings = AppSettings()
+    @StateObject private var settings: AppSettings
     @StateObject private var viewModel: DochiViewModel
 
     init() {
-        let settings = AppSettings()
+        let keychainService = KeychainService()
+        let supabaseService = SupabaseService(keychainService: keychainService)
+        let cloudContext = CloudContextService(supabaseService: supabaseService)
+        let settings = AppSettings(keychainService: keychainService, contextService: cloudContext)
         _settings = StateObject(wrappedValue: settings)
-        _viewModel = StateObject(wrappedValue: DochiViewModel(settings: settings))
+        _viewModel = StateObject(wrappedValue: DochiViewModel(
+            settings: settings,
+            contextService: cloudContext,
+            supabaseService: supabaseService
+        ))
     }
 
     var body: some Scene {

--- a/Dochi/Services/CloudContextService.swift
+++ b/Dochi/Services/CloudContextService.swift
@@ -1,0 +1,408 @@
+import Foundation
+import Supabase
+import os
+
+/// 클라우드 동기화 컨텍스트 서비스
+/// - 로컬 ContextService를 래핑하여 write-through 클라우드 동기화 제공
+/// - 오프라인 시 로컬만 사용, 온라인 복귀 시 동기화
+/// - Cloud-always-wins on pull: 풀 시 클라우드 내용이 로컬을 덮어씁니다
+@MainActor
+final class CloudContextService: ContextServiceProtocol {
+    private let local: ContextService
+    private let supabaseService: SupabaseService
+
+    init(local: ContextService = ContextService(), supabaseService: SupabaseService) {
+        self.local = local
+        self.supabaseService = supabaseService
+    }
+
+    // MARK: - Cloud Sync State
+
+    private var isSyncing = false
+
+    // MARK: - System
+
+    func loadSystem() -> String {
+        local.loadSystem()
+    }
+
+    func saveSystem(_ content: String) {
+        local.saveSystem(content)
+        scheduleCloudPush(fileType: "system", content: content)
+    }
+
+    var systemPath: String {
+        local.systemPath
+    }
+
+    // MARK: - Memory
+
+    func loadMemory() -> String {
+        local.loadMemory()
+    }
+
+    func saveMemory(_ content: String) {
+        local.saveMemory(content)
+        scheduleCloudPush(fileType: "memory", content: content)
+    }
+
+    func appendMemory(_ content: String) {
+        local.appendMemory(content)
+        scheduleCloudPush(fileType: "memory", content: local.loadMemory())
+    }
+
+    var memoryPath: String {
+        local.memoryPath
+    }
+
+    var memorySize: Int {
+        local.memorySize
+    }
+
+    // MARK: - Family Memory
+
+    func loadFamilyMemory() -> String {
+        local.loadFamilyMemory()
+    }
+
+    func saveFamilyMemory(_ content: String) {
+        local.saveFamilyMemory(content)
+        scheduleCloudPush(fileType: "family_memory", content: content)
+    }
+
+    func appendFamilyMemory(_ content: String) {
+        local.appendFamilyMemory(content)
+        scheduleCloudPush(fileType: "family_memory", content: local.loadFamilyMemory())
+    }
+
+    // MARK: - User Memory
+
+    func loadUserMemory(userId: UUID) -> String {
+        local.loadUserMemory(userId: userId)
+    }
+
+    func saveUserMemory(userId: UUID, content: String) {
+        local.saveUserMemory(userId: userId, content: content)
+        scheduleCloudPush(fileType: "user_memory", content: content, userId: userId)
+    }
+
+    func appendUserMemory(userId: UUID, content: String) {
+        local.appendUserMemory(userId: userId, content: content)
+        scheduleCloudPush(fileType: "user_memory", content: local.loadUserMemory(userId: userId), userId: userId)
+    }
+
+    // MARK: - Profiles
+
+    func loadProfiles() -> [UserProfile] {
+        local.loadProfiles()
+    }
+
+    func saveProfiles(_ profiles: [UserProfile]) {
+        local.saveProfiles(profiles)
+        scheduleProfilesPush(profiles)
+    }
+
+    // MARK: - Migration
+
+    func migrateIfNeeded() {
+        local.migrateIfNeeded()
+    }
+
+    // MARK: - Sync Operations
+
+    /// 앱 시작 시 클라우드에서 최신 버전 가져오기 (Pull-on-launch)
+    func pullFromCloud() async {
+        guard let client = supabaseService.client,
+              let wsId = resolveWorkspaceId() else { return }
+        guard !isSyncing else { return }
+        isSyncing = true
+        defer { isSyncing = false }
+
+        do {
+            let files: [ContextFileRow] = try await client
+                .from("context_files")
+                .select()
+                .eq("workspace_id", value: wsId)
+                .execute()
+                .value
+
+            for file in files {
+                applyCloudFile(file)
+            }
+
+            // Pull profiles
+            await pullProfilesFromCloud(workspaceId: wsId)
+
+            Log.cloud.info("클라우드 컨텍스트 동기화 완료: \(files.count)개 파일")
+        } catch {
+            Log.cloud.warning("클라우드 컨텍스트 풀 실패: \(error, privacy: .public)")
+        }
+    }
+
+    /// 로컬 변경 → 클라우드 동기화 (write-through, 비동기 fire-and-forget)
+    private func scheduleCloudPush(fileType: String, content: String, userId: UUID? = nil) {
+        let svc = supabaseService
+        Task {
+            guard let client = svc.client,
+                  let wsId = svc.selectedWorkspace?.id else { return }
+            guard case .signedIn = svc.authState else { return }
+            let authUserId = self.resolveAuthUserId()
+
+            do {
+                let existing = try await self.fetchContextFile(workspaceId: wsId, fileType: fileType, userId: userId)
+
+                if let existing {
+                    let newVersion = existing.version + 1
+                    try await client
+                        .from("context_files")
+                        .update(ContextFileUpdate(
+                            content: content,
+                            version: newVersion,
+                            updated_at: Date(),
+                            updated_by: authUserId
+                        ))
+                        .eq("id", value: existing.id)
+                        .execute()
+
+                    try await self.recordHistory(
+                        contextFileId: existing.id,
+                        workspaceId: wsId,
+                        fileType: fileType,
+                        content: content,
+                        version: newVersion
+                    )
+                } else {
+                    let inserted: ContextFileRow = try await client
+                        .from("context_files")
+                        .insert(ContextFileInsert(
+                            workspace_id: wsId,
+                            file_type: fileType,
+                            user_id: userId,
+                            content: content,
+                            updated_by: authUserId
+                        ))
+                        .select()
+                        .single()
+                        .execute()
+                        .value
+
+                    try await self.recordHistory(
+                        contextFileId: inserted.id,
+                        workspaceId: wsId,
+                        fileType: fileType,
+                        content: content,
+                        version: 1
+                    )
+                }
+
+                Log.cloud.debug("클라우드 푸시 완료: \(fileType, privacy: .public)")
+            } catch {
+                Log.cloud.warning("클라우드 푸시 실패 (\(fileType, privacy: .public)): \(error, privacy: .public)")
+            }
+        }
+    }
+
+    private func scheduleProfilesPush(_ profiles: [UserProfile]) {
+        let svc = supabaseService
+        Task {
+            guard let client = svc.client,
+                  let wsId = svc.selectedWorkspace?.id else { return }
+            guard case .signedIn = svc.authState else { return }
+
+            do {
+                if profiles.isEmpty {
+                    try await client
+                        .from("profiles")
+                        .delete()
+                        .eq("workspace_id", value: wsId)
+                        .execute()
+                } else {
+                    let rows = profiles.map { profile in
+                        ProfileRow(
+                            id: profile.id,
+                            workspace_id: wsId,
+                            name: profile.name,
+                            aliases: profile.aliases,
+                            description: profile.description
+                        )
+                    }
+                    try await client
+                        .from("profiles")
+                        .upsert(rows)
+                        .execute()
+
+                    // Remove profiles no longer in the list
+                    let currentIds = profiles.map(\.id)
+                    try await client
+                        .from("profiles")
+                        .delete()
+                        .eq("workspace_id", value: wsId)
+                        .not("id", operator: .in, value: currentIds)
+                        .execute()
+                }
+
+                Log.cloud.debug("프로필 클라우드 푸시 완료: \(profiles.count)명")
+            } catch {
+                Log.cloud.warning("프로필 클라우드 푸시 실패: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    private func pullProfilesFromCloud(workspaceId: UUID) async {
+        guard let client = supabaseService.client else { return }
+        do {
+            let rows: [ProfileRow] = try await client
+                .from("profiles")
+                .select()
+                .eq("workspace_id", value: workspaceId)
+                .execute()
+                .value
+
+            if !rows.isEmpty {
+                let profiles = rows.map { row in
+                    UserProfile(
+                        id: row.id,
+                        name: row.name,
+                        aliases: row.aliases,
+                        description: row.description
+                    )
+                }
+                local.saveProfiles(profiles)
+                Log.cloud.debug("프로필 클라우드 풀 완료: \(profiles.count)명")
+            }
+        } catch {
+            Log.cloud.warning("프로필 클라우드 풀 실패: \(error, privacy: .public)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func resolveWorkspaceId() -> UUID? {
+        guard case .signedIn = supabaseService.authState else { return nil }
+        return supabaseService.selectedWorkspace?.id
+    }
+
+    private func resolveAuthUserId() -> UUID? {
+        if case .signedIn(let id, _) = supabaseService.authState {
+            return id
+        }
+        return nil
+    }
+
+    private func fetchContextFile(workspaceId: UUID, fileType: String, userId: UUID? = nil) async throws -> ContextFileRow? {
+        guard let client = supabaseService.client else { return nil }
+        var query = client
+            .from("context_files")
+            .select()
+            .eq("workspace_id", value: workspaceId)
+            .eq("file_type", value: fileType)
+
+        if let userId {
+            query = query.eq("user_id", value: userId)
+        } else {
+            query = query.is("user_id", value: nil)
+        }
+
+        let rows: [ContextFileRow] = try await query.execute().value
+        return rows.first
+    }
+
+    private func applyCloudFile(_ file: ContextFileRow) {
+        let localContent: String
+        switch file.file_type {
+        case "system":
+            localContent = local.loadSystem()
+        case "memory":
+            localContent = local.loadMemory()
+        case "family_memory":
+            localContent = local.loadFamilyMemory()
+        case "user_memory":
+            if let uid = file.user_id {
+                localContent = local.loadUserMemory(userId: uid)
+            } else {
+                return
+            }
+        default:
+            return
+        }
+
+        // Cloud-always-wins: cloud content overwrites local if different
+        if file.content != localContent {
+            switch file.file_type {
+            case "system":
+                local.saveSystem(file.content)
+            case "memory":
+                local.saveMemory(file.content)
+            case "family_memory":
+                local.saveFamilyMemory(file.content)
+            case "user_memory":
+                if let uid = file.user_id {
+                    local.saveUserMemory(userId: uid, content: file.content)
+                }
+            default:
+                break
+            }
+            Log.cloud.info("클라우드 → 로컬 동기화: \(file.file_type, privacy: .public)")
+        }
+    }
+
+    private func recordHistory(contextFileId: UUID, workspaceId: UUID, fileType: String, content: String, version: Int) async throws {
+        guard let client = supabaseService.client else { return }
+        try await client
+            .from("context_history")
+            .insert(ContextHistoryInsert(
+                context_file_id: contextFileId,
+                workspace_id: workspaceId,
+                file_type: fileType,
+                content: content,
+                version: version,
+                edited_by: resolveAuthUserId()
+            ))
+            .execute()
+    }
+}
+
+// MARK: - Codable DTOs
+
+private struct ContextFileRow: Codable {
+    let id: UUID
+    let workspace_id: UUID
+    let file_type: String
+    let user_id: UUID?
+    let content: String
+    let version: Int
+    let updated_at: Date
+    let updated_by: UUID?
+}
+
+private struct ContextFileInsert: Encodable {
+    let workspace_id: UUID
+    let file_type: String
+    let user_id: UUID?
+    let content: String
+    let updated_by: UUID?
+}
+
+private struct ContextFileUpdate: Encodable {
+    let content: String
+    let version: Int
+    let updated_at: Date
+    let updated_by: UUID?
+}
+
+private struct ContextHistoryInsert: Encodable {
+    let context_file_id: UUID
+    let workspace_id: UUID
+    let file_type: String
+    let content: String
+    let version: Int
+    let edited_by: UUID?
+}
+
+private struct ProfileRow: Codable {
+    let id: UUID
+    let workspace_id: UUID
+    let name: String
+    let aliases: [String]
+    let description: String
+}

--- a/Dochi/Services/ContextService.swift
+++ b/Dochi/Services/ContextService.swift
@@ -8,6 +8,7 @@ import os
 /// - family.md: 가족 공유 기억
 /// - memory/{userId}.md: 개인 기억
 /// - profiles.json: 사용자 프로필
+@MainActor
 final class ContextService: ContextServiceProtocol {
     private let fileManager: FileManager
     private let baseDir: URL

--- a/Dochi/Services/Protocols/ContextServiceProtocol.swift
+++ b/Dochi/Services/Protocols/ContextServiceProtocol.swift
@@ -6,6 +6,7 @@ import Foundation
 /// - family.md: 가족 공유 기억
 /// - memory/{userId}.md: 개인 기억
 /// - profiles.json: 사용자 프로필
+@MainActor
 protocol ContextServiceProtocol {
     // MARK: - System (페르소나 + 행동 지침)
     func loadSystem() -> String

--- a/Dochi/Services/SupabaseService.swift
+++ b/Dochi/Services/SupabaseService.swift
@@ -9,7 +9,8 @@ final class SupabaseService: ObservableObject, SupabaseServiceProtocol {
     @Published private(set) var authState: AuthState = .signedOut
     var onAuthStateChanged: ((AuthState) -> Void)?
 
-    private let client: SupabaseClient?
+    /// Supabase 클라이언트 (CloudContextService 등에서 DB 접근용). nil when config is missing.
+    let client: SupabaseClient?
     private let keychainService: KeychainServiceProtocol
     private let defaults: UserDefaults
 

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -116,9 +116,12 @@ final class DochiViewModel: ObservableObject {
             connect()
         }
 
-        // Restore cloud session
+        // Restore cloud session and sync context
         Task {
             await supabaseService.restoreSession()
+            if let cloudContext = contextService as? CloudContextService {
+                await cloudContext.pullFromCloud()
+            }
         }
     }
 

--- a/DochiTests/Mocks/MockContextService.swift
+++ b/DochiTests/Mocks/MockContextService.swift
@@ -1,7 +1,8 @@
 import Foundation
 @testable import Dochi
 
-final class MockContextService: ContextServiceProtocol, @unchecked Sendable {
+@MainActor
+final class MockContextService: ContextServiceProtocol {
     var systemContent: String = ""
     var memoryContent: String = ""
     var familyMemoryContent: String = ""

--- a/DochiTests/Services/ContextServiceTests.swift
+++ b/DochiTests/Services/ContextServiceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Dochi
 
+@MainActor
 final class ContextServiceTests: XCTestCase {
     var sut: ContextService!
     var tempDir: URL!

--- a/supabase/migrations/002_context_history.sql
+++ b/supabase/migrations/002_context_history.sql
@@ -1,0 +1,22 @@
+-- Context edit history for tracking changes
+create table if not exists context_history (
+    id uuid primary key default gen_random_uuid(),
+    context_file_id uuid not null references context_files(id) on delete cascade,
+    workspace_id uuid not null references workspaces(id) on delete cascade,
+    file_type text not null,
+    content text not null,
+    version integer not null,
+    edited_by uuid references auth.users(id),
+    edited_at timestamptz not null default now()
+);
+
+-- RLS
+alter table context_history enable row level security;
+
+create policy "history_select" on context_history for select using (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+create policy "history_insert" on context_history for insert with check (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);


### PR DESCRIPTION
## Summary
- CloudContextService wraps local ContextService with Supabase sync
- Write-through: save/append push to cloud asynchronously
- Pull-on-launch: fetches latest context from cloud on app start
- Cloud-always-wins conflict resolution
- @MainActor isolation, guard let client pattern
- ContextServiceProtocol made @MainActor

Closes #6

Replaces #29 (closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)