### PR TITLE
Add cloud conversation sync with write-through and soft delete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Dochi/
 │   ├── SupabaseService.swift
 │   ├── CloudContextService.swift
 │   ├── DeviceService.swift
+│   ├── CloudConversationService.swift
 │   └── Supertonic/           # TTS helpers
 └── Resources/
     └── CHANGELOG.md

--- a/Dochi/DochiApp.swift
+++ b/Dochi/DochiApp.swift
@@ -10,11 +10,13 @@ struct DochiApp: App {
         let supabaseService = SupabaseService(keychainService: keychainService)
         let cloudContext = CloudContextService(supabaseService: supabaseService)
         let deviceService = DeviceService(supabaseService: supabaseService, keychainService: keychainService)
+        let cloudConversation = CloudConversationService(supabaseService: supabaseService, deviceService: deviceService)
         let settings = AppSettings(keychainService: keychainService, contextService: cloudContext)
         _settings = StateObject(wrappedValue: settings)
         _viewModel = StateObject(wrappedValue: DochiViewModel(
             settings: settings,
             contextService: cloudContext,
+            conversationService: cloudConversation,
             supabaseService: supabaseService,
             deviceService: deviceService
         ))

--- a/Dochi/Services/CloudConversationService.swift
+++ b/Dochi/Services/CloudConversationService.swift
@@ -1,0 +1,232 @@
+import Foundation
+import Supabase
+import os
+
+/// 클라우드 동기화 대화 히스토리 서비스
+/// - 로컬 ConversationService를 래핑하여 Supabase 동기화 제공
+/// - Write-through: 저장/삭제 시 로컬 + 클라우드 동시 처리
+/// - Pull-on-launch: 앱 시작 시 클라우드에서 대화 목록 동기화
+/// - 소프트 딜리트: 클라우드에서는 deleted_at으로 표시
+@MainActor
+final class CloudConversationService: ConversationServiceProtocol {
+    private let local: ConversationService
+    private let supabaseService: SupabaseService
+    private let deviceService: any DeviceServiceProtocol
+
+    init(
+        local: ConversationService = ConversationService(),
+        supabaseService: SupabaseService,
+        deviceService: any DeviceServiceProtocol
+    ) {
+        self.local = local
+        self.supabaseService = supabaseService
+        self.deviceService = deviceService
+    }
+
+    // MARK: - ConversationServiceProtocol
+
+    func list() -> [Conversation] {
+        local.list()
+    }
+
+    func load(id: UUID) -> Conversation? {
+        local.load(id: id)
+    }
+
+    func save(_ conversation: Conversation) {
+        local.save(conversation)
+        schedulePush(conversation)
+    }
+
+    func delete(id: UUID) {
+        local.delete(id: id)
+        scheduleSoftDelete(id: id)
+    }
+
+    // MARK: - Cloud Sync
+
+    /// 앱 시작 시 클라우드에서 대화 목록 동기화
+    /// Cloud-always-wins on pull: 풀 시 클라우드 내용이 로컬을 덮어씁니다
+    func pullFromCloud() async {
+        guard let client = supabaseService.client,
+              case .signedIn = supabaseService.authState,
+              let wsId = supabaseService.selectedWorkspace?.id else { return }
+
+        do {
+            // Fetch non-deleted conversations from cloud
+            let cloudConversations: [CloudConversationRow] = try await client
+                .from("conversations")
+                .select()
+                .eq("workspace_id", value: wsId)
+                .is("deleted_at", value: nil)
+                .order("updated_at", ascending: false)
+                .execute()
+                .value
+
+            let localConversations = local.list()
+            let localById = Dictionary(uniqueKeysWithValues: localConversations.map { ($0.id, $0) })
+
+            for row in cloudConversations {
+                if let localConv = localById[row.id] {
+                    // Update local if cloud is newer
+                    if row.updated_at > localConv.updatedAt {
+                        local.save(row.toConversation())
+                    }
+                } else {
+                    // Cloud-only conversation — save locally
+                    local.save(row.toConversation())
+                }
+            }
+
+            // Fetch soft-deleted conversations to clean up local copies
+            let deletedRows: [CloudConversationRow] = try await client
+                .from("conversations")
+                .select()
+                .eq("workspace_id", value: wsId)
+                .not("deleted_at", operator: .is, value: Bool?.none)
+                .execute()
+                .value
+
+            let deletedIds = Set(deletedRows.map(\.id))
+            for localConv in localConversations where deletedIds.contains(localConv.id) {
+                local.delete(id: localConv.id)
+            }
+
+            Log.cloud.info("대화 클라우드 동기화 완료: \(cloudConversations.count)개, 삭제: \(deletedRows.count)개")
+        } catch {
+            Log.cloud.warning("대화 클라우드 풀 실패: \(error, privacy: .public)")
+        }
+    }
+
+    // MARK: - Push
+
+    private func schedulePush(_ conversation: Conversation) {
+        Task {
+            guard let client = supabaseService.client,
+                  case .signedIn = supabaseService.authState,
+                  let wsId = supabaseService.selectedWorkspace?.id else { return }
+
+            do {
+                try await client
+                    .from("conversations")
+                    .upsert(CloudConversationInsert(
+                        id: conversation.id,
+                        workspace_id: wsId,
+                        device_id: deviceService.currentDevice?.id,
+                        title: conversation.title,
+                        messages: conversation.messages,
+                        summary: conversation.summary,
+                        user_id: conversation.userId,
+                        created_at: conversation.createdAt,
+                        updated_at: conversation.updatedAt
+                    ))
+                    .execute()
+
+                Log.cloud.debug("대화 클라우드 푸시 완료: \(conversation.id, privacy: .public)")
+            } catch {
+                Log.cloud.warning("대화 클라우드 푸시 실패: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    private func scheduleSoftDelete(id: UUID) {
+        Task {
+            guard let client = supabaseService.client,
+                  case .signedIn = supabaseService.authState,
+                  let wsId = supabaseService.selectedWorkspace?.id else { return }
+
+            do {
+                struct SoftDelete: Encodable {
+                    let deleted_at: Date
+                }
+
+                try await client
+                    .from("conversations")
+                    .update(SoftDelete(deleted_at: Date()))
+                    .eq("id", value: id)
+                    .eq("workspace_id", value: wsId)
+                    .execute()
+
+                Log.cloud.debug("대화 소프트 삭제: \(id, privacy: .public)")
+            } catch {
+                Log.cloud.warning("대화 소프트 삭제 실패: \(error, privacy: .public)")
+            }
+        }
+    }
+}
+
+// MARK: - DTOs
+
+private struct CloudConversationRow: Codable {
+    let id: UUID
+    let workspace_id: UUID
+    let device_id: UUID?
+    let title: String
+    let messages: [Message]
+    let summary: String?
+    let user_id: String?
+    let created_at: Date
+    let updated_at: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id, workspace_id, device_id, title, messages, summary, user_id, created_at, updated_at
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        workspace_id = try container.decode(UUID.self, forKey: .workspace_id)
+        device_id = try container.decodeIfPresent(UUID.self, forKey: .device_id)
+        title = try container.decode(String.self, forKey: .title)
+        summary = try container.decodeIfPresent(String.self, forKey: .summary)
+        user_id = try container.decodeIfPresent(String.self, forKey: .user_id)
+        created_at = try container.decode(Date.self, forKey: .created_at)
+        updated_at = try container.decode(Date.self, forKey: .updated_at)
+
+        // Handle both JSONB array and legacy double-encoded string
+        let rowId = id
+        do {
+            messages = try container.decode([Message].self, forKey: .messages)
+        } catch {
+            // Fallback: try decoding as string (legacy double-encoded format)
+            if let jsonString = try? container.decode(String.self, forKey: .messages),
+               let data = jsonString.data(using: .utf8) {
+                let msgDecoder = JSONDecoder()
+                msgDecoder.dateDecodingStrategy = .iso8601
+                do {
+                    messages = try msgDecoder.decode([Message].self, from: data)
+                } catch {
+                    Log.cloud.warning("메시지 파싱 실패 (id: \(rowId)): \(error, privacy: .public)")
+                    messages = []
+                }
+            } else {
+                Log.cloud.warning("메시지 파싱 실패 (id: \(rowId)): \(error, privacy: .public)")
+                messages = []
+            }
+        }
+    }
+
+    func toConversation() -> Conversation {
+        Conversation(
+            id: id,
+            title: title,
+            messages: messages,
+            createdAt: created_at,
+            updatedAt: updated_at,
+            userId: user_id,
+            summary: summary
+        )
+    }
+}
+
+private struct CloudConversationInsert: Encodable {
+    let id: UUID
+    let workspace_id: UUID
+    let device_id: UUID?
+    let title: String
+    let messages: [Message]
+    let summary: String?
+    let user_id: String?
+    let created_at: Date
+    let updated_at: Date
+}

--- a/Dochi/Services/ConversationService.swift
+++ b/Dochi/Services/ConversationService.swift
@@ -3,6 +3,7 @@ import os
 
 /// 대화 히스토리 저장 서비스
 /// ~/Library/Application Support/Dochi/conversations/ 디렉토리에 JSON 파일로 저장
+@MainActor
 final class ConversationService: ConversationServiceProtocol {
     private let fileManager: FileManager
     private let conversationsDir: URL

--- a/Dochi/Services/Protocols/ConversationServiceProtocol.swift
+++ b/Dochi/Services/Protocols/ConversationServiceProtocol.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// 대화 히스토리 저장 서비스 프로토콜
+@MainActor
 protocol ConversationServiceProtocol {
     /// 전체 대화 목록 반환 (updatedAt 내림차순)
     func list() -> [Conversation]

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -143,11 +143,15 @@ final class DochiViewModel: ObservableObject {
             connect()
         }
 
-        // Restore cloud session, sync context, register device
+        // Restore cloud session, sync context/conversations, register device
         Task {
             await supabaseService.restoreSession()
             if let cloudContext = contextService as? CloudContextService {
                 await cloudContext.pullFromCloud()
+            }
+            if let cloudConversation = conversationService as? CloudConversationService {
+                await cloudConversation.pullFromCloud()
+                conversationManager.loadAll()
             }
             if case .signedIn = supabaseService.authState {
                 do {

--- a/DochiTests/Mocks/MockConversationService.swift
+++ b/DochiTests/Mocks/MockConversationService.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import Dochi
 
+@MainActor
 final class MockConversationService: ConversationServiceProtocol {
     var conversations: [UUID: Conversation] = [:]
 

--- a/DochiTests/Services/ConversationServiceTests.swift
+++ b/DochiTests/Services/ConversationServiceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Dochi
 
+@MainActor
 final class ConversationServiceTests: XCTestCase {
     var sut: ConversationService!
     var tempDir: URL!

--- a/supabase/migrations/003_conversations.sql
+++ b/supabase/migrations/003_conversations.sql
@@ -1,0 +1,35 @@
+-- Cloud conversations table
+create table if not exists conversations (
+    id uuid primary key,
+    workspace_id uuid not null references workspaces(id) on delete cascade,
+    device_id uuid references devices(id) on delete set null,
+    title text not null,
+    messages jsonb not null default '[]',
+    summary text,
+    user_id text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz -- soft delete
+);
+
+-- RLS
+alter table conversations enable row level security;
+
+create policy "conversation_select" on conversations for select using (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+create policy "conversation_insert" on conversations for insert with check (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+create policy "conversation_update" on conversations for update using (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+create policy "conversation_delete" on conversations for delete using (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+-- Index for faster workspace queries
+create index if not exists idx_conversations_workspace on conversations(workspace_id, updated_at desc);


### PR DESCRIPTION
## Summary
- CloudConversationService wraps local ConversationService
- Write-through sync, pull-on-launch with cloud-always-wins
- Soft delete with deleted_at, messages as [Message] JSONB
- @MainActor, ConversationServiceProtocol made @MainActor

Closes #8

Replaces #31 (closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)