### PR TITLE
feat(routing): Auto model selection (beta)

### DIFF
--- a/Dochi/Models/Settings.swift
+++ b/Dochi/Models/Settings.swift
@@ -24,6 +24,11 @@ final class AppSettings: ObservableObject {
         didSet { defaults.set(llmModel, forKey: Keys.llmModel) }
     }
 
+    // Model routing (beta)
+    @Published var autoModelRoutingEnabled: Bool {
+        didSet { defaults.set(autoModelRoutingEnabled, forKey: Keys.autoModelRoutingEnabled) }
+    }
+
     // TTS settings
     @Published var supertonicVoice: SupertonicVoice {
         didSet { defaults.set(supertonicVoice.rawValue, forKey: Keys.supertonicVoice) }
@@ -114,6 +119,7 @@ final class AppSettings: ObservableObject {
         static let migratedToWorkspaceStructure = "settings.migratedToWorkspaceStructure"
         static let telegramEnabled = "settings.telegramEnabled"
         static let toolsRegistryAutoReset = "settings.toolsRegistryAutoReset"
+        static let autoModelRoutingEnabled = "settings.autoModelRoutingEnabled"
     }
 
     // MARK: - Dependencies
@@ -158,6 +164,7 @@ final class AppSettings: ObservableObject {
         self.activeAgentName = defaults.string(forKey: Keys.activeAgentName) ?? Constants.Agent.defaultName
         self.telegramEnabled = defaults.bool(forKey: Keys.telegramEnabled)
         self.toolsRegistryAutoReset = defaults.object(forKey: Keys.toolsRegistryAutoReset) as? Bool ?? true
+        self.autoModelRoutingEnabled = defaults.object(forKey: Keys.autoModelRoutingEnabled) as? Bool ?? false
 
         // MCP servers
         if let data = defaults.data(forKey: Keys.mcpServers) {

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -76,6 +76,10 @@ struct SettingsView: View {
                             Text(model).tag(model)
                         }
                     }
+                    Toggle("자동 모델 선택 (베타)", isOn: $viewModel.settings.autoModelRoutingEnabled)
+                    Text("짧은 대화는 경량 모델, 복잡/긴 요청은 고급 모델로 자동 선택합니다.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 // MARK: - Display


### PR DESCRIPTION
Adds a toggle to enable simple auto model selection within the chosen provider. Short chats route to lightweight models (mini/haiku), otherwise to higher-capability models. Persists in settings and applied in ConversationFlowController.