### PR TITLE
Add device registry with heartbeat and management UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,14 +64,16 @@ Dochi/
 │   ├── SettingsView.swift
 │   ├── ConversationView.swift
 │   ├── ChangelogView.swift
-│   └── CloudSettingsView.swift
+│   ├── CloudSettingsView.swift
+│   └── DeviceSettingsView.swift
 ├── Services/
 │   ├── Protocols/            # Service protocols for DI
 │   │   ├── ContextServiceProtocol.swift
 │   │   ├── ConversationServiceProtocol.swift
 │   │   ├── KeychainServiceProtocol.swift
 │   │   ├── SoundServiceProtocol.swift
-│   │   └── SupabaseServiceProtocol.swift
+│   │   ├── SupabaseServiceProtocol.swift
+│   │   └── DeviceServiceProtocol.swift
 │   ├── BuiltInTools/         # Built-in tool modules
 │   │   ├── BuiltInToolProtocol.swift
 │   │   ├── WebSearchTool.swift
@@ -90,6 +92,7 @@ Dochi/
 │   ├── ChangelogService.swift
 │   ├── SupabaseService.swift
 │   ├── CloudContextService.swift
+│   ├── DeviceService.swift
 │   └── Supertonic/           # TTS helpers
 └── Resources/
     └── CHANGELOG.md
@@ -100,7 +103,8 @@ DochiTests/
 │   ├── MockConversationService.swift
 │   ├── MockKeychainService.swift
 │   ├── MockSoundService.swift
-│   └── MockSupabaseService.swift
+│   ├── MockSupabaseService.swift
+│   └── MockDeviceService.swift
 └── Services/
     ├── ContextServiceTests.swift
     └── ConversationServiceTests.swift
@@ -123,6 +127,7 @@ DochiTests/
 | SoundService | SoundServiceProtocol | UI sound effects |
 | ChangelogService | - | Version tracking and changelog |
 | SupabaseService | SupabaseServiceProtocol | Cloud auth, workspace CRUD |
+| DeviceService | DeviceServiceProtocol | Device registration, heartbeat |
 
 **Callbacks in SpeechService:**
 - `onQueryCaptured` — STT result ready

--- a/Dochi/DochiApp.swift
+++ b/Dochi/DochiApp.swift
@@ -9,12 +9,14 @@ struct DochiApp: App {
         let keychainService = KeychainService()
         let supabaseService = SupabaseService(keychainService: keychainService)
         let cloudContext = CloudContextService(supabaseService: supabaseService)
+        let deviceService = DeviceService(supabaseService: supabaseService, keychainService: keychainService)
         let settings = AppSettings(keychainService: keychainService, contextService: cloudContext)
         _settings = StateObject(wrappedValue: settings)
         _viewModel = StateObject(wrappedValue: DochiViewModel(
             settings: settings,
             contextService: cloudContext,
-            supabaseService: supabaseService
+            supabaseService: supabaseService,
+            deviceService: deviceService
         ))
     }
 

--- a/Dochi/Services/DeviceService.swift
+++ b/Dochi/Services/DeviceService.swift
@@ -1,0 +1,216 @@
+import Foundation
+import Supabase
+import os
+
+@MainActor
+final class DeviceService: ObservableObject, DeviceServiceProtocol {
+    @Published private(set) var currentDevice: DeviceInfo?
+    @Published private(set) var workspaceDevices: [DeviceInfo] = []
+
+    private let supabaseService: SupabaseService
+    private let keychainService: KeychainServiceProtocol
+    private var heartbeatTask: Task<Void, Never>?
+
+    private enum KeychainKeys {
+        static let deviceId = "device_id"
+    }
+
+    private static let heartbeatInterval: TimeInterval = 30
+
+    init(supabaseService: SupabaseService, keychainService: KeychainServiceProtocol = KeychainService()) {
+        self.supabaseService = supabaseService
+        self.keychainService = keychainService
+    }
+
+    // MARK: - Device Registration
+
+    func registerDevice() async throws {
+        guard let client = supabaseService.client,
+              case .signedIn(let userId, _) = supabaseService.authState,
+              let workspaceId = supabaseService.selectedWorkspace?.id else {
+            return
+        }
+
+        let deviceId = getOrCreateDeviceId()
+        let deviceName = Host.current().localizedName ?? "Mac"
+
+        // Check if already registered
+        let existing: [DeviceInfo] = try await client
+            .from("devices")
+            .select()
+            .eq("id", value: deviceId)
+            .eq("workspace_id", value: workspaceId)
+            .execute()
+            .value
+
+        if let device = existing.first {
+            // Update existing device
+            let updated: DeviceInfo = try await client
+                .from("devices")
+                .update(DeviceUpdate(
+                    is_online: true,
+                    last_seen_at: Date()
+                ))
+                .eq("id", value: deviceId)
+                .select()
+                .single()
+                .execute()
+                .value
+            currentDevice = updated
+            Log.cloud.info("디바이스 재등록: \(device.deviceName, privacy: .public)")
+        } else {
+            // Insert new device
+            let device: DeviceInfo = try await client
+                .from("devices")
+                .insert(DeviceInsert(
+                    id: deviceId,
+                    workspace_id: workspaceId,
+                    user_id: userId,
+                    device_name: deviceName,
+                    platform: "macOS",
+                    is_online: true,
+                    last_seen_at: Date()
+                ))
+                .select()
+                .single()
+                .execute()
+                .value
+            currentDevice = device
+            Log.cloud.info("디바이스 등록: \(deviceName, privacy: .public)")
+        }
+    }
+
+    // MARK: - Heartbeat
+
+    func startHeartbeat() {
+        stopHeartbeat()
+        heartbeatTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(DeviceService.heartbeatInterval * 1_000_000_000))
+                guard !Task.isCancelled else { break }
+                await self?.sendHeartbeat()
+            }
+        }
+        Log.cloud.debug("하트비트 시작")
+    }
+
+    func stopHeartbeat() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+
+        // Mark offline
+        if let deviceId = currentDevice?.id, let client = supabaseService.client {
+            Task { @MainActor in
+                do {
+                    try await client
+                        .from("devices")
+                        .update(DeviceUpdate(is_online: false, last_seen_at: Date()))
+                        .eq("id", value: deviceId)
+                        .execute()
+                } catch {
+                    Log.cloud.warning("오프라인 마킹 실패: \(error, privacy: .public)")
+                }
+            }
+        }
+        Log.cloud.debug("하트비트 중지")
+    }
+
+    private func sendHeartbeat() async {
+        guard let client = supabaseService.client,
+              let deviceId = currentDevice?.id else { return }
+        do {
+            try await client
+                .from("devices")
+                .update(DeviceUpdate(is_online: true, last_seen_at: Date()))
+                .eq("id", value: deviceId)
+                .execute()
+        } catch {
+            Log.cloud.warning("하트비트 실패: \(error, privacy: .public)")
+        }
+    }
+
+    // MARK: - Device List
+
+    func fetchWorkspaceDevices() async throws -> [DeviceInfo] {
+        guard let client = supabaseService.client,
+              let workspaceId = supabaseService.selectedWorkspace?.id else {
+            return []
+        }
+
+        let devices: [DeviceInfo] = try await client
+            .from("devices")
+            .select()
+            .eq("workspace_id", value: workspaceId)
+            .order("last_seen_at", ascending: false)
+            .execute()
+            .value
+
+        workspaceDevices = devices
+        return devices
+    }
+
+    // MARK: - Device Management
+
+    func updateDeviceName(_ name: String) async throws {
+        guard let client = supabaseService.client,
+              let deviceId = currentDevice?.id else { return }
+
+        struct NameUpdate: Encodable {
+            let device_name: String
+        }
+
+        try await client
+            .from("devices")
+            .update(NameUpdate(device_name: name))
+            .eq("id", value: deviceId)
+            .execute()
+
+        currentDevice?.deviceName = name
+        Log.cloud.info("디바이스 이름 변경: \(name, privacy: .public)")
+    }
+
+    func removeDevice(id: UUID) async throws {
+        guard let client = supabaseService.client else { return }
+        try await client
+            .from("devices")
+            .delete()
+            .eq("id", value: id)
+            .execute()
+
+        workspaceDevices.removeAll { $0.id == id }
+        if currentDevice?.id == id {
+            currentDevice = nil
+            stopHeartbeat()
+        }
+        Log.cloud.info("디바이스 제거: \(id, privacy: .public)")
+    }
+
+    // MARK: - Helpers
+
+    private func getOrCreateDeviceId() -> UUID {
+        if let idString = keychainService.load(account: KeychainKeys.deviceId),
+           let id = UUID(uuidString: idString) {
+            return id
+        }
+        let newId = UUID()
+        keychainService.save(account: KeychainKeys.deviceId, value: newId.uuidString)
+        return newId
+    }
+}
+
+// MARK: - DTOs
+
+private struct DeviceInsert: Encodable {
+    let id: UUID
+    let workspace_id: UUID
+    let user_id: UUID
+    let device_name: String
+    let platform: String
+    let is_online: Bool
+    let last_seen_at: Date
+}
+
+private struct DeviceUpdate: Encodable {
+    let is_online: Bool
+    let last_seen_at: Date
+}

--- a/Dochi/Services/Protocols/DeviceServiceProtocol.swift
+++ b/Dochi/Services/Protocols/DeviceServiceProtocol.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct DeviceInfo: Identifiable, Codable {
+    let id: UUID
+    let workspaceId: UUID
+    let userId: UUID
+    var deviceName: String
+    let platform: String
+    var isOnline: Bool
+    var lastSeenAt: Date
+    let createdAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case workspaceId = "workspace_id"
+        case userId = "user_id"
+        case deviceName = "device_name"
+        case platform
+        case isOnline = "is_online"
+        case lastSeenAt = "last_seen_at"
+        case createdAt = "created_at"
+    }
+}
+
+@MainActor
+protocol DeviceServiceProtocol: AnyObject {
+    var currentDevice: DeviceInfo? { get }
+    var workspaceDevices: [DeviceInfo] { get }
+
+    func registerDevice() async throws
+    func startHeartbeat()
+    func stopHeartbeat()
+    func fetchWorkspaceDevices() async throws -> [DeviceInfo]
+    func updateDeviceName(_ name: String) async throws
+    func removeDevice(id: UUID) async throws
+}

--- a/Dochi/ViewModels/DochiViewModel+Callbacks.swift
+++ b/Dochi/ViewModels/DochiViewModel+Callbacks.swift
@@ -142,6 +142,12 @@ extension DochiViewModel {
                 .sink { [weak self] _ in self?.objectWillChange.send() }
                 .store(in: &cancellables)
         }
+        if let device = deviceService as? DeviceService {
+            device.objectWillChange
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.objectWillChange.send() }
+                .store(in: &cancellables)
+        }
     }
 
     func setupProfileCallback() {

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -31,6 +31,7 @@ final class DochiViewModel: ObservableObject {
     // Dependencies
     let contextService: ContextServiceProtocol
     let supabaseService: any SupabaseServiceProtocol
+    let deviceService: any DeviceServiceProtocol
 
     // Tool loop 관련
     @Published var currentToolExecution: String?
@@ -56,9 +57,13 @@ final class DochiViewModel: ObservableObject {
 
     private let conversationService: ConversationServiceProtocol
 
-    /// Concrete accessor for views that need @ObservedObject
+    /// Concrete accessors for views that need @ObservedObject
     var supabaseServiceForView: SupabaseService? {
         supabaseService as? SupabaseService
+    }
+
+    var deviceServiceForView: DeviceService? {
+        deviceService as? DeviceService
     }
 
     var isConnected: Bool {
@@ -72,7 +77,8 @@ final class DochiViewModel: ObservableObject {
         contextService: ContextServiceProtocol = ContextService(),
         conversationService: ConversationServiceProtocol = ConversationService(),
         mcpService: MCPServiceProtocol? = nil,
-        supabaseService: (any SupabaseServiceProtocol)? = nil
+        supabaseService: (any SupabaseServiceProtocol)? = nil,
+        deviceService: (any DeviceServiceProtocol)? = nil
     ) {
         self.settings = settings
         self.contextService = contextService
@@ -82,12 +88,33 @@ final class DochiViewModel: ObservableObject {
         self.supertonicService = SupertonicService()
         self.mcpService = mcpService ?? MCPService()
         self.builtInToolService = BuiltInToolService()
-        self.supabaseService = supabaseService ?? SupabaseService(keychainService: settings.keychainServiceRef)
+        let supa = supabaseService ?? SupabaseService(keychainService: settings.keychainServiceRef)
+        self.supabaseService = supa
+        if let deviceService {
+            self.deviceService = deviceService
+        } else if let concreteSupa = supa as? SupabaseService {
+            self.deviceService = DeviceService(supabaseService: concreteSupa, keychainService: settings.keychainServiceRef)
+        } else {
+            self.deviceService = DeviceService(supabaseService: SupabaseService(keychainService: settings.keychainServiceRef), keychainService: settings.keychainServiceRef)
+        }
 
         setupCallbacks()
         setupChangeForwarding()
         setupProfileCallback()
+        setupTerminationHandler()
         conversationManager.loadAll()
+    }
+
+    private func setupTerminationHandler() {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.deviceService.stopHeartbeat()
+            }
+        }
     }
 
     // MARK: - Wake Word (forwarding to SessionManager)
@@ -116,11 +143,19 @@ final class DochiViewModel: ObservableObject {
             connect()
         }
 
-        // Restore cloud session and sync context
+        // Restore cloud session, sync context, register device
         Task {
             await supabaseService.restoreSession()
             if let cloudContext = contextService as? CloudContextService {
                 await cloudContext.pullFromCloud()
+            }
+            if case .signedIn = supabaseService.authState {
+                do {
+                    try await deviceService.registerDevice()
+                } catch {
+                    Log.cloud.warning("디바이스 등록 실패: \(error, privacy: .public)")
+                }
+                deviceService.startHeartbeat()
             }
         }
     }

--- a/Dochi/Views/DeviceSettingsView.swift
+++ b/Dochi/Views/DeviceSettingsView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct DeviceSettingsView: View {
+    @ObservedObject var deviceService: DeviceService
+    @State private var devices: [DeviceInfo] = []
+    @State private var editingName = false
+    @State private var newName = ""
+
+    var body: some View {
+        Section("디바이스") {
+            if devices.isEmpty {
+                Text("등록된 디바이스가 없습니다.")
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(devices) { device in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 6) {
+                                Circle()
+                                    .fill(device.isOnline ? Color.green : Color.gray)
+                                    .frame(width: 8, height: 8)
+                                Text(device.deviceName)
+                                    .font(.body)
+                                if device.id == deviceService.currentDevice?.id {
+                                    Text("이 기기")
+                                        .font(.caption2)
+                                        .padding(.horizontal, 4)
+                                        .padding(.vertical, 1)
+                                        .background(.blue.opacity(0.15), in: Capsule())
+                                        .foregroundStyle(.blue)
+                                }
+                            }
+                            HStack(spacing: 8) {
+                                Text(device.platform)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                if !device.isOnline {
+                                    Text("마지막: \(formatLastSeen(device.lastSeenAt))")
+                                        .font(.caption)
+                                        .foregroundStyle(.tertiary)
+                                }
+                            }
+                        }
+                        Spacer()
+                        if device.id != deviceService.currentDevice?.id {
+                            Button(role: .destructive) {
+                                removeDevice(device)
+                            } label: {
+                                Image(systemName: "trash")
+                                    .font(.caption)
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                    }
+                }
+            }
+
+            if deviceService.currentDevice != nil {
+                Button {
+                    newName = deviceService.currentDevice?.deviceName ?? ""
+                    editingName = true
+                } label: {
+                    Label("이 기기 이름 변경", systemImage: "pencil")
+                }
+            }
+        }
+        .onAppear { loadDevices() }
+        .alert("디바이스 이름 변경", isPresented: $editingName) {
+            TextField("이름", text: $newName)
+            Button("변경") {
+                Task {
+                    try? await deviceService.updateDeviceName(newName)
+                    loadDevices()
+                }
+            }
+            Button("취소", role: .cancel) {}
+        }
+    }
+
+    private func loadDevices() {
+        Task {
+            devices = (try? await deviceService.fetchWorkspaceDevices()) ?? []
+        }
+    }
+
+    private func removeDevice(_ device: DeviceInfo) {
+        Task {
+            try? await deviceService.removeDevice(id: device.id)
+            loadDevices()
+        }
+    }
+
+    private func formatLastSeen(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -343,6 +343,11 @@ struct SettingsView: View {
                     CloudSettingsView(supabaseService: supabase)
                 }
 
+                if case .signedIn = viewModel.supabaseService.authState,
+                   let device = viewModel.deviceServiceForView {
+                    DeviceSettingsView(deviceService: device)
+                }
+
                 // MARK: - About
                 Section("정보") {
                     HStack {

--- a/DochiTests/Mocks/MockDeviceService.swift
+++ b/DochiTests/Mocks/MockDeviceService.swift
@@ -1,0 +1,44 @@
+import Foundation
+@testable import Dochi
+
+@MainActor
+final class MockDeviceService: DeviceServiceProtocol {
+    var currentDevice: DeviceInfo?
+    var workspaceDevices: [DeviceInfo] = []
+    var registerCalled = false
+    var heartbeatStarted = false
+
+    func registerDevice() async throws {
+        registerCalled = true
+        currentDevice = DeviceInfo(
+            id: UUID(),
+            workspaceId: UUID(),
+            userId: UUID(),
+            deviceName: "Test Mac",
+            platform: "macOS",
+            isOnline: true,
+            lastSeenAt: Date(),
+            createdAt: Date()
+        )
+    }
+
+    func startHeartbeat() {
+        heartbeatStarted = true
+    }
+
+    func stopHeartbeat() {
+        heartbeatStarted = false
+    }
+
+    func fetchWorkspaceDevices() async throws -> [DeviceInfo] {
+        workspaceDevices
+    }
+
+    func updateDeviceName(_ name: String) async throws {
+        currentDevice?.deviceName = name
+    }
+
+    func removeDevice(id: UUID) async throws {
+        workspaceDevices.removeAll { $0.id == id }
+    }
+}


### PR DESCRIPTION
## Summary
- DeviceService with protocol-based DI (DeviceServiceProtocol)
- Device registration, heartbeat (30s), offline marking on termination
- DeviceSettingsView for workspace device management
- guard let client, do/catch with Log.cloud

Closes #7

Replaces #30 (closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)