### PR TITLE
feat(ui): Tools Registry controls in Inspector

### DIFF
--- a/Dochi/Models/Settings.swift
+++ b/Dochi/Models/Settings.swift
@@ -79,6 +79,11 @@ final class AppSettings: ObservableObject {
         }
     }
 
+    // Tools Registry
+    @Published var toolsRegistryAutoReset: Bool {
+        didSet { defaults.set(toolsRegistryAutoReset, forKey: Keys.toolsRegistryAutoReset) }
+    }
+
     // User profiles
     @Published var defaultUserId: UUID? {
         didSet {
@@ -108,6 +113,7 @@ final class AppSettings: ObservableObject {
         static let currentWorkspaceId = "settings.currentWorkspaceId"
         static let migratedToWorkspaceStructure = "settings.migratedToWorkspaceStructure"
         static let telegramEnabled = "settings.telegramEnabled"
+        static let toolsRegistryAutoReset = "settings.toolsRegistryAutoReset"
     }
 
     // MARK: - Dependencies
@@ -151,6 +157,7 @@ final class AppSettings: ObservableObject {
 
         self.activeAgentName = defaults.string(forKey: Keys.activeAgentName) ?? Constants.Agent.defaultName
         self.telegramEnabled = defaults.bool(forKey: Keys.telegramEnabled)
+        self.toolsRegistryAutoReset = defaults.object(forKey: Keys.toolsRegistryAutoReset) as? Bool ?? true
 
         // MCP servers
         if let data = defaults.data(forKey: Keys.mcpServers) {

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -300,7 +300,9 @@ final class DochiViewModel: ObservableObject {
         state = .idle
         sessionManager.startWakeWordIfNeeded()
         // Auto-reset enabled admin/advanced tools at session end to save tokens
-        builtInToolService.setEnabledToolNames(nil)
+        if settings.toolsRegistryAutoReset {
+            builtInToolService.setEnabledToolNames(nil)
+        }
     }
 
     // MARK: - Conversation (forwarding to ConversationManager)


### PR DESCRIPTION
Adds Tools Registry UI in Inspector: TTL slider, category toggles, enabled list and reset; new Settings flag to auto-reset on session end; DochiViewModel now respects the flag.