### PR TITLE
feat: built-in tools for settings, agent mgmt, editing, workspace, telegram + tools registry

### DIFF
--- a/Dochi/Services/BuiltInToolService.swift
+++ b/Dochi/Services/BuiltInToolService.swift
@@ -12,6 +12,36 @@ final class BuiltInToolService: ObservableObject {
     let printImageTool = PrintImageTool()
     let memoryTool = MemoryTool()
     let profileTool = ProfileTool()
+    let settingsTool = SettingsTool()
+    let agentTool = AgentTool()
+    let agentEditorTool = AgentEditorTool()
+    let contextEditTool = ContextEditTool()
+    let profileAdminTool = ProfileAdminTool()
+    let workspaceTool = WorkspaceTool()
+    let telegramTool = TelegramTool()
+    let toolsRegistryTool = ToolsRegistryTool()
+
+    // Optional shared services for tools that need them
+    private(set) weak var conversationService: ConversationServiceProtocol?
+    private(set) weak var supabaseService: (any SupabaseServiceProtocol)?
+    private(set) weak var telegramService: TelegramService?
+
+    // Registry-based enablement: if set, only these names (plus baseline) are exposed
+    private var enabledToolNames: Set<String>? = nil
+
+    // Baseline tools always included to serve common conversational needs
+    private let baselineAllowlist: Set<String> = [
+        // Registry
+        "tools.list", "tools.enable",
+        // Reminders
+        "create_reminder", "list_reminders", "complete_reminder",
+        // Alarm
+        "set_alarm", "list_alarms", "cancel_alarm",
+        // Memory + Profile basics
+        "save_memory", "update_memory", "set_current_user",
+        // Utility
+        "web_search", "print_image", "generate_image"
+    ]
 
     /// 활성 알람 (AlarmTool에서 포워딩)
     var activeAlarms: [AlarmTool.AlarmEntry] {
@@ -34,6 +64,40 @@ final class BuiltInToolService: ObservableObject {
         memoryTool.contextService = contextService
         memoryTool.currentUserId = currentUserId
         profileTool.contextService = contextService
+        agentTool.contextService = contextService
+        contextEditTool.contextService = contextService
+        profileAdminTool.contextService = contextService
+        agentEditorTool.contextService = contextService
+    }
+
+    /// 앱 설정 참조 주입 (SettingsTool에서 사용)
+    func configureSettings(_ settings: AppSettings) {
+        settingsTool.settings = settings
+        agentTool.settings = settings
+        contextEditTool.settings = settings
+        profileAdminTool.settings = settings
+        workspaceTool.settings = settings
+        agentEditorTool.settings = settings
+        telegramTool.settings = settings
+        toolsRegistryTool.registryHost = self
+    }
+
+    /// 대화 저장소 주입 (프로필 병합 시 userId 이관에 사용)
+    func configureConversations(_ service: ConversationServiceProtocol) {
+        self.conversationService = service
+        profileAdminTool.conversationService = service
+    }
+
+    /// Supabase 주입 (워크스페이스 도구)
+    func configureSupabase(_ service: any SupabaseServiceProtocol) {
+        self.supabaseService = service
+        workspaceTool.supabase = service
+    }
+
+    /// Telegram 주입
+    func configureTelegram(_ service: TelegramService) {
+        self.telegramService = service
+        telegramTool.telegram = service
     }
 
     var availableTools: [MCPToolInfo] {
@@ -68,12 +132,71 @@ final class BuiltInToolService: ObservableObject {
             tools.append(contentsOf: profileTool.tools)
         }
 
-        return tools
+        // 설정 변경: 설정 참조가 주입된 경우만 노출
+        if settingsTool.settings != nil {
+            tools.append(contentsOf: settingsTool.tools)
+        }
+
+        // 에이전트 관리: 컨텍스트/설정이 모두 준비된 경우 노출
+        if agentTool.contextService != nil, agentTool.settings != nil {
+            tools.append(contentsOf: agentTool.tools)
+        }
+
+        if agentEditorTool.contextService != nil, agentEditorTool.settings != nil {
+            tools.append(contentsOf: agentEditorTool.tools)
+        }
+
+        // 컨텍스트 편집 (base system prompt)
+        if contextEditTool.contextService != nil {
+            tools.append(contentsOf: contextEditTool.tools)
+        }
+
+        // 프로필 관리(고급)
+        if profileAdminTool.contextService != nil {
+            tools.append(contentsOf: profileAdminTool.tools)
+        }
+
+        // 워크스페이스 관련 (Supabase 구성 시)
+        if workspaceTool.supabase != nil {
+            tools.append(contentsOf: workspaceTool.tools)
+        }
+
+        // 텔레그램 도구 (서비스/설정 존재 시)
+        if telegramTool.telegram != nil, telegramTool.settings != nil {
+            tools.append(contentsOf: telegramTool.tools)
+        }
+
+        // Registry tools always available
+        tools.append(contentsOf: toolsRegistryTool.tools)
+
+        // Apply registry filter if enabled
+        if let enabled = enabledToolNames {
+            let allowed = baselineAllowlist.union(enabled)
+            return tools.filter { allowed.contains($0.name) }
+        }
+        // Default: expose only baseline to reduce token usage
+        return tools.filter { baselineAllowlist.contains($0.name) }
     }
 
     func callTool(name: String, arguments: [String: Any]) async throws -> MCPToolResult {
         // 각 도구 모듈에 라우팅
-        let allModules: [any BuiltInTool] = [webSearchTool, remindersTool, alarmTool, imageGenerationTool, printImageTool, memoryTool, profileTool]
+        let allModules: [any BuiltInTool] = [
+            toolsRegistryTool,
+            webSearchTool,
+            remindersTool,
+            alarmTool,
+            imageGenerationTool,
+            printImageTool,
+            memoryTool,
+            profileTool,
+            settingsTool,
+            agentTool,
+            agentEditorTool,
+            contextEditTool,
+            profileAdminTool,
+            workspaceTool,
+            telegramTool
+        ]
 
         for module in allModules {
             if module.tools.contains(where: { $0.name == name }) {
@@ -82,6 +205,63 @@ final class BuiltInToolService: ObservableObject {
         }
 
         throw BuiltInToolError.unknownTool(name)
+    }
+}
+
+// MARK: - Registry (public helpers for ToolsRegistryTool)
+
+extension BuiltInToolService {
+    func setEnabledToolNames(_ names: [String]?) {
+        if let names { self.enabledToolNames = Set(names) } else { self.enabledToolNames = nil }
+    }
+
+    func getEnabledToolNames() -> [String]? {
+        enabledToolNames.map { Array($0) }
+    }
+
+    func toolCatalogByCategory() -> [String: [String]] {
+        var catalog: [String: [String]] = [:]
+        func add(_ category: String, _ list: [MCPToolInfo]) {
+            if list.isEmpty { return }
+            let names = list.map { $0.name }
+            catalog[category, default: []].append(contentsOf: names)
+        }
+        // Compute candidates (respecting current service availability but ignoring registry filter)
+        var all: [MCPToolInfo] = []
+        if !webSearchTool.apiKey.isEmpty { all.append(contentsOf: webSearchTool.tools) }
+        all.append(contentsOf: remindersTool.tools)
+        all.append(contentsOf: alarmTool.tools)
+        if !imageGenerationTool.apiKey.isEmpty { all.append(contentsOf: imageGenerationTool.tools) }
+        all.append(contentsOf: printImageTool.tools)
+        if memoryTool.contextService != nil { all.append(contentsOf: memoryTool.tools) }
+        if profileTool.contextService != nil { all.append(contentsOf: profileTool.tools) }
+        if settingsTool.settings != nil { all.append(contentsOf: settingsTool.tools) }
+        if agentTool.contextService != nil, agentTool.settings != nil { all.append(contentsOf: agentTool.tools) }
+        if agentEditorTool.contextService != nil, agentEditorTool.settings != nil { all.append(contentsOf: agentEditorTool.tools) }
+        if contextEditTool.contextService != nil { all.append(contentsOf: contextEditTool.tools) }
+        if profileAdminTool.contextService != nil { all.append(contentsOf: profileAdminTool.tools) }
+        if workspaceTool.supabase != nil { all.append(contentsOf: workspaceTool.tools) }
+        if telegramTool.telegram != nil, telegramTool.settings != nil { all.append(contentsOf: telegramTool.tools) }
+
+        let available = Set(all.map { $0.name })
+        add("registry", toolsRegistryTool.tools)
+        add("reminders", remindersTool.tools)
+        add("alarm", alarmTool.tools)
+        add("memory", memoryTool.tools)
+        add("profile", profileTool.tools)
+        add("search_image", webSearchTool.tools + imageGenerationTool.tools + printImageTool.tools)
+        add("settings", settingsTool.tools)
+        add("agent", agentTool.tools)
+        add("agent_edit", agentEditorTool.tools)
+        add("context", contextEditTool.tools)
+        add("profile_admin", profileAdminTool.tools)
+        add("workspace", workspaceTool.tools)
+        add("telegram", telegramTool.tools)
+
+        for (k, v) in catalog {
+            catalog[k] = v.filter { available.contains($0) }
+        }
+        return catalog
     }
 }
 

--- a/Dochi/Services/BuiltInTools/AgentEditorTool.swift
+++ b/Dochi/Services/BuiltInTools/AgentEditorTool.swift
@@ -1,0 +1,335 @@
+import Foundation
+import os
+
+/// 에이전트 페르소나/메모리/설정 편집 도구
+@MainActor
+final class AgentEditorTool: BuiltInTool {
+    var contextService: (any ContextServiceProtocol)?
+    weak var settings: AppSettings?
+
+    nonisolated var tools: [MCPToolInfo] {
+        [
+            // Persona
+            MCPToolInfo(
+                id: "builtin:agent.persona_get",
+                name: "agent.persona_get",
+                description: "Get persona.md for an agent. Defaults to active agent.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["name": ["type": "string"]]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.persona_search",
+                name: "agent.persona_search",
+                description: "Search persona.md and return matching lines with indices.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "query": ["type": "string"],
+                        "name": ["type": "string"]
+                    ],
+                    "required": ["query"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.persona_replace",
+                name: "agent.persona_replace",
+                description: "Replace occurrences of 'find' with 'replace' in persona.md.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "find": ["type": "string"],
+                        "replace": ["type": "string"],
+                        "name": ["type": "string"]
+                    ],
+                    "required": ["find", "replace"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.persona_delete_lines",
+                name: "agent.persona_delete_lines",
+                description: "Delete lines in persona.md that contain the substring.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "contains": ["type": "string"],
+                        "name": ["type": "string"]
+                    ],
+                    "required": ["contains"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.persona_update",
+                name: "agent.persona_update",
+                description: "Update persona.md (replace or append). Defaults to active agent.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "mode": ["type": "string", "enum": ["replace", "append"]],
+                        "content": ["type": "string"],
+                        "name": ["type": "string"]
+                    ],
+                    "required": ["mode", "content"]
+                ]
+            ),
+
+            // Memory
+            MCPToolInfo(
+                id: "builtin:agent.memory_get",
+                name: "agent.memory_get",
+                description: "Get memory.md for an agent. Defaults to active agent.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["name": ["type": "string"]]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.memory_append",
+                name: "agent.memory_append",
+                description: "Append content to memory.md (prepends '- ' if needed). Defaults to active agent.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "content": ["type": "string"],
+                        "name": ["type": "string"]
+                    ],
+                    "required": ["content"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.memory_replace",
+                name: "agent.memory_replace",
+                description: "Replace memory.md entirely. Defaults to active agent.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "content": ["type": "string"],
+                        "name": ["type": "string"]
+                    ],
+                    "required": ["content"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.memory_update",
+                name: "agent.memory_update",
+                description: "Update or delete a single line in memory.md. Replaces the first line containing 'find' with '- replace'. If replace is empty, deletes the line.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "find": ["type": "string"],
+                        "replace": ["type": "string"],
+                        "name": ["type": "string"]
+                    ],
+                    "required": ["find", "replace"]
+                ]
+            ),
+
+            // Config
+            MCPToolInfo(
+                id: "builtin:agent.config_get",
+                name: "agent.config_get",
+                description: "Get agent config (wakeWord, description). Defaults to active agent.",
+                inputSchema: ["type": "object", "properties": ["name": ["type": "string"]]]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.config_update",
+                name: "agent.config_update",
+                description: "Update agent config fields. Defaults to active agent.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "name": ["type": "string"],
+                        "wake_word": ["type": "string"],
+                        "description": ["type": "string"]
+                    ]
+                ]
+            )
+        ]
+    }
+
+    func callTool(name: String, arguments: [String : Any]) async throws -> MCPToolResult {
+        guard let contextService, let settings else {
+            return MCPToolResult(content: "Agent editor requires contextService and settings", isError: true)
+        }
+        switch name {
+        case "agent.persona_get":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            let text = wsId != nil
+                ? contextService.loadAgentPersona(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentPersona(agentName: agentName)
+            return MCPToolResult(content: text, isError: false)
+
+        case "agent.persona_update":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            guard let mode = arguments["mode"] as? String, let content = arguments["content"] as? String else {
+                return MCPToolResult(content: "mode and content are required", isError: true)
+            }
+            let current = wsId != nil
+                ? contextService.loadAgentPersona(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentPersona(agentName: agentName)
+            let updated: String
+            if mode == "replace" { updated = content }
+            else if mode == "append" {
+                updated = current.isEmpty ? content : current + "\n\n" + content
+            } else { return MCPToolResult(content: "mode must be replace|append", isError: true) }
+            if let wsId {
+                contextService.saveAgentPersona(workspaceId: wsId, agentName: agentName, content: updated)
+            } else {
+                contextService.saveAgentPersona(agentName: agentName, content: updated)
+            }
+            return MCPToolResult(content: "Persona updated (mode=\(mode))", isError: false)
+
+        case "agent.persona_search":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            guard let query = arguments["query"] as? String, !query.isEmpty else {
+                return MCPToolResult(content: "query is required", isError: true)
+            }
+            let text = wsId != nil
+                ? contextService.loadAgentPersona(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentPersona(agentName: agentName)
+            let lines = text.components(separatedBy: "\n")
+            var matches: [[String: Any]] = []
+            for (idx, line) in lines.enumerated() where line.localizedCaseInsensitiveContains(query) {
+                matches.append(["index": idx, "line": line])
+            }
+            let data = try? JSONSerialization.data(withJSONObject: matches, options: [.prettyPrinted])
+            return MCPToolResult(content: String(data: data ?? Data()) , isError: false)
+
+        case "agent.persona_replace":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            guard let find = arguments["find"] as? String, let replace = arguments["replace"] as? String else {
+                return MCPToolResult(content: "find and replace are required", isError: true)
+            }
+            let text = wsId != nil
+                ? contextService.loadAgentPersona(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentPersona(agentName: agentName)
+            let replaced = text.replacingOccurrences(of: find, with: replace, options: [.caseInsensitive])
+            if let wsId {
+                contextService.saveAgentPersona(workspaceId: wsId, agentName: agentName, content: replaced)
+            } else {
+                contextService.saveAgentPersona(agentName: agentName, content: replaced)
+            }
+            return MCPToolResult(content: "Persona replaced occurrences", isError: false)
+
+        case "agent.persona_delete_lines":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            guard let contains = arguments["contains"] as? String, !contains.isEmpty else {
+                return MCPToolResult(content: "contains is required", isError: true)
+            }
+            let text = wsId != nil
+                ? contextService.loadAgentPersona(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentPersona(agentName: agentName)
+            let lines = text.components(separatedBy: "\n")
+            let filtered = lines.filter { !$0.localizedCaseInsensitiveContains(contains) }
+            if let wsId {
+                contextService.saveAgentPersona(workspaceId: wsId, agentName: agentName, content: filtered.joined(separator: "\n"))
+            } else {
+                contextService.saveAgentPersona(agentName: agentName, content: filtered.joined(separator: "\n"))
+            }
+            let removed = lines.count - filtered.count
+            return MCPToolResult(content: "Deleted \(removed) lines", isError: false)
+
+        case "agent.memory_get":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            let text = wsId != nil
+                ? contextService.loadAgentMemory(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentMemory(agentName: agentName)
+            return MCPToolResult(content: text, isError: false)
+
+        case "agent.memory_append":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            guard let content = arguments["content"] as? String else {
+                return MCPToolResult(content: "content is required", isError: true)
+            }
+            let entry = content.hasPrefix("-") ? content : "- \(content)"
+            if let wsId {
+                contextService.appendAgentMemory(workspaceId: wsId, agentName: agentName, content: entry)
+            } else {
+                contextService.appendAgentMemory(agentName: agentName, content: entry)
+            }
+            return MCPToolResult(content: "Memory appended", isError: false)
+
+        case "agent.memory_replace":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            guard let content = arguments["content"] as? String else {
+                return MCPToolResult(content: "content is required", isError: true)
+            }
+            if let wsId {
+                contextService.saveAgentMemory(workspaceId: wsId, agentName: agentName, content: content)
+            } else {
+                contextService.saveAgentMemory(agentName: agentName, content: content)
+            }
+            return MCPToolResult(content: "Memory replaced", isError: false)
+
+        case "agent.memory_update":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            guard let find = arguments["find"] as? String, let replace = arguments["replace"] as? String else {
+                return MCPToolResult(content: "find and replace are required", isError: true)
+            }
+            let text = wsId != nil
+                ? contextService.loadAgentMemory(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentMemory(agentName: agentName)
+            var lines = text.components(separatedBy: "\n")
+            if let idx = lines.firstIndex(where: { $0.localizedCaseInsensitiveContains(find) }) {
+                if replace.isEmpty {
+                    lines.remove(at: idx)
+                } else {
+                    let newLine = replace.hasPrefix("-") ? replace : "- \(replace)"
+                    lines[idx] = newLine
+                }
+                let newText = lines.joined(separator: "\n")
+                if let wsId {
+                    contextService.saveAgentMemory(workspaceId: wsId, agentName: agentName, content: newText)
+                } else {
+                    contextService.saveAgentMemory(agentName: agentName, content: newText)
+                }
+                return MCPToolResult(content: replace.isEmpty ? "Deleted 1 line" : "Updated 1 line", isError: false)
+            } else {
+                return MCPToolResult(content: "No line found containing '\(find)'", isError: true)
+            }
+
+        case "agent.config_get":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            let cfg = wsId != nil
+                ? contextService.loadAgentConfig(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentConfig(agentName: agentName)
+            let dict: [String: Any] = [
+                "name": cfg?.name ?? agentName,
+                "wakeWord": cfg?.wakeWord ?? settings.wakeWord,
+                "description": cfg?.description ?? ""
+            ]
+            if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.prettyPrinted]), let str = String(data: data, encoding: .utf8) {
+                return MCPToolResult(content: str, isError: false)
+            }
+            return MCPToolResult(content: "{}", isError: false)
+
+        case "agent.config_update":
+            let (agentName, wsId) = resolveAgentNameAndWorkspace(settings: settings, args: arguments)
+            let wake = (arguments["wake_word"] as? String)
+            let desc = (arguments["description"] as? String)
+            var cfg = wsId != nil
+                ? contextService.loadAgentConfig(workspaceId: wsId!, agentName: agentName)
+                : contextService.loadAgentConfig(agentName: agentName)
+            if cfg == nil { cfg = AgentConfig(name: agentName, wakeWord: wake ?? settings.wakeWord, description: desc ?? "") }
+            if let wake { cfg!.wakeWord = wake }
+            if let desc { cfg!.description = desc }
+            if let wsId {
+                contextService.saveAgentConfig(workspaceId: wsId, config: cfg!)
+            } else {
+                contextService.saveAgentConfig(cfg!)
+            }
+            return MCPToolResult(content: "Config updated for \(agentName)", isError: false)
+
+        default:
+            throw BuiltInToolError.unknownTool(name)
+        }
+    }
+
+    // MARK: - Helpers
+    private func resolveAgentNameAndWorkspace(settings: AppSettings, args: [String: Any]) -> (String, UUID?) {
+        let name = (args["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let agentName = (name?.isEmpty ?? true) ? settings.activeAgentName : name!
+        return (agentName, settings.currentWorkspaceId)
+    }
+}

--- a/Dochi/Services/BuiltInTools/AgentTool.swift
+++ b/Dochi/Services/BuiltInTools/AgentTool.swift
@@ -1,0 +1,112 @@
+import Foundation
+import os
+
+/// 에이전트 생성/목록/전환 도구
+@MainActor
+final class AgentTool: BuiltInTool {
+    var contextService: (any ContextServiceProtocol)?
+    weak var settings: AppSettings?
+
+    nonisolated var tools: [MCPToolInfo] {
+        [
+            MCPToolInfo(
+                id: "builtin:agent.create",
+                name: "agent.create",
+                description: "Create a new agent with optional wake word and description. Workspace-aware if currentWorkspaceId is set.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "name": ["type": "string"],
+                        "wake_word": ["type": "string"],
+                        "description": ["type": "string"]
+                    ],
+                    "required": ["name"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.list",
+                name: "agent.list",
+                description: "List agent names. Workspace-aware if currentWorkspaceId is set.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [:]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:agent.set_active",
+                name: "agent.set_active",
+                description: "Set active agent by name.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "name": ["type": "string"]
+                    ],
+                    "required": ["name"]
+                ]
+            )
+        ]
+    }
+
+    func callTool(name: String, arguments: [String: Any]) async throws -> MCPToolResult {
+        guard let contextService, let settings else {
+            return MCPToolResult(content: "Agent tools require contextService and settings.", isError: true)
+        }
+        switch name {
+        case "agent.create":
+            return createAgent(contextService: contextService, settings: settings, args: arguments)
+        case "agent.list":
+            return listAgents(contextService: contextService, settings: settings)
+        case "agent.set_active":
+            return setActiveAgent(settings: settings, contextService: contextService, args: arguments)
+        default:
+            throw BuiltInToolError.unknownTool(name)
+        }
+    }
+
+    private func createAgent(contextService: any ContextServiceProtocol, settings: AppSettings, args: [String: Any]) -> MCPToolResult {
+        guard let name = args["name"] as? String, !name.isEmpty else {
+            return MCPToolResult(content: "name is required", isError: true)
+        }
+        let wake = (args["wake_word"] as? String) ?? settings.wakeWord
+        let desc = (args["description"] as? String) ?? ""
+
+        if let wsId = settings.currentWorkspaceId {
+            contextService.createAgent(workspaceId: wsId, name: name, wakeWord: wake, description: desc)
+        } else {
+            contextService.createAgent(name: name, wakeWord: wake, description: desc)
+        }
+        Log.tool.info("에이전트 생성: name=\(name), wake=\(wake)")
+        return MCPToolResult(content: "Created agent '\(name)'", isError: false)
+    }
+
+    private func listAgents(contextService: any ContextServiceProtocol, settings: AppSettings) -> MCPToolResult {
+        let names: [String]
+        if let wsId = settings.currentWorkspaceId {
+            names = contextService.listAgents(workspaceId: wsId)
+        } else {
+            names = contextService.listAgents()
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: names, options: [.prettyPrinted]), let str = String(data: data, encoding: .utf8) {
+            return MCPToolResult(content: str, isError: false)
+        }
+        return MCPToolResult(content: names.joined(separator: ", "), isError: false)
+    }
+
+    private func setActiveAgent(settings: AppSettings, contextService: any ContextServiceProtocol, args: [String: Any]) -> MCPToolResult {
+        guard let name = args["name"] as? String, !name.isEmpty else {
+            return MCPToolResult(content: "name is required", isError: true)
+        }
+        let available: [String]
+        if let wsId = settings.currentWorkspaceId {
+            available = contextService.listAgents(workspaceId: wsId)
+        } else {
+            available = contextService.listAgents()
+        }
+        guard available.contains(name) else {
+            return MCPToolResult(content: "Agent not found: \(name). Available: \(available)", isError: true)
+        }
+        settings.activeAgentName = name
+        return MCPToolResult(content: "Active agent set to \(name)", isError: false)
+    }
+}
+

--- a/Dochi/Services/BuiltInTools/ContextEditTool.swift
+++ b/Dochi/Services/BuiltInTools/ContextEditTool.swift
@@ -1,0 +1,54 @@
+import Foundation
+import os
+
+/// 컨텍스트 파일 편집 도구 (base system prompt)
+@MainActor
+final class ContextEditTool: BuiltInTool {
+    var contextService: (any ContextServiceProtocol)?
+    weak var settings: AppSettings?
+
+    nonisolated var tools: [MCPToolInfo] {
+        [
+            MCPToolInfo(
+                id: "builtin:context.update_base_system_prompt",
+                name: "context.update_base_system_prompt",
+                description: "Replace or append to the base system prompt (system_prompt.md).",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "mode": ["type": "string", "enum": ["replace", "append"]],
+                        "content": ["type": "string"]
+                    ],
+                    "required": ["mode", "content"]
+                ]
+            )
+        ]
+    }
+
+    func callTool(name: String, arguments: [String: Any]) async throws -> MCPToolResult {
+        guard let contextService else {
+            return MCPToolResult(content: "ContextService not available", isError: true)
+        }
+        switch name {
+        case "context.update_base_system_prompt":
+            guard let mode = arguments["mode"] as? String, let content = arguments["content"] as? String else {
+                return MCPToolResult(content: "mode and content are required", isError: true)
+            }
+            let current = contextService.loadBaseSystemPrompt()
+            let updated: String
+            if mode == "replace" {
+                updated = content
+            } else if mode == "append" {
+                updated = current.isEmpty ? content : current + "\n\n" + content
+            } else {
+                return MCPToolResult(content: "mode must be 'replace' or 'append'", isError: true)
+            }
+            contextService.saveBaseSystemPrompt(updated)
+            Log.tool.info("system_prompt.md updated (mode=\(mode))")
+            return MCPToolResult(content: "Base system prompt updated (mode=\(mode))", isError: false)
+        default:
+            throw BuiltInToolError.unknownTool(name)
+        }
+    }
+}
+

--- a/Dochi/Services/BuiltInTools/ProfileAdminTool.swift
+++ b/Dochi/Services/BuiltInTools/ProfileAdminTool.swift
@@ -1,0 +1,207 @@
+import Foundation
+import os
+
+/// 프로필 관리 도구 (create, merge, rename, add_alias)
+@MainActor
+final class ProfileAdminTool: BuiltInTool {
+    var contextService: (any ContextServiceProtocol)?
+    weak var settings: AppSettings?
+    weak var conversationService: ConversationServiceProtocol?
+
+    nonisolated var tools: [MCPToolInfo] {
+        [
+            MCPToolInfo(
+                id: "builtin:profile.create",
+                name: "profile.create",
+                description: "Create a new user profile.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "name": ["type": "string"],
+                        "aliases": ["type": "array", "items": ["type": "string"]],
+                        "description": ["type": "string"]
+                    ],
+                    "required": ["name"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:profile.add_alias",
+                name: "profile.add_alias",
+                description: "Add an alias to an existing profile by name.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "name": ["type": "string"],
+                        "alias": ["type": "string"]
+                    ],
+                    "required": ["name", "alias"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:profile.rename",
+                name: "profile.rename",
+                description: "Rename a profile.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "from": ["type": "string"],
+                        "to": ["type": "string"]
+                    ],
+                    "required": ["from", "to"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:profile.merge",
+                name: "profile.merge",
+                description: "Merge source profile into target by name. merge_memory: append|skip|replace",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "source": ["type": "string"],
+                        "target": ["type": "string"],
+                        "merge_memory": ["type": "string", "enum": ["append", "skip", "replace"]]
+                    ],
+                    "required": ["source", "target", "merge_memory"]
+                ]
+            )
+        ]
+    }
+
+    func callTool(name: String, arguments: [String: Any]) async throws -> MCPToolResult {
+        guard let contextService else {
+            return MCPToolResult(content: "ContextService not available", isError: true)
+        }
+        switch name {
+        case "profile.create":
+            return createProfile(context: contextService, args: arguments)
+        case "profile.add_alias":
+            return addAlias(context: contextService, args: arguments)
+        case "profile.rename":
+            return renameProfile(context: contextService, args: arguments)
+        case "profile.merge":
+            return mergeProfiles(context: contextService, args: arguments)
+        default:
+            throw BuiltInToolError.unknownTool(name)
+        }
+    }
+
+    // MARK: - Handlers
+
+    private func createProfile(context: any ContextServiceProtocol, args: [String: Any]) -> MCPToolResult {
+        guard let name = args["name"] as? String, !name.isEmpty else {
+            return MCPToolResult(content: "name is required", isError: true)
+        }
+        let aliases = (args["aliases"] as? [Any])?.compactMap { $0 as? String } ?? []
+        let description = (args["description"] as? String) ?? ""
+        var profiles = context.loadProfiles()
+        if profiles.contains(where: { $0.allNames.contains { $0.caseInsensitiveCompare(name) == .orderedSame } }) {
+            return MCPToolResult(content: "Profile already exists: \(name)", isError: true)
+        }
+        let newProfile = UserProfile(name: name, aliases: aliases, description: description)
+        profiles.append(newProfile)
+        context.saveProfiles(profiles)
+        return MCPToolResult(content: "Created profile '\(name)' (id=\(newProfile.id.uuidString))", isError: false)
+    }
+
+    private func addAlias(context: any ContextServiceProtocol, args: [String: Any]) -> MCPToolResult {
+        guard let name = args["name"] as? String, let alias = args["alias"] as? String, !name.isEmpty, !alias.isEmpty else {
+            return MCPToolResult(content: "name and alias are required", isError: true)
+        }
+        var profiles = context.loadProfiles()
+        guard let idx = resolveProfileIndex(profiles: profiles, by: name) else {
+            return MCPToolResult(content: "Profile not found: \(name)", isError: true)
+        }
+        if !profiles[idx].aliases.contains(where: { $0.caseInsensitiveCompare(alias) == .orderedSame }) {
+            profiles[idx].aliases.append(alias)
+            context.saveProfiles(profiles)
+        }
+        return MCPToolResult(content: "Added alias '\(alias)' to \(profiles[idx].name)", isError: false)
+    }
+
+    private func renameProfile(context: any ContextServiceProtocol, args: [String: Any]) -> MCPToolResult {
+        guard let from = args["from"] as? String, let to = args["to"] as? String, !from.isEmpty, !to.isEmpty else {
+            return MCPToolResult(content: "from and to are required", isError: true)
+        }
+        var profiles = context.loadProfiles()
+        guard let idx = resolveProfileIndex(profiles: profiles, by: from) else {
+            return MCPToolResult(content: "Profile not found: \(from)", isError: true)
+        }
+        profiles[idx].name = to
+        context.saveProfiles(profiles)
+        return MCPToolResult(content: "Renamed profile '\(from)' -> '\(to)'", isError: false)
+    }
+
+    private func mergeProfiles(context: any ContextServiceProtocol, args: [String: Any]) -> MCPToolResult {
+        guard let sourceName = args["source"] as? String,
+              let targetName = args["target"] as? String,
+              let strategy = args["merge_memory"] as? String else {
+            return MCPToolResult(content: "source, target, merge_memory are required", isError: true)
+        }
+        guard strategy == "append" || strategy == "skip" || strategy == "replace" else {
+            return MCPToolResult(content: "merge_memory must be append|skip|replace", isError: true)
+        }
+        var profiles = context.loadProfiles()
+        guard let sIdx = resolveProfileIndex(profiles: profiles, by: sourceName) else {
+            return MCPToolResult(content: "Source profile not found: \(sourceName)", isError: true)
+        }
+        guard let tIdx = resolveProfileIndex(profiles: profiles, by: targetName) else {
+            return MCPToolResult(content: "Target profile not found: \(targetName)", isError: true)
+        }
+        let source = profiles[sIdx]
+        let target = profiles[tIdx]
+
+        // Merge aliases and description (keep target description if non-empty)
+        let newAliases = Array(Set(target.aliases + source.allNames.filter { $0.caseInsensitiveCompare(target.name) != .orderedSame }))
+        profiles[tIdx].aliases = newAliases
+        if profiles[tIdx].description.isEmpty, !source.description.isEmpty {
+            profiles[tIdx].description = source.description
+        }
+
+        // Merge memories
+        let sMem = context.loadUserMemory(userId: source.id)
+        let tMem = context.loadUserMemory(userId: target.id)
+        let mergedMem: String
+        switch strategy {
+        case "append":
+            if tMem.isEmpty { mergedMem = sMem }
+            else if sMem.isEmpty { mergedMem = tMem }
+            else { mergedMem = tMem + "\n" + sMem }
+        case "skip":
+            mergedMem = tMem
+        case "replace":
+            mergedMem = sMem
+        default:
+            mergedMem = tMem
+        }
+        context.saveUserMemory(userId: target.id, content: mergedMem)
+        // Clear source memory file (non-destructive delete)
+        context.saveUserMemory(userId: source.id, content: "")
+
+        // Remove source profile
+        profiles.remove(at: sIdx)
+        context.saveProfiles(profiles)
+
+        // Migrate conversations' userId from source to target (best-effort)
+        if let conversationService {
+            let all = conversationService.list()
+            for var c in all where c.userId == source.id.uuidString {
+                c.userId = target.id.uuidString
+                conversationService.save(c)
+            }
+        }
+
+        Log.tool.info("프로필 병합: \(source.name) -> \(target.name), strategy=\(strategy)")
+        return MCPToolResult(content: "Merged '\(source.name)' into '\(target.name)' (memory=\(strategy))", isError: false)
+    }
+
+    // MARK: - Helpers
+
+    private func resolveProfileIndex(profiles: [UserProfile], by name: String) -> Int? {
+        profiles.firstIndex { profile in
+            profile.allNames.contains { n in
+                n.localizedCaseInsensitiveContains(name) || name.localizedCaseInsensitiveContains(n)
+            }
+        }
+    }
+}
+

--- a/Dochi/Services/BuiltInTools/SettingsTool.swift
+++ b/Dochi/Services/BuiltInTools/SettingsTool.swift
@@ -1,0 +1,324 @@
+import Foundation
+import os
+
+/// 앱 설정 변경/조회용 내장 도구
+@MainActor
+final class SettingsTool: BuiltInTool {
+    weak var settings: AppSettings?
+
+    // 지원 키와 타입 정의
+    private enum Key: String, CaseIterable {
+        case wakeWordEnabled
+        case wakeWord
+        case llmProvider
+        case llmModel
+        case supertonicVoice
+        case ttsSpeed
+        case ttsDiffusionSteps
+        case chatFontSize
+        case sttSilenceTimeout
+        case contextAutoCompress
+        case contextMaxSize
+        case activeAgentName
+        case telegramEnabled
+        case defaultUserId
+
+        // API keys
+        case openaiApiKey
+        case anthropicApiKey
+        case zaiApiKey
+        case tavilyApiKey
+        case falaiApiKey
+        case telegramBotToken
+    }
+
+    nonisolated var tools: [MCPToolInfo] {
+        [
+            MCPToolInfo(
+                id: "builtin:settings.set",
+                name: "settings.set",
+                description: "Set an application setting. Use list to discover keys and types.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "key": [
+                            "type": "string",
+                            "enum": Key.allCases.map { $0.rawValue },
+                            "description": "Setting key to update"
+                        ],
+                        "value": [
+                            "type": "string",
+                            "description": "New value (stringified). Types are inferred per key"
+                        ]
+                    ],
+                    "required": ["key", "value"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:settings.get",
+                name: "settings.get",
+                description: "Get current value of a setting key.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "key": [
+                            "type": "string",
+                            "enum": Key.allCases.map { $0.rawValue }
+                        ]
+                    ],
+                    "required": ["key"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:settings.list",
+                name: "settings.list",
+                description: "List supported setting keys and current values.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [:]
+                ]
+            ),
+            // MCP servers management
+            MCPToolInfo(
+                id: "builtin:settings.mcp_add_server",
+                name: "settings.mcp_add_server",
+                description: "Add a new MCP server configuration (HTTP-only supported).",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "name": ["type": "string"],
+                        "command": ["type": "string", "description": "HTTP endpoint URL"],
+                        "arguments": ["type": "array", "items": ["type": "string"]],
+                        "environment": ["type": "object", "additionalProperties": ["type": "string"]],
+                        "is_enabled": ["type": "boolean"]
+                    ],
+                    "required": ["name", "command"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:settings.mcp_update_server",
+                name: "settings.mcp_update_server",
+                description: "Update an existing MCP server configuration by id.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "id": ["type": "string", "description": "UUID"],
+                        "name": ["type": "string"],
+                        "command": ["type": "string"],
+                        "arguments": ["type": "array", "items": ["type": "string"]],
+                        "environment": ["type": "object", "additionalProperties": ["type": "string"]],
+                        "is_enabled": ["type": "boolean"]
+                    ],
+                    "required": ["id"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:settings.mcp_remove_server",
+                name: "settings.mcp_remove_server",
+                description: "Remove an MCP server by id.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "id": ["type": "string", "description": "UUID"]
+                    ],
+                    "required": ["id"]
+                ]
+            )
+        ]
+    }
+
+    func callTool(name: String, arguments: [String: Any]) async throws -> MCPToolResult {
+        guard let settings else {
+            return MCPToolResult(content: "Settings are not available.", isError: true)
+        }
+
+        switch name {
+        case "settings.set":
+            return setSetting(settings, arguments)
+        case "settings.get":
+            return getSetting(settings, arguments)
+        case "settings.list":
+            return listSettings(settings)
+        case "settings.mcp_add_server":
+            return try addMCPServer(settings, arguments)
+        case "settings.mcp_update_server":
+            return try updateMCPServer(settings, arguments)
+        case "settings.mcp_remove_server":
+            return try removeMCPServer(settings, arguments)
+        default:
+            throw BuiltInToolError.unknownTool(name)
+        }
+    }
+
+    // MARK: - Core
+
+    private func setSetting(_ s: AppSettings, _ args: [String: Any]) -> MCPToolResult {
+        guard let keyStr = args["key"] as? String, let key = Key(rawValue: keyStr) else {
+            return MCPToolResult(content: "Invalid or missing key", isError: true)
+        }
+        guard let valueStr = args["value"] as? String else {
+            return MCPToolResult(content: "Missing value (string)", isError: true)
+        }
+
+        switch key {
+        case .wakeWordEnabled:
+            s.wakeWordEnabled = parseBool(valueStr)
+        case .wakeWord:
+            s.wakeWord = valueStr
+        case .llmProvider:
+            guard let provider = LLMProvider(rawValue: valueStr) else {
+                return MCPToolResult(content: "Invalid provider. Allowed: \(LLMProvider.allCases.map { $0.rawValue }.joined(separator: ", "))", isError: true)
+            }
+            s.llmProvider = provider
+        case .llmModel:
+            if !s.llmProvider.models.contains(valueStr) {
+                return MCPToolResult(content: "Model not in provider models: \(s.llmProvider.models)", isError: true)
+            }
+            s.llmModel = valueStr
+        case .supertonicVoice:
+            guard let voice = SupertonicVoice(rawValue: valueStr) else {
+                return MCPToolResult(content: "Invalid voice. Allowed: \(SupertonicVoice.allCases.map { $0.rawValue }.joined(separator: ", "))", isError: true)
+            }
+            s.supertonicVoice = voice
+        case .ttsSpeed:
+            guard let v = Float(valueStr) else { return MCPToolResult(content: "ttsSpeed must be float", isError: true) }
+            s.ttsSpeed = v
+        case .ttsDiffusionSteps:
+            guard let v = Int(valueStr) else { return MCPToolResult(content: "ttsDiffusionSteps must be int", isError: true) }
+            s.ttsDiffusionSteps = v
+        case .chatFontSize:
+            guard let v = Double(valueStr) else { return MCPToolResult(content: "chatFontSize must be number", isError: true) }
+            s.chatFontSize = v
+        case .sttSilenceTimeout:
+            guard let v = Double(valueStr) else { return MCPToolResult(content: "sttSilenceTimeout must be number", isError: true) }
+            s.sttSilenceTimeout = v
+        case .contextAutoCompress:
+            s.contextAutoCompress = parseBool(valueStr)
+        case .contextMaxSize:
+            guard let v = Int(valueStr) else { return MCPToolResult(content: "contextMaxSize must be int", isError: true) }
+            s.contextMaxSize = v
+        case .activeAgentName:
+            s.activeAgentName = valueStr
+        case .telegramEnabled:
+            s.telegramEnabled = parseBool(valueStr)
+        case .defaultUserId:
+            if valueStr.isEmpty || valueStr.lowercased() == "none" {
+                s.defaultUserId = nil
+            } else if let uuid = UUID(uuidString: valueStr) {
+                s.defaultUserId = uuid
+            } else {
+                return MCPToolResult(content: "defaultUserId must be UUID or 'none'", isError: true)
+            }
+
+        case .openaiApiKey:
+            s.apiKey = valueStr
+        case .anthropicApiKey:
+            s.anthropicApiKey = valueStr
+        case .zaiApiKey:
+            s.zaiApiKey = valueStr
+        case .tavilyApiKey:
+            s.tavilyApiKey = valueStr
+        case .falaiApiKey:
+            s.falaiApiKey = valueStr
+        case .telegramBotToken:
+            s.telegramBotToken = valueStr
+        }
+
+        Log.tool.info("설정 변경: \(key.rawValue)=\(valueStr.prefix(80))")
+        return MCPToolResult(content: "Updated \(key.rawValue)", isError: false)
+    }
+
+    private func getSetting(_ s: AppSettings, _ args: [String: Any]) -> MCPToolResult {
+        guard let keyStr = args["key"] as? String, let key = Key(rawValue: keyStr) else {
+            return MCPToolResult(content: "Invalid or missing key", isError: true)
+        }
+        let value: String
+        switch key {
+        case .wakeWordEnabled: value = String(s.wakeWordEnabled)
+        case .wakeWord: value = s.wakeWord
+        case .llmProvider: value = s.llmProvider.rawValue
+        case .llmModel: value = s.llmModel
+        case .supertonicVoice: value = s.supertonicVoice.rawValue
+        case .ttsSpeed: value = String(s.ttsSpeed)
+        case .ttsDiffusionSteps: value = String(s.ttsDiffusionSteps)
+        case .chatFontSize: value = String(s.chatFontSize)
+        case .sttSilenceTimeout: value = String(s.sttSilenceTimeout)
+        case .contextAutoCompress: value = String(s.contextAutoCompress)
+        case .contextMaxSize: value = String(s.contextMaxSize)
+        case .activeAgentName: value = s.activeAgentName
+        case .telegramEnabled: value = String(s.telegramEnabled)
+        case .defaultUserId: value = s.defaultUserId?.uuidString ?? ""
+        case .openaiApiKey: value = s.apiKey.isEmpty ? "" : "***"
+        case .anthropicApiKey: value = s.anthropicApiKey.isEmpty ? "" : "***"
+        case .zaiApiKey: value = s.zaiApiKey.isEmpty ? "" : "***"
+        case .tavilyApiKey: value = s.tavilyApiKey.isEmpty ? "" : "***"
+        case .falaiApiKey: value = s.falaiApiKey.isEmpty ? "" : "***"
+        case .telegramBotToken: value = s.telegramBotToken.isEmpty ? "" : "***"
+        }
+        return MCPToolResult(content: "{\"key\":\"\(key.rawValue)\",\"value\":\"\(value)\"}", isError: false)
+    }
+
+    private func listSettings(_ s: AppSettings) -> MCPToolResult {
+        // 간단한 JSON 문자열 반환
+        var items: [[String: String]] = []
+        for key in Key.allCases {
+            let value = getSetting(s, ["key": key.rawValue]).content
+            items.append(["key": key.rawValue, "value": value])
+        }
+        let json: String
+        if let data = try? JSONSerialization.data(withJSONObject: items, options: [.prettyPrinted]), let str = String(data: data, encoding: .utf8) {
+            json = str
+        } else {
+            json = items.map { "\($0["key"] ?? ""): \($0["value"] ?? "")" }.joined(separator: "\n")
+        }
+        return MCPToolResult(content: json, isError: false)
+    }
+
+    // MARK: - MCP Servers
+
+    private func addMCPServer(_ s: AppSettings, _ args: [String: Any]) throws -> MCPToolResult {
+        guard let name = args["name"] as? String, !name.isEmpty, let command = args["command"] as? String, !command.isEmpty else {
+            throw BuiltInToolError.invalidArguments("name and command are required")
+        }
+        let arguments = (args["arguments"] as? [Any])?.compactMap { $0 as? String } ?? []
+        let env = args["environment"] as? [String: String]
+        let isEnabled = (args["is_enabled"] as? Bool) ?? true
+
+        let config = MCPServerConfig(name: name, command: command, arguments: arguments, environment: env, isEnabled: isEnabled)
+        s.addMCPServer(config)
+        return MCPToolResult(content: "Added MCP server id=\(config.id.uuidString)", isError: false)
+    }
+
+    private func updateMCPServer(_ s: AppSettings, _ args: [String: Any]) throws -> MCPToolResult {
+        guard let idStr = args["id"] as? String, let id = UUID(uuidString: idStr) else {
+            throw BuiltInToolError.invalidArguments("id must be UUID")
+        }
+        guard let existing = s.mcpServers.first(where: { $0.id == id }) else {
+            return MCPToolResult(content: "Server not found: \(idStr)", isError: true)
+        }
+        var new = existing
+        if let name = args["name"] as? String { new.name = name }
+        if let command = args["command"] as? String { new.command = command }
+        if let argArr = args["arguments"] as? [Any] { new.arguments = argArr.compactMap { $0 as? String } }
+        if let env = args["environment"] as? [String: String] { new.environment = env }
+        if let enabled = args["is_enabled"] as? Bool { new.isEnabled = enabled }
+        s.updateMCPServer(new)
+        return MCPToolResult(content: "Updated MCP server id=\(id.uuidString)", isError: false)
+    }
+
+    private func removeMCPServer(_ s: AppSettings, _ args: [String: Any]) throws -> MCPToolResult {
+        guard let idStr = args["id"] as? String, let id = UUID(uuidString: idStr) else {
+            throw BuiltInToolError.invalidArguments("id must be UUID")
+        }
+        s.removeMCPServer(id: id)
+        return MCPToolResult(content: "Removed MCP server id=\(id.uuidString)", isError: false)
+    }
+
+    // MARK: - Helpers
+
+    private func parseBool(_ str: String) -> Bool {
+        let v = str.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return ["true", "1", "yes", "on", "y"].contains(v)
+    }
+}
+

--- a/Dochi/Services/BuiltInTools/TelegramTool.swift
+++ b/Dochi/Services/BuiltInTools/TelegramTool.swift
@@ -1,0 +1,110 @@
+import Foundation
+import os
+
+/// 텔레그램 설정/동작 도구
+@MainActor
+final class TelegramTool: BuiltInTool {
+    weak var settings: AppSettings?
+    var telegram: TelegramService?
+
+    nonisolated var tools: [MCPToolInfo] {
+        [
+            MCPToolInfo(
+                id: "builtin:telegram.enable",
+                name: "telegram.enable",
+                description: "Enable or disable Telegram integration. Optionally set token.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "enabled": ["type": "boolean"],
+                        "token": ["type": "string"]
+                    ],
+                    "required": ["enabled"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:telegram.set_token",
+                name: "telegram.set_token",
+                description: "Set Telegram bot token (stored securely).",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["token": ["type": "string"]],
+                    "required": ["token"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:telegram.get_me",
+                name: "telegram.get_me",
+                description: "Fetch bot username for the configured token.",
+                inputSchema: ["type": "object", "properties": [:]]
+            ),
+            MCPToolInfo(
+                id: "builtin:telegram.send_message",
+                name: "telegram.send_message",
+                description: "Send a test message to a chat id (DM chat id).",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "chat_id": ["type": "integer"],
+                        "text": ["type": "string"]
+                    ],
+                    "required": ["chat_id", "text"]
+                ]
+            )
+        ]
+    }
+
+    func callTool(name: String, arguments: [String : Any]) async throws -> MCPToolResult {
+        guard let settings, let telegram else {
+            return MCPToolResult(content: "Telegram settings/service unavailable", isError: true)
+        }
+        switch name {
+        case "telegram.enable":
+            guard let enabled = arguments["enabled"] as? Bool else {
+                return MCPToolResult(content: "enabled is required (boolean)", isError: true)
+            }
+            if let token = arguments["token"] as? String, !token.isEmpty {
+                settings.telegramBotToken = token
+            }
+            settings.telegramEnabled = enabled
+            if enabled {
+                telegram.start(token: settings.telegramBotToken)
+            } else {
+                telegram.stop()
+            }
+            return MCPToolResult(content: enabled ? "Telegram enabled" : "Telegram disabled", isError: false)
+
+        case "telegram.set_token":
+            guard let token = arguments["token"] as? String, !token.isEmpty else {
+                return MCPToolResult(content: "token is required", isError: true)
+            }
+            settings.telegramBotToken = token
+            if settings.telegramEnabled { telegram.start(token: token) }
+            return MCPToolResult(content: "Token updated", isError: false)
+
+        case "telegram.get_me":
+            let token = settings.telegramBotToken
+            guard !token.isEmpty else { return MCPToolResult(content: "Token is not set", isError: true) }
+            do {
+                let name = try await telegram.getMe(token: token)
+                return MCPToolResult(content: name, isError: false)
+            } catch { return MCPToolResult(content: error.localizedDescription, isError: true) }
+
+        case "telegram.send_message":
+            guard let chatIdVal = arguments["chat_id"], let text = arguments["text"] as? String, !text.isEmpty else {
+                return MCPToolResult(content: "chat_id and text are required", isError: true)
+            }
+            let chatId: Int64
+            if let n = chatIdVal as? Int64 { chatId = n }
+            else if let i = chatIdVal as? Int { chatId = Int64(i) }
+            else if let s = chatIdVal as? String, let i = Int64(s) { chatId = i }
+            else { return MCPToolResult(content: "chat_id must be integer", isError: true) }
+            let _ = await telegram.sendMessage(chatId: chatId, text: text)
+            return MCPToolResult(content: "Sent", isError: false)
+
+        default:
+            throw BuiltInToolError.unknownTool(name)
+        }
+    }
+}
+

--- a/Dochi/Services/BuiltInTools/ToolsRegistryTool.swift
+++ b/Dochi/Services/BuiltInTools/ToolsRegistryTool.swift
@@ -1,0 +1,55 @@
+import Foundation
+import os
+
+/// 툴 레지스트리: 최소 스펙만 노출하고, 필요한 도구 이름만 활성화하도록 함
+@MainActor
+final class ToolsRegistryTool: BuiltInTool {
+    weak var registryHost: BuiltInToolService?
+
+    nonisolated var tools: [MCPToolInfo] {
+        [
+            MCPToolInfo(
+                id: "builtin:tools.list",
+                name: "tools.list",
+                description: "List available built-in tool names grouped by category. This does not include full schemas.",
+                inputSchema: ["type": "object", "properties": [:]]
+            ),
+            MCPToolInfo(
+                id: "builtin:tools.enable",
+                name: "tools.enable",
+                description: "Enable a set of tools by name. Only enabled tools (plus baseline) will be exposed in subsequent requests.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": [
+                        "names": ["type": "array", "items": ["type": "string"]]
+                    ],
+                    "required": ["names"]
+                ]
+            )
+        ]
+    }
+
+    func callTool(name: String, arguments: [String : Any]) async throws -> MCPToolResult {
+        guard let host = registryHost else {
+            return MCPToolResult(content: "Registry host unavailable", isError: true)
+        }
+        switch name {
+        case "tools.list":
+            let catalog = host.toolCatalogByCategory()
+            let data = try JSONSerialization.data(withJSONObject: catalog, options: [.prettyPrinted])
+            return MCPToolResult(content: String(data: data, encoding: .utf8) ?? "{}", isError: false)
+
+        case "tools.enable":
+            guard let arr = arguments["names"] as? [Any] else {
+                return MCPToolResult(content: "names array is required", isError: true)
+            }
+            let names = arr.compactMap { $0 as? String }
+            host.setEnabledToolNames(names)
+            return MCPToolResult(content: "Enabled tools: \(names)", isError: false)
+
+        default:
+            throw BuiltInToolError.unknownTool(name)
+        }
+    }
+}
+

--- a/Dochi/Services/BuiltInTools/WorkspaceTool.swift
+++ b/Dochi/Services/BuiltInTools/WorkspaceTool.swift
@@ -1,0 +1,121 @@
+import Foundation
+import os
+
+/// 워크스페이스 관리 도구 (Supabase 연동 필요)
+@MainActor
+final class WorkspaceTool: BuiltInTool {
+    weak var settings: AppSettings?
+    var supabase: (any SupabaseServiceProtocol)?
+
+    nonisolated var tools: [MCPToolInfo] {
+        [
+            MCPToolInfo(
+                id: "builtin:workspace.create",
+                name: "workspace.create",
+                description: "Create a new workspace (requires auth).",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["name": ["type": "string"]],
+                    "required": ["name"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:workspace.join_by_invite",
+                name: "workspace.join_by_invite",
+                description: "Join a workspace using invite code.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["invite_code": ["type": "string"]],
+                    "required": ["invite_code"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:workspace.list",
+                name: "workspace.list",
+                description: "List workspaces for current user.",
+                inputSchema: ["type": "object", "properties": [:]]
+            ),
+            MCPToolInfo(
+                id: "builtin:workspace.switch",
+                name: "workspace.switch",
+                description: "Switch current workspace by id.",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["id": ["type": "string"]],
+                    "required": ["id"]
+                ]
+            ),
+            MCPToolInfo(
+                id: "builtin:workspace.regenerate_invite_code",
+                name: "workspace.regenerate_invite_code",
+                description: "Regenerate invite code (owner permission required).",
+                inputSchema: [
+                    "type": "object",
+                    "properties": ["id": ["type": "string"]],
+                    "required": ["id"]
+                ]
+            )
+        ]
+    }
+
+    func callTool(name: String, arguments: [String: Any]) async throws -> MCPToolResult {
+        guard let supabase else {
+            return MCPToolResult(content: "Supabase is not configured", isError: true)
+        }
+        switch name {
+        case "workspace.create":
+            guard let name = arguments["name"] as? String, !name.isEmpty else {
+                return MCPToolResult(content: "name is required", isError: true)
+            }
+            do {
+                let ws = try await supabase.createWorkspace(name: name)
+                return MCPToolResult(content: "Created workspace \(ws.name) (id=\(ws.id), invite=\(ws.inviteCode ?? ""))", isError: false)
+            } catch { return MCPToolResult(content: error.localizedDescription, isError: true) }
+
+        case "workspace.join_by_invite":
+            guard let code = arguments["invite_code"] as? String, !code.isEmpty else {
+                return MCPToolResult(content: "invite_code is required", isError: true)
+            }
+            do {
+                let ws = try await supabase.joinWorkspace(inviteCode: code)
+                return MCPToolResult(content: "Joined workspace \(ws.name) (id=\(ws.id))", isError: false)
+            } catch { return MCPToolResult(content: error.localizedDescription, isError: true) }
+
+        case "workspace.list":
+            do {
+                let wss = try await supabase.listWorkspaces()
+                let arr = wss.map { ["id": $0.id.uuidString, "name": $0.name] }
+                let data = try JSONSerialization.data(withJSONObject: arr, options: [.prettyPrinted])
+                return MCPToolResult(content: String(data: data, encoding: .utf8) ?? "", isError: false)
+            } catch { return MCPToolResult(content: error.localizedDescription, isError: true) }
+
+        case "workspace.switch":
+            guard let idStr = arguments["id"] as? String, let id = UUID(uuidString: idStr) else {
+                return MCPToolResult(content: "id must be UUID", isError: true)
+            }
+            do {
+                // Fetch details and set current
+                let all = try await supabase.listWorkspaces()
+                if let ws = all.first(where: { $0.id == id }) {
+                    supabase.setCurrentWorkspace(ws)
+                    return MCPToolResult(content: "Switched workspace to \(ws.name)", isError: false)
+                } else {
+                    return MCPToolResult(content: "Workspace not found: \(idStr)", isError: true)
+                }
+            } catch { return MCPToolResult(content: error.localizedDescription, isError: true) }
+
+        case "workspace.regenerate_invite_code":
+            guard let idStr = arguments["id"] as? String, let id = UUID(uuidString: idStr) else {
+                return MCPToolResult(content: "id must be UUID", isError: true)
+            }
+            do {
+                let code = try await supabase.regenerateInviteCode(workspaceId: id)
+                return MCPToolResult(content: "New invite code: \(code)", isError: false)
+            } catch { return MCPToolResult(content: error.localizedDescription, isError: true) }
+
+        default:
+            throw BuiltInToolError.unknownTool(name)
+        }
+    }
+}
+

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -108,6 +108,11 @@ final class DochiViewModel: ObservableObject {
         setupTerminationHandler()
         conversationManager.loadAll()
 
+        // Inject settings to built-in tools that need it
+        builtInToolService.configureSettings(settings)
+        builtInToolService.configureConversations(conversationService)
+        builtInToolService.configureSupabase(supa)
+
         // Initialize Telegram service
         self.telegramService = TelegramService(
             conversationService: conversationService,
@@ -116,6 +121,8 @@ final class DochiViewModel: ObservableObject {
             }
         )
         setupTelegramBindings()
+        // Provide Telegram to built-in tools
+        if let telegramService { builtInToolService.configureTelegram(telegramService) }
     }
 
     private func setupTerminationHandler() {

--- a/docs/issue-builtin-tools-config-edit.md
+++ b/docs/issue-builtin-tools-config-edit.md
@@ -1,0 +1,107 @@
+# Feature: 내장 도구로 컨텍스트/설정 편집 기능 추가 (LLM 모델 변경, 에이전트/프로필/워크스페이스 관리)
+
+## 배경
+- 현재 Dochi는 내장 도구(웹검색, 미리알림, 이미지 생성, 기억 관리, 사용자 식별)와 MCP 도구를 통해 외부 작업을 수행합니다.
+- 컨텍스트 파일(`system_prompt.md`, `agents/*/persona.md`, `memory/*.md`, `profiles.json`)과 앱 설정(AppSettings: LLM 제공자/모델, 활성 에이전트 등)은 사용자 UI에서 변경하지만, LLM 스스로 도구 호출로 갱신할 수 없습니다.
+- 대화 흐름 안에서 “모델 바꿔줘”, “새 에이전트 만들어줘”, “OOO와 △△△ 프로필 합쳐줘”, “이 초대 코드로 워크스페이스 참여해” 같은 요청을 도구 호출로 처리할 수 있으면 자율성이 커집니다.
+
+## 목표
+- 내장 도구로 컨텍스트·설정 파일을 안전하게 편집/관리할 수 있게 합니다.
+- 대표 시나리오: LLM 모델 변경, 에이전트 생성/전환, 프로필 추가/병합/개명/별칭 추가, 워크스페이스 생성/참여/전환/초대 코드 재발급.
+- 워크스페이스 관련 동작은 Supabase 설정/인증이 된 경우에만 노출합니다.
+
+## 제안 도구 목록 (초안)
+1) 설정
+- `settings.set_llm`
+  - 입력: `{ provider: "openai|anthropic|zai", model?: string }`
+  - 동작: 제공자 변경 후 모델 유효성 검사. `model` 생략 시 해당 제공자의 첫 모델로 설정.
+- `settings.set_active_agent`
+  - 입력: `{ name: string }`
+  - 동작: `AppSettings.activeAgentName` 갱신. 존재하지 않으면 에러.
+
+2) 에이전트 관리 (로컬/워크스페이스 인식)
+- `agent.create`
+  - 입력: `{ name: string, wake_word?: string, description?: string, workspace_id?: string }`
+  - 동작: `ContextService.createAgent(...)` 호출. 워크스페이스 지정 시 해당 경로에 `config.json`/`persona.md` 생성.
+- `agent.list`
+  - 입력: `{ workspace_id?: string }`
+  - 동작: 에이전트 이름 목록 반환.
+
+3) 컨텍스트 편집
+- `context.update_base_system_prompt`
+  - 입력: `{ mode: "replace|append", content: string }`
+  - 동작: `system_prompt.md` 교체 또는 덧붙이기.
+
+4) 프로필 관리
+- `profile.create`
+  - 입력: `{ name: string, alias?: string[] }`
+  - 동작: 새 `UserProfile` 추가, `profiles.json` 저장.
+- `profile.merge`
+  - 입력: `{ source: string, target: string, merge_memory: "append|skip|replace" }`
+  - 동작: 이름/별칭 기준으로 두 프로필 병합. 개인 기억(`memory/{userId}.md`)은 전략에 따라 병합. 대화의 `userId`(문자열)도 target로 이관.
+- `profile.rename`
+  - 입력: `{ from: string, to: string }`
+  - 동작: 이름 변경 및 `profiles.json` 반영.
+- `profile.add_alias`
+  - 입력: `{ name: string, alias: string }`
+  - 동작: 해당 프로필에 별칭 추가.
+
+5) 워크스페이스 (Supabase 구성 시)
+- `workspace.create`
+  - 입력: `{ name: string }`
+  - 동작: `SupabaseService.createWorkspace` 호출, 생성된 초대 코드 반환.
+- `workspace.join_by_invite`
+  - 입력: `{ invite_code: string }`
+  - 동작: `SupabaseService.joinWorkspace` 호출, 현재 워크스페이스로 전환.
+- `workspace.list`
+  - 입력: `{}`
+  - 동작: 현재 사용자가 속한 워크스페이스 목록 반환.
+- `workspace.switch`
+  - 입력: `{ id: string }`
+  - 동작: `SupabaseService.setCurrentWorkspace` 호출.
+- `workspace.regenerate_invite_code`
+  - 입력: `{ id: string }`
+  - 동작: 새 초대 코드 발급(권한 체크 필요).
+
+## 기술 설계
+- 구조 확장
+  - `Dochi/Services/BuiltInTools/`에 새 모듈 추가: `SettingsTool.swift`, `AgentTool.swift`, `ContextEditTool.swift`, `ProfileAdminTool.swift`, `WorkspaceTool.swift`.
+  - 각 모듈은 `BuiltInTool` 프로토콜을 준수하고 `tools: [MCPToolInfo]`와 `callTool(...)` 구현.
+  - `BuiltInToolService`에 위 모듈을 보유하고 `availableTools`에 조건부로 노출.
+- 상태/저장소 연동
+  - 설정: `AppSettings` 인스턴스 참조를 `BuiltInToolService`에 주입하거나, 각 Tool에 의존성 주입. 모델-제공자 유효성 검사(`LLMProvider.models`) 적용.
+  - 에이전트/컨텍스트: `ContextServiceProtocol`을 사용, 워크스페이스 ID가 있으면 워크스페이스 경로 사용.
+  - 프로필 병합: `profiles.json` 로드/저장 + 개인 기억 파일 이동/머지 + `Conversation.userId` 매핑 업데이트.
+  - 워크스페이스: `SupabaseServiceProtocol` 사용. 미구성/미인증 시 도구 비노출 또는 에러 반환.
+- LLM 도구 사양
+  - 각 도구는 `MCPToolInfo(name, description, inputSchema)`로 스키마 정의(OpenAI/Anthropic 양쪽 호환).
+  - 반환은 사용자 가독성 중심의 요약 문자열. 필요 시 구조화된 텍스트(JSON snippet)를 포함.
+- 통합 포인트
+  - `DochiViewModel.sendLLMRequest(...)` 경로에서 이미 `BuiltInToolService.availableTools`를 합성 중 — 새 도구 자동 반영.
+
+## 보안/가드레일
+- 위험 작업(프로필 병합/삭제, 워크스페이스 전환)은 확인 플래그가 없으면 no-op 또는 미리보기만 반환 후 재호출 시 적용.
+- 워크스페이스 도구는 인증 필요. 권한(Owner/Member)에 따라 제한.
+- 파일 입출력은 앱 전용 디렉토리 하위만 허용.
+
+## 수락 기준
+- 대화에서 “모델을 anthropic/claude-haiku-4-5-20251001로 바꿔” → `settings.set_llm` 실행, `AppSettings` 반영, 이후 요청에 새 모델 사용.
+- “에이전트 ‘여행도치’ 만들어줘” → `agent.create`로 디렉토리/설정/기본 페르소나 생성.
+- “민수와 민서 프로필 합쳐줘, 기억은 append” → `profile.merge` 수행, 개인 기억 병합 및 대화 userId 이관.
+- Supabase 구성 시 “초대 코드 ABCD1234로 참여해” → `workspace.join_by_invite` 성공, 현재 워크스페이스 전환.
+
+## 작업 항목
+1. Tool 모듈 스캐폴딩 및 `BuiltInToolService` 통합
+2. `SettingsTool`: 제공자/모델 변경, 활성 에이전트 전환
+3. `AgentTool`: 생성/목록(워크스페이스 인식)
+4. `ContextEditTool`: base system prompt 교체/추가
+5. `ProfileAdminTool`: 생성/병합/개명/별칭 추가 + 기억/대화 이관 로직
+6. `WorkspaceTool`: 생성/참여/목록/전환/초대코드 재발급(권한체크)
+7. 에러/권한/확인 플래그 처리, 로깅
+8. 기본 단위 테스트(프로필 병합, 에이전트 생성, 설정 변경)
+
+## 오픈 이슈
+- 프로필 병합 시 충돌 해결 정책(동명이인, 별칭 중복) 세부 규칙 확정 필요.
+- 대화 `userId`가 문자열인 현 구조에서 UUID 안정성/마이그레이션 여부.
+- 워크스페이스 권한 모델(Owner만 초대코드 재발급 등) UI/도구 일관화.
+


### PR DESCRIPTION
# Built-in tools for settings, agent management/editing, workspace, telegram + tools registry

Closes #77

## Summary
Adds a comprehensive set of built-in tools to edit app settings, agents (create/list/switch and persona/memory/config editing), profiles, workspace (Supabase), and Telegram integration — plus a token‑friendly tools registry that keeps default tool exposure minimal.

## Highlights
- SettingsTool: set/get/list settings incl. chatFontSize, llmProvider/model, wakeWord, TTS/STT, API keys; MCP server add/update/remove
- AgentTool: create/list/set_active agents (workspace-aware)
- AgentEditorTool: agent persona/memory/config get/update; persona search/replace/delete lines; memory append/replace/update
- ContextEditTool: update base system prompt (replace/append)
- ProfileAdminTool: create/add_alias/rename/merge (append|skip|replace) with memory merge + conversation userId migration
- WorkspaceTool (Supabase): create/join_by_invite/list/switch/regenerate_invite_code
- TelegramTool: enable/set_token/get_me/send_message
- ToolsRegistryTool: tools.list (category → names), tools.enable (on-demand enable of admin/advanced tools)
- BuiltInToolService: wiring + dependency injection (settings, context, conversations, supabase, telegram) and registry-based filtering
- DochiViewModel: injects settings/conversations/supabase/telegram into BuiltInToolService

## Why (context budget)
Exposing many tools inflates the request body and context tokens. Default now exposes only a small baseline (reminders/alarms/basic memory/profile/web search/print/image). Admin/advanced tools are enabled on demand via tools.enable, minimizing token overhead while keeping power available when needed.

## Usage examples
- Change font size: `settings.set {"key":"chatFontSize","value":"16"}`
- Create/switch agent: `agent.create {"name":"여행도치"}` → `agent.set_active {"name":"여행도치"}`
- Edit persona: `agent.persona_update {"mode":"append","content":"새 규칙"}`
- Update memory line: `agent.memory_update {"find":"제주","replace":"- 제주 맛집 지도 관리"}`
- Workspace join: `workspace.join_by_invite {"invite_code":"ABCD1234"}`
- Telegram enable: `telegram.enable {"enabled":true,"token":"123:ABC..."}`
- Registry: `tools.list {}` → `tools.enable {"names":["agent.persona_update","settings.set","workspace.join_by_invite"]}`

## Implementation notes
- New files under `Dochi/Services/BuiltInTools/*` and routing in `BuiltInToolService`
- Workspace-aware ops use `settings.currentWorkspaceId` when present
- Profile merge updates conversations' `userId` (string) best‑effort and merges personal memories
- Registry baseline allowlist keeps core tools always available; others are opt‑in

## Risks / follow-ups
- Consider auto-reset of enabled tools after N minutes / at session end
- Optional: category-based enable (e.g., `tools.enable_categories`)
- Add guardrails (preview/confirm) for destructive edits (persona delete, large replacements)
- Light unit tests for profile merge, agent create, settings updates

## Screenshots / Docs
- Design notes in `docs/issue-builtin-tools-config-edit.md`
