### PR TITLE
fix: prevent keychain password prompt on app launch

### DIFF
--- a/Dochi/Services/KeychainSessionStorage.swift
+++ b/Dochi/Services/KeychainSessionStorage.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Auth
+import Security
+
+/// Keychain-based session storage with proper access control to avoid password prompts
+final class KeychainSessionStorage: AuthLocalStorage {
+    private let serviceName = "com.dochi.supabase.session"
+    
+    func store(key: String, value: Data) throws {
+        // Delete existing item first
+        try? remove(key: key)
+        
+        // Create access control that allows access without user interaction
+        guard let access = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleAfterFirstUnlock,
+            [],
+            nil
+        ) else {
+            throw KeychainError.accessControlCreationFailed
+        }
+        
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: value,
+            kSecAttrAccessControl as String: access
+        ]
+        
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw KeychainError.storeFailed(status)
+        }
+    }
+    
+    func retrieve(key: String) throws -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        
+        if status == errSecItemNotFound {
+            return nil
+        }
+        
+        guard status == errSecSuccess else {
+            throw KeychainError.retrieveFailed(status)
+        }
+        
+        return result as? Data
+    }
+    
+    func remove(key: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
+            kSecAttrAccount as String: key
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainError.deleteFailed(status)
+        }
+    }
+}
+
+enum KeychainError: Error {
+    case accessControlCreationFailed
+    case storeFailed(OSStatus)
+    case retrieveFailed(OSStatus)
+    case deleteFailed(OSStatus)
+}

--- a/Dochi/Services/SupabaseService.swift
+++ b/Dochi/Services/SupabaseService.swift
@@ -41,7 +41,15 @@ final class SupabaseService: ObservableObject, SupabaseServiceProtocol {
             return
         }
 
-        self.client = SupabaseClient(supabaseURL: supabaseURL, supabaseKey: key)
+        // Use keychain with proper access control to avoid password prompts
+        let sessionStorage = KeychainSessionStorage()
+        self.client = SupabaseClient(
+            supabaseURL: supabaseURL,
+            supabaseKey: key,
+            options: .init(
+                auth: .init(storage: sessionStorage)
+            )
+        )
         Log.cloud.info("Supabase 클라이언트 초기화 완료")
     }
 


### PR DESCRIPTION
## 문제
앱 실행 시마다 Supabase 세션 정보에 접근하기 위해 키체인 비밀번호를 요구하는 문제

## 해결 방법
- **KeychainSessionStorage** 구현: 적절한 접근 제어 설정
- **kSecAttrAccessibleAfterFirstUnlock** 사용: 비밀번호 프롬프트 없이 접근 가능
- Supabase 클라이언트 초기화 시 커스텀 세션 스토리지 사용

## 장점
✅ 사용자 경험 개선 (비밀번호 입력 불필요)
✅ 키체인의 보안성 유지 (시스템 레벨 암호화)
✅ 모든 사용자에게 동일하게 작동
✅ FileVault와 함께 사용 시 디스크 암호화 보장

## 테스트
- [x] 빌드 성공
- [ ] 앱 실행 시 비밀번호 프롬프트 없음 확인 필요

Closes #66