### PR TITLE
Phase 2 누락 파일 보충: DeviceService, CloudConversationService, migrations

### DIFF
--- a/Dochi/DochiApp.swift
+++ b/Dochi/DochiApp.swift
@@ -8,13 +8,17 @@ struct DochiApp: App {
     init() {
         let keychainService = KeychainService()
         let supabaseService = SupabaseService(keychainService: keychainService)
-        let cloudContext = CloudContextService(supabaseService: supabaseService)
+        let deviceService = DeviceService(supabaseService: supabaseService, keychainService: keychainService)
+        let cloudContext = CloudContextService(supabaseService: supabaseService, deviceService: deviceService)
+        let cloudConversation = CloudConversationService(supabaseService: supabaseService, deviceService: deviceService)
         let settings = AppSettings(keychainService: keychainService, contextService: cloudContext)
         _settings = StateObject(wrappedValue: settings)
         _viewModel = StateObject(wrappedValue: DochiViewModel(
             settings: settings,
             contextService: cloudContext,
-            supabaseService: supabaseService
+            conversationService: cloudConversation,
+            supabaseService: supabaseService,
+            deviceService: deviceService
         ))
     }
 

--- a/Dochi/Services/CloudConversationService.swift
+++ b/Dochi/Services/CloudConversationService.swift
@@ -1,0 +1,317 @@
+import Foundation
+import Supabase
+import os
+
+/// 클라우드 동기화 대화 히스토리 서비스
+/// - 로컬 ConversationService를 래핑하여 Supabase 동기화 제공
+/// - Write-through: 저장/삭제 시 로컬 + 클라우드 동시 처리
+/// - Supabase Realtime으로 다른 디바이스 변경사항 즉시 반영
+/// - 소프트 딜리트: 클라우드에서는 deleted_at으로 표시
+@MainActor
+final class CloudConversationService: ConversationServiceProtocol {
+    private let local: ConversationService
+    private let supabaseService: SupabaseService
+    private let deviceService: any DeviceServiceProtocol
+
+    /// 다른 디바이스에서 대화가 변경되었을 때 호출
+    var onConversationsChanged: (() -> Void)?
+
+    private var realtimeTask: Task<Void, Never>?
+
+    init(
+        local: ConversationService = ConversationService(),
+        supabaseService: SupabaseService,
+        deviceService: any DeviceServiceProtocol
+    ) {
+        self.local = local
+        self.supabaseService = supabaseService
+        self.deviceService = deviceService
+    }
+
+    // MARK: - ConversationServiceProtocol
+
+    func list() -> [Conversation] {
+        local.list()
+    }
+
+    func load(id: UUID) -> Conversation? {
+        local.load(id: id)
+    }
+
+    func save(_ conversation: Conversation) {
+        local.save(conversation)
+        schedulePush(conversation)
+    }
+
+    func delete(id: UUID) {
+        local.delete(id: id)
+        scheduleSoftDelete(id: id)
+    }
+
+    // MARK: - Cloud Sync
+
+    /// 앱 시작 시 클라우드에서 대화 목록 동기화
+    /// Cloud-always-wins on pull: 풀 시 클라우드 내용이 로컬을 덮어씁니다
+    func pullFromCloud() async {
+        guard let client = supabaseService.client,
+              case .signedIn = supabaseService.authState,
+              let wsId = supabaseService.selectedWorkspace?.id else { return }
+
+        do {
+            // Fetch non-deleted conversations from cloud
+            let cloudConversations: [CloudConversationRow] = try await client
+                .from("conversations")
+                .select()
+                .eq("workspace_id", value: wsId)
+                .is("deleted_at", value: nil)
+                .order("updated_at", ascending: false)
+                .execute()
+                .value
+
+            let localConversations = local.list()
+            let localById = Dictionary(uniqueKeysWithValues: localConversations.map { ($0.id, $0) })
+
+            for row in cloudConversations {
+                if let localConv = localById[row.id] {
+                    // Update local if cloud is newer
+                    if row.updated_at > localConv.updatedAt {
+                        local.save(row.toConversation())
+                    }
+                } else {
+                    // Cloud-only conversation — save locally
+                    local.save(row.toConversation())
+                }
+            }
+
+            // Fetch soft-deleted conversations to clean up local copies
+            let deletedRows: [CloudConversationRow] = try await client
+                .from("conversations")
+                .select()
+                .eq("workspace_id", value: wsId)
+                .not("deleted_at", operator: .is, value: Bool?.none)
+                .execute()
+                .value
+
+            let deletedIds = Set(deletedRows.map(\.id))
+            for localConv in localConversations where deletedIds.contains(localConv.id) {
+                local.delete(id: localConv.id)
+            }
+
+            Log.cloud.info("대화 클라우드 동기화 완료: \(cloudConversations.count)개, 삭제: \(deletedRows.count)개")
+        } catch {
+            Log.cloud.warning("대화 클라우드 풀 실패: \(error, privacy: .public)")
+        }
+    }
+
+    // MARK: - Realtime Subscriptions
+
+    /// Supabase Realtime 구독 시작 — 다른 디바이스의 대화 변경사항 즉시 반영
+    func subscribeToRealtimeChanges() {
+        guard let client = supabaseService.client,
+              case .signedIn = supabaseService.authState,
+              let wsId = supabaseService.selectedWorkspace?.id else { return }
+        unsubscribeFromRealtime()
+
+        realtimeTask = Task { [weak self] in
+            let channel = client.realtimeV2.channel("conversations-\(wsId.uuidString)")
+
+            let changes = channel.postgresChange(
+                AnyAction.self,
+                schema: "public",
+                table: "conversations",
+                filter: .eq("workspace_id", value: wsId)
+            )
+
+            do {
+                try await channel.subscribeWithError()
+                Log.cloud.info("대화 Realtime 구독 시작")
+            } catch {
+                Log.cloud.warning("대화 Realtime 구독 실패: \(error, privacy: .public)")
+                return
+            }
+
+            for await action in changes {
+                guard !Task.isCancelled else { break }
+                await self?.handleConversationRealtimeEvent(action)
+            }
+        }
+    }
+
+    /// Realtime 구독 해제
+    func unsubscribeFromRealtime() {
+        realtimeTask?.cancel()
+        realtimeTask = nil
+    }
+
+    private func handleConversationRealtimeEvent(_ action: AnyAction) {
+        let ownDeviceId = deviceService.currentDevice?.id
+        do {
+            switch action {
+            case .insert(let insert):
+                let row = try insert.decodeRecord(as: CloudConversationRow.self, decoder: PostgrestClient.Configuration.jsonDecoder)
+                // Skip own device's writes
+                if row.device_id == ownDeviceId { return }
+                if local.load(id: row.id) == nil {
+                    local.save(row.toConversation())
+                    onConversationsChanged?()
+                    Log.cloud.debug("Realtime 대화 추가: \(row.id, privacy: .public)")
+                }
+            case .update(let update):
+                let row = try update.decodeRecord(as: CloudConversationRow.self, decoder: PostgrestClient.Configuration.jsonDecoder)
+                // Skip own device's writes
+                if row.device_id == ownDeviceId { return }
+                // soft delete 감지
+                if row.deleted_at != nil {
+                    local.delete(id: row.id)
+                } else {
+                    local.save(row.toConversation())
+                }
+                onConversationsChanged?()
+                Log.cloud.debug("Realtime 대화 업데이트: \(row.id, privacy: .public)")
+            case .delete(let delete):
+                if let idString = delete.oldRecord["id"]?.stringValue,
+                   let id = UUID(uuidString: idString) {
+                    local.delete(id: id)
+                    onConversationsChanged?()
+                    Log.cloud.debug("Realtime 대화 삭제: \(id, privacy: .public)")
+                }
+            }
+        } catch {
+            Log.cloud.warning("대화 Realtime 이벤트 디코딩 실패: \(error, privacy: .public)")
+        }
+    }
+
+    // MARK: - Push
+
+    private func schedulePush(_ conversation: Conversation) {
+        Task {
+            guard let client = supabaseService.client,
+                  case .signedIn = supabaseService.authState,
+                  let wsId = supabaseService.selectedWorkspace?.id else { return }
+
+            do {
+                try await client
+                    .from("conversations")
+                    .upsert(CloudConversationInsert(
+                        id: conversation.id,
+                        workspace_id: wsId,
+                        device_id: deviceService.currentDevice?.id,
+                        title: conversation.title,
+                        messages: conversation.messages,
+                        summary: conversation.summary,
+                        user_id: conversation.userId,
+                        created_at: conversation.createdAt,
+                        updated_at: conversation.updatedAt
+                    ))
+                    .execute()
+
+                Log.cloud.debug("대화 클라우드 푸시 완료: \(conversation.id, privacy: .public)")
+            } catch {
+                Log.cloud.warning("대화 클라우드 푸시 실패: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    private func scheduleSoftDelete(id: UUID) {
+        Task {
+            guard let client = supabaseService.client,
+                  case .signedIn = supabaseService.authState,
+                  let wsId = supabaseService.selectedWorkspace?.id else { return }
+
+            do {
+                struct SoftDelete: Encodable {
+                    let deleted_at: Date
+                }
+
+                try await client
+                    .from("conversations")
+                    .update(SoftDelete(deleted_at: Date()))
+                    .eq("id", value: id)
+                    .eq("workspace_id", value: wsId)
+                    .execute()
+
+                Log.cloud.debug("대화 소프트 삭제: \(id, privacy: .public)")
+            } catch {
+                Log.cloud.warning("대화 소프트 삭제 실패: \(error, privacy: .public)")
+            }
+        }
+    }
+}
+
+// MARK: - DTOs
+
+private struct CloudConversationRow: Codable {
+    let id: UUID
+    let workspace_id: UUID
+    let device_id: UUID?
+    let title: String
+    let messages: [Message]
+    let summary: String?
+    let user_id: String?
+    let created_at: Date
+    let updated_at: Date
+    let deleted_at: Date?
+
+    enum CodingKeys: String, CodingKey {
+        case id, workspace_id, device_id, title, messages, summary, user_id, created_at, updated_at, deleted_at
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        workspace_id = try container.decode(UUID.self, forKey: .workspace_id)
+        device_id = try container.decodeIfPresent(UUID.self, forKey: .device_id)
+        title = try container.decode(String.self, forKey: .title)
+        summary = try container.decodeIfPresent(String.self, forKey: .summary)
+        user_id = try container.decodeIfPresent(String.self, forKey: .user_id)
+        created_at = try container.decode(Date.self, forKey: .created_at)
+        updated_at = try container.decode(Date.self, forKey: .updated_at)
+        deleted_at = try container.decodeIfPresent(Date.self, forKey: .deleted_at)
+
+        // Handle both JSONB array and legacy double-encoded string
+        let rowId = id
+        do {
+            messages = try container.decode([Message].self, forKey: .messages)
+        } catch {
+            // Fallback: try decoding as string (legacy double-encoded format)
+            if let jsonString = try? container.decode(String.self, forKey: .messages),
+               let data = jsonString.data(using: .utf8) {
+                let msgDecoder = JSONDecoder()
+                msgDecoder.dateDecodingStrategy = .iso8601
+                do {
+                    messages = try msgDecoder.decode([Message].self, from: data)
+                } catch {
+                    Log.cloud.warning("메시지 파싱 실패 (id: \(rowId)): \(error, privacy: .public)")
+                    messages = []
+                }
+            } else {
+                Log.cloud.warning("메시지 파싱 실패 (id: \(rowId)): \(error, privacy: .public)")
+                messages = []
+            }
+        }
+    }
+
+    func toConversation() -> Conversation {
+        Conversation(
+            id: id,
+            title: title,
+            messages: messages,
+            createdAt: created_at,
+            updatedAt: updated_at,
+            userId: user_id,
+            summary: summary
+        )
+    }
+}
+
+private struct CloudConversationInsert: Encodable {
+    let id: UUID
+    let workspace_id: UUID
+    let device_id: UUID?
+    let title: String
+    let messages: [Message]
+    let summary: String?
+    let user_id: String?
+    let created_at: Date
+    let updated_at: Date
+}

--- a/Dochi/Services/ConversationService.swift
+++ b/Dochi/Services/ConversationService.swift
@@ -3,6 +3,7 @@ import os
 
 /// 대화 히스토리 저장 서비스
 /// ~/Library/Application Support/Dochi/conversations/ 디렉토리에 JSON 파일로 저장
+@MainActor
 final class ConversationService: ConversationServiceProtocol {
     private let fileManager: FileManager
     private let conversationsDir: URL

--- a/Dochi/Services/DeviceService.swift
+++ b/Dochi/Services/DeviceService.swift
@@ -1,0 +1,240 @@
+import Foundation
+import Supabase
+import os
+
+@MainActor
+final class DeviceService: ObservableObject, DeviceServiceProtocol {
+    @Published private(set) var currentDevice: DeviceInfo?
+    @Published private(set) var workspaceDevices: [DeviceInfo] = []
+
+    private let supabaseService: SupabaseService
+    private let keychainService: KeychainServiceProtocol
+    private var heartbeatTask: Task<Void, Never>?
+
+    private enum KeychainKeys {
+        static let deviceId = "device_id"
+    }
+
+    private static let heartbeatInterval: TimeInterval = 30
+
+    init(supabaseService: SupabaseService, keychainService: KeychainServiceProtocol = KeychainService()) {
+        self.supabaseService = supabaseService
+        self.keychainService = keychainService
+    }
+
+    // MARK: - Device Registration
+
+    func registerDevice() async throws {
+        guard let client = supabaseService.client,
+              case .signedIn(let userId, _) = supabaseService.authState,
+              let workspaceId = supabaseService.selectedWorkspace?.id else {
+            return
+        }
+
+        let deviceId = getOrCreateDeviceId()
+        let deviceName = Host.current().localizedName ?? "Mac"
+        let caps = detectCapabilities()
+
+        // Check if already registered
+        let existing: [DeviceInfo] = try await client
+            .from("devices")
+            .select()
+            .eq("id", value: deviceId)
+            .eq("workspace_id", value: workspaceId)
+            .execute()
+            .value
+
+        if let device = existing.first {
+            // Update existing device
+            let updated: DeviceInfo = try await client
+                .from("devices")
+                .update(DeviceRegistrationUpdate(
+                    is_online: true,
+                    last_seen_at: Date(),
+                    capabilities: caps
+                ))
+                .eq("id", value: deviceId)
+                .select()
+                .single()
+                .execute()
+                .value
+            currentDevice = updated
+            Log.cloud.info("디바이스 재등록: \(device.deviceName, privacy: .public) [\(caps.joined(separator: ", "), privacy: .public)]")
+        } else {
+            // Insert new device
+            let device: DeviceInfo = try await client
+                .from("devices")
+                .insert(DeviceInsert(
+                    id: deviceId,
+                    workspace_id: workspaceId,
+                    user_id: userId,
+                    device_name: deviceName,
+                    platform: "macOS",
+                    is_online: true,
+                    last_seen_at: Date(),
+                    capabilities: caps
+                ))
+                .select()
+                .single()
+                .execute()
+                .value
+            currentDevice = device
+            Log.cloud.info("디바이스 등록: \(deviceName, privacy: .public) [\(caps.joined(separator: ", "), privacy: .public)]")
+        }
+    }
+
+    // MARK: - Heartbeat
+
+    func startHeartbeat() {
+        stopHeartbeat()
+        heartbeatTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(DeviceService.heartbeatInterval * 1_000_000_000))
+                guard !Task.isCancelled else { break }
+                await self?.sendHeartbeat()
+            }
+        }
+        Log.cloud.debug("하트비트 시작")
+    }
+
+    func stopHeartbeat() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+
+        // Mark offline
+        if let deviceId = currentDevice?.id, let client = supabaseService.client {
+            Task { @MainActor in
+                do {
+                    try await client
+                        .from("devices")
+                        .update(DeviceUpdate(is_online: false, last_seen_at: Date()))
+                        .eq("id", value: deviceId)
+                        .execute()
+                } catch {
+                    Log.cloud.warning("오프라인 마킹 실패: \(error, privacy: .public)")
+                }
+            }
+        }
+        Log.cloud.debug("하트비트 중지")
+    }
+
+    private func sendHeartbeat() async {
+        guard let client = supabaseService.client,
+              let deviceId = currentDevice?.id else { return }
+        do {
+            try await client
+                .from("devices")
+                .update(DeviceUpdate(is_online: true, last_seen_at: Date()))
+                .eq("id", value: deviceId)
+                .execute()
+        } catch {
+            Log.cloud.warning("하트비트 실패: \(error, privacy: .public)")
+        }
+    }
+
+    // MARK: - Device List
+
+    func fetchWorkspaceDevices() async throws -> [DeviceInfo] {
+        guard let client = supabaseService.client,
+              let workspaceId = supabaseService.selectedWorkspace?.id else {
+            return []
+        }
+
+        let devices: [DeviceInfo] = try await client
+            .from("devices")
+            .select()
+            .eq("workspace_id", value: workspaceId)
+            .order("last_seen_at", ascending: false)
+            .execute()
+            .value
+
+        workspaceDevices = devices
+        return devices
+    }
+
+    // MARK: - Device Management
+
+    func updateDeviceName(_ name: String) async throws {
+        guard let client = supabaseService.client,
+              let deviceId = currentDevice?.id else { return }
+
+        struct NameUpdate: Encodable {
+            let device_name: String
+        }
+
+        try await client
+            .from("devices")
+            .update(NameUpdate(device_name: name))
+            .eq("id", value: deviceId)
+            .execute()
+
+        currentDevice?.deviceName = name
+        Log.cloud.info("디바이스 이름 변경: \(name, privacy: .public)")
+    }
+
+    func removeDevice(id: UUID) async throws {
+        guard let client = supabaseService.client else { return }
+        try await client
+            .from("devices")
+            .delete()
+            .eq("id", value: id)
+            .execute()
+
+        workspaceDevices.removeAll { $0.id == id }
+        if currentDevice?.id == id {
+            currentDevice = nil
+            stopHeartbeat()
+        }
+        Log.cloud.info("디바이스 제거: \(id, privacy: .public)")
+    }
+
+    // MARK: - Helpers
+
+    private func getOrCreateDeviceId() -> UUID {
+        if let idString = keychainService.load(account: KeychainKeys.deviceId),
+           let id = UUID(uuidString: idString) {
+            return id
+        }
+        let newId = UUID()
+        keychainService.save(account: KeychainKeys.deviceId, value: newId.uuidString)
+        return newId
+    }
+
+    /// macOS 디바이스의 기능 목록 감지
+    // TODO: iOS/watchOS 클라이언트 추가 시 런타임 기능 탐지로 전환 필요
+    private func detectCapabilities() -> [String] {
+        var caps: [String] = []
+        // macOS는 기본적으로 모든 기능 지원
+        caps.append(DeviceCapability.screen.rawValue)
+        caps.append(DeviceCapability.tts.rawValue)
+        caps.append(DeviceCapability.stt.rawValue)
+        caps.append(DeviceCapability.mcp.rawValue)
+        caps.append(DeviceCapability.speaker.rawValue)
+        caps.append(DeviceCapability.mic.rawValue)
+        return caps
+    }
+}
+
+// MARK: - DTOs
+
+private struct DeviceInsert: Encodable {
+    let id: UUID
+    let workspace_id: UUID
+    let user_id: UUID
+    let device_name: String
+    let platform: String
+    let is_online: Bool
+    let last_seen_at: Date
+    let capabilities: [String]
+}
+
+private struct DeviceUpdate: Encodable {
+    let is_online: Bool
+    let last_seen_at: Date
+}
+
+private struct DeviceRegistrationUpdate: Encodable {
+    let is_online: Bool
+    let last_seen_at: Date
+    let capabilities: [String]
+}

--- a/Dochi/Services/Protocols/ConversationServiceProtocol.swift
+++ b/Dochi/Services/Protocols/ConversationServiceProtocol.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// 대화 히스토리 저장 서비스 프로토콜
+@MainActor
 protocol ConversationServiceProtocol {
     /// 전체 대화 목록 반환 (updatedAt 내림차순)
     func list() -> [Conversation]

--- a/Dochi/Services/Protocols/DeviceServiceProtocol.swift
+++ b/Dochi/Services/Protocols/DeviceServiceProtocol.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+struct DeviceInfo: Identifiable, Codable {
+    let id: UUID
+    let workspaceId: UUID
+    let userId: UUID
+    var deviceName: String
+    let platform: String
+    var isOnline: Bool
+    var lastSeenAt: Date
+    let createdAt: Date
+    var capabilities: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case workspaceId = "workspace_id"
+        case userId = "user_id"
+        case deviceName = "device_name"
+        case platform
+        case isOnline = "is_online"
+        case lastSeenAt = "last_seen_at"
+        case createdAt = "created_at"
+        case capabilities
+    }
+
+    init(id: UUID, workspaceId: UUID, userId: UUID, deviceName: String, platform: String, isOnline: Bool, lastSeenAt: Date, createdAt: Date, capabilities: [String] = []) {
+        self.id = id
+        self.workspaceId = workspaceId
+        self.userId = userId
+        self.deviceName = deviceName
+        self.platform = platform
+        self.isOnline = isOnline
+        self.lastSeenAt = lastSeenAt
+        self.createdAt = createdAt
+        self.capabilities = capabilities
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        workspaceId = try container.decode(UUID.self, forKey: .workspaceId)
+        userId = try container.decode(UUID.self, forKey: .userId)
+        deviceName = try container.decode(String.self, forKey: .deviceName)
+        platform = try container.decode(String.self, forKey: .platform)
+        isOnline = try container.decode(Bool.self, forKey: .isOnline)
+        lastSeenAt = try container.decode(Date.self, forKey: .lastSeenAt)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        capabilities = try container.decodeIfPresent([String].self, forKey: .capabilities) ?? []
+    }
+}
+
+/// 디바이스가 지원하는 기능
+enum DeviceCapability: String, CaseIterable {
+    case tts       // 텍스트 → 음성 변환
+    case stt       // 음성 → 텍스트 변환
+    case mcp       // MCP 도구 실행
+    case screen    // 화면 표시 (GUI)
+    case speaker   // 스피커 출력
+    case mic       // 마이크 입력
+}
+
+@MainActor
+protocol DeviceServiceProtocol: AnyObject {
+    var currentDevice: DeviceInfo? { get }
+    var workspaceDevices: [DeviceInfo] { get }
+
+    func registerDevice() async throws
+    func startHeartbeat()
+    func stopHeartbeat()
+    func fetchWorkspaceDevices() async throws -> [DeviceInfo]
+    func updateDeviceName(_ name: String) async throws
+    func removeDevice(id: UUID) async throws
+}

--- a/Dochi/ViewModels/DochiViewModel+Callbacks.swift
+++ b/Dochi/ViewModels/DochiViewModel+Callbacks.swift
@@ -142,6 +142,12 @@ extension DochiViewModel {
                 .sink { [weak self] _ in self?.objectWillChange.send() }
                 .store(in: &cancellables)
         }
+        if let device = deviceService as? DeviceService {
+            device.objectWillChange
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.objectWillChange.send() }
+                .store(in: &cancellables)
+        }
     }
 
     func setupProfileCallback() {

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -31,6 +31,7 @@ final class DochiViewModel: ObservableObject {
     // Dependencies
     let contextService: ContextServiceProtocol
     let supabaseService: any SupabaseServiceProtocol
+    let deviceService: any DeviceServiceProtocol
 
     // Tool loop 관련
     @Published var currentToolExecution: String?
@@ -56,9 +57,13 @@ final class DochiViewModel: ObservableObject {
 
     private let conversationService: ConversationServiceProtocol
 
-    /// Concrete accessor for views that need @ObservedObject
+    /// Concrete accessors for views that need @ObservedObject
     var supabaseServiceForView: SupabaseService? {
         supabaseService as? SupabaseService
+    }
+
+    var deviceServiceForView: DeviceService? {
+        deviceService as? DeviceService
     }
 
     var isConnected: Bool {
@@ -72,7 +77,8 @@ final class DochiViewModel: ObservableObject {
         contextService: ContextServiceProtocol = ContextService(),
         conversationService: ConversationServiceProtocol = ConversationService(),
         mcpService: MCPServiceProtocol? = nil,
-        supabaseService: (any SupabaseServiceProtocol)? = nil
+        supabaseService: (any SupabaseServiceProtocol)? = nil,
+        deviceService: (any DeviceServiceProtocol)? = nil
     ) {
         self.settings = settings
         self.contextService = contextService
@@ -82,12 +88,33 @@ final class DochiViewModel: ObservableObject {
         self.supertonicService = SupertonicService()
         self.mcpService = mcpService ?? MCPService()
         self.builtInToolService = BuiltInToolService()
-        self.supabaseService = supabaseService ?? SupabaseService(keychainService: settings.keychainServiceRef)
+        let supa = supabaseService ?? SupabaseService(keychainService: settings.keychainServiceRef)
+        self.supabaseService = supa
+        if let deviceService {
+            self.deviceService = deviceService
+        } else if let concreteSupa = supa as? SupabaseService {
+            self.deviceService = DeviceService(supabaseService: concreteSupa, keychainService: settings.keychainServiceRef)
+        } else {
+            self.deviceService = DeviceService(supabaseService: SupabaseService(keychainService: settings.keychainServiceRef), keychainService: settings.keychainServiceRef)
+        }
 
         setupCallbacks()
         setupChangeForwarding()
         setupProfileCallback()
+        setupTerminationHandler()
         conversationManager.loadAll()
+    }
+
+    private func setupTerminationHandler() {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.deviceService.stopHeartbeat()
+            }
+        }
     }
 
     // MARK: - Wake Word (forwarding to SessionManager)
@@ -116,11 +143,22 @@ final class DochiViewModel: ObservableObject {
             connect()
         }
 
-        // Restore cloud session and sync context
+        // Restore cloud session, sync context/conversations, register device, start Realtime
         Task {
             await supabaseService.restoreSession()
-            if let cloudContext = contextService as? CloudContextService {
-                await cloudContext.pullFromCloud()
+            setupCloudServices()
+        }
+
+        // Cleanup Realtime on logout, re-setup on login
+        supabaseService.onAuthStateChanged = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .signedOut:
+                self.cleanupCloudServices()
+            case .signedIn:
+                Task {
+                    self.setupCloudServices()
+                }
             }
         }
     }
@@ -133,6 +171,51 @@ final class DochiViewModel: ObservableObject {
         } else if supertonicService.state == .unloaded {
             connect()
         }
+    }
+
+    private func setupCloudServices() {
+        if let cloudContext = contextService as? CloudContextService {
+            Task {
+                await cloudContext.pullFromCloud()
+            }
+            cloudContext.onContextChanged = {
+                Log.app.info("Realtime: 컨텍스트 변경 감지")
+            }
+            cloudContext.subscribeToRealtimeChanges()
+        }
+        if let cloudConversation = conversationService as? CloudConversationService {
+            Task {
+                await cloudConversation.pullFromCloud()
+                conversationManager.loadAll()
+            }
+            cloudConversation.onConversationsChanged = { [weak self] in
+                self?.conversationManager.loadAll()
+            }
+            cloudConversation.subscribeToRealtimeChanges()
+        }
+        if case .signedIn = supabaseService.authState {
+            Task {
+                do {
+                    try await deviceService.registerDevice()
+                } catch {
+                    Log.cloud.warning("디바이스 등록 실패: \(error, privacy: .public)")
+                }
+                deviceService.startHeartbeat()
+            }
+        }
+    }
+
+    private func cleanupCloudServices() {
+        if let cloudContext = contextService as? CloudContextService {
+            cloudContext.unsubscribeFromRealtime()
+            cloudContext.onContextChanged = nil
+        }
+        if let cloudConversation = conversationService as? CloudConversationService {
+            cloudConversation.unsubscribeFromRealtime()
+            cloudConversation.onConversationsChanged = nil
+        }
+        deviceService.stopHeartbeat()
+        Log.app.info("클라우드 서비스 정리 완료")
     }
 
     private func connect() {

--- a/Dochi/Views/DeviceSettingsView.swift
+++ b/Dochi/Views/DeviceSettingsView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+import os
+
+struct DeviceSettingsView: View {
+    @ObservedObject var deviceService: DeviceService
+    @State private var devices: [DeviceInfo] = []
+    @State private var editingName = false
+    @State private var newName = ""
+
+    var body: some View {
+        Section("디바이스") {
+            if devices.isEmpty {
+                Text("등록된 디바이스가 없습니다.")
+                    .foregroundStyle(.tertiary)
+            } else {
+                ForEach(devices) { device in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 6) {
+                                Circle()
+                                    .fill(device.isOnline ? Color.green : Color.gray)
+                                    .frame(width: 8, height: 8)
+                                Text(device.deviceName)
+                                    .font(.body)
+                                if device.id == deviceService.currentDevice?.id {
+                                    Text("이 기기")
+                                        .font(.caption2)
+                                        .padding(.horizontal, 4)
+                                        .padding(.vertical, 1)
+                                        .background(.blue.opacity(0.15), in: Capsule())
+                                        .foregroundStyle(.blue)
+                                }
+                            }
+                            HStack(spacing: 8) {
+                                Text(device.platform)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                if !device.capabilities.isEmpty {
+                                    Text(device.capabilities.joined(separator: ", "))
+                                        .font(.caption2)
+                                        .foregroundStyle(.tertiary)
+                                }
+                                if !device.isOnline {
+                                    Text("마지막: \(formatLastSeen(device.lastSeenAt))")
+                                        .font(.caption)
+                                        .foregroundStyle(.tertiary)
+                                }
+                            }
+                        }
+                        Spacer()
+                        if device.id != deviceService.currentDevice?.id {
+                            Button(role: .destructive) {
+                                removeDevice(device)
+                            } label: {
+                                Image(systemName: "trash")
+                                    .font(.caption)
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                    }
+                }
+            }
+
+            if deviceService.currentDevice != nil {
+                Button {
+                    newName = deviceService.currentDevice?.deviceName ?? ""
+                    editingName = true
+                } label: {
+                    Label("이 기기 이름 변경", systemImage: "pencil")
+                }
+            }
+        }
+        .onAppear { loadDevices() }
+        .alert("디바이스 이름 변경", isPresented: $editingName) {
+            TextField("이름", text: $newName)
+            Button("변경") {
+                Task {
+                    do {
+                        try await deviceService.updateDeviceName(newName)
+                    } catch {
+                        Log.cloud.warning("디바이스 이름 변경 실패: \(error, privacy: .public)")
+                    }
+                    loadDevices()
+                }
+            }
+            Button("취소", role: .cancel) {}
+        }
+    }
+
+    private func loadDevices() {
+        Task {
+            do {
+                devices = try await deviceService.fetchWorkspaceDevices()
+            } catch {
+                Log.cloud.warning("디바이스 목록 로드 실패: \(error, privacy: .public)")
+            }
+        }
+    }
+
+    private func removeDevice(_ device: DeviceInfo) {
+        Task {
+            do {
+                try await deviceService.removeDevice(id: device.id)
+            } catch {
+                Log.cloud.warning("디바이스 제거 실패: \(error, privacy: .public)")
+            }
+            loadDevices()
+        }
+    }
+
+    private func formatLastSeen(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -343,6 +343,11 @@ struct SettingsView: View {
                     CloudSettingsView(supabaseService: supabase)
                 }
 
+                if case .signedIn = viewModel.supabaseService.authState,
+                   let device = viewModel.deviceServiceForView {
+                    DeviceSettingsView(deviceService: device)
+                }
+
                 // MARK: - About
                 Section("정보") {
                     HStack {

--- a/DochiTests/Mocks/MockConversationService.swift
+++ b/DochiTests/Mocks/MockConversationService.swift
@@ -1,6 +1,7 @@
 import Foundation
 @testable import Dochi
 
+@MainActor
 final class MockConversationService: ConversationServiceProtocol {
     var conversations: [UUID: Conversation] = [:]
 

--- a/DochiTests/Mocks/MockDeviceService.swift
+++ b/DochiTests/Mocks/MockDeviceService.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import Dochi
+
+@MainActor
+final class MockDeviceService: DeviceServiceProtocol {
+    var currentDevice: DeviceInfo?
+    var workspaceDevices: [DeviceInfo] = []
+    var registerCalled = false
+    var heartbeatStarted = false
+
+    func registerDevice() async throws {
+        registerCalled = true
+        currentDevice = DeviceInfo(
+            id: UUID(),
+            workspaceId: UUID(),
+            userId: UUID(),
+            deviceName: "Test Mac",
+            platform: "macOS",
+            isOnline: true,
+            lastSeenAt: Date(),
+            createdAt: Date(),
+            capabilities: ["tts", "stt", "mcp", "screen", "speaker", "mic"]
+        )
+    }
+
+    func startHeartbeat() {
+        heartbeatStarted = true
+    }
+
+    func stopHeartbeat() {
+        heartbeatStarted = false
+    }
+
+    func fetchWorkspaceDevices() async throws -> [DeviceInfo] {
+        workspaceDevices
+    }
+
+    func updateDeviceName(_ name: String) async throws {
+        currentDevice?.deviceName = name
+    }
+
+    func removeDevice(id: UUID) async throws {
+        workspaceDevices.removeAll { $0.id == id }
+    }
+}

--- a/DochiTests/Services/ConversationServiceTests.swift
+++ b/DochiTests/Services/ConversationServiceTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Dochi
 
+@MainActor
 final class ConversationServiceTests: XCTestCase {
     var sut: ConversationService!
     var tempDir: URL!

--- a/supabase/migrations/003_conversations.sql
+++ b/supabase/migrations/003_conversations.sql
@@ -1,0 +1,35 @@
+-- Cloud conversations table
+create table if not exists conversations (
+    id uuid primary key,
+    workspace_id uuid not null references workspaces(id) on delete cascade,
+    device_id uuid references devices(id) on delete set null,
+    title text not null,
+    messages jsonb not null default '[]',
+    summary text,
+    user_id text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    deleted_at timestamptz -- soft delete
+);
+
+-- RLS
+alter table conversations enable row level security;
+
+create policy "conversation_select" on conversations for select using (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+create policy "conversation_insert" on conversations for insert with check (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+create policy "conversation_update" on conversations for update using (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+create policy "conversation_delete" on conversations for delete using (
+    workspace_id in (select workspace_id from workspace_members where user_id = auth.uid())
+);
+
+-- Index for faster workspace queries
+create index if not exists idx_conversations_workspace on conversations(workspace_id, updated_at desc);

--- a/supabase/migrations/004_enable_realtime.sql
+++ b/supabase/migrations/004_enable_realtime.sql
@@ -1,0 +1,6 @@
+-- Enable Supabase Realtime for cross-device live sync
+-- Tables must be added to the supabase_realtime publication for Postgres Changes to work
+
+alter publication supabase_realtime add table context_files;
+alter publication supabase_realtime add table profiles;
+alter publication supabase_realtime add table conversations;

--- a/supabase/migrations/005_device_capabilities.sql
+++ b/supabase/migrations/005_device_capabilities.sql
@@ -1,0 +1,8 @@
+-- Enhance devices table with capabilities for peer communication (Phase 4 prep)
+alter table devices add column if not exists capabilities text[] not null default '{}';
+
+-- Add device_id FK to context_files for tracking which device modified context
+alter table context_files add column if not exists device_id uuid references devices(id) on delete set null;
+
+-- Enable Realtime for devices table (peer status tracking)
+alter publication supabase_realtime add table devices;


### PR DESCRIPTION
## Summary
PR #35 통합 과정에서 누락된 Phase 2 핵심 파일들을 보충합니다.

### 추가된 파일 (8개)
- `CloudConversationService.swift` — 대화 히스토리 클라우드 동기화
- `DeviceService.swift` — 디바이스 등록, heartbeat, capabilities
- `DeviceServiceProtocol.swift` — 프로토콜 + DeviceInfo 모델
- `DeviceSettingsView.swift` — 디바이스 관리 UI
- `MockDeviceService.swift` — 테스트 mock
- `003_conversations.sql` — 대화 테이블 migration
- `004_enable_realtime.sql` — Realtime publication
- `005_device_capabilities.sql` — capabilities 컬럼

### 수정된 파일 (9개)
- `CloudContextService.swift` — device_id 추적 추가
- `DochiApp.swift` — DeviceService, CloudConversationService 주입
- `DochiViewModel.swift` — deviceService 프로퍼티 추가
- `DochiViewModel+Callbacks.swift` — cloud 콜백 연결
- 기타 프로토콜/mock/테스트 업데이트

Closes #7 Closes #8

## Test plan
- [x] 빌드 성공
- [x] 102개 테스트 통과
- [x] 충돌 마커 없음