### PR TITLE
UI layout overhaul: 1-line appbar, accordion sidebar, tools toggles

### DIFF
--- a/Dochi/Components/AppToolbar.swift
+++ b/Dochi/Components/AppToolbar.swift
@@ -1,0 +1,214 @@
+import SwiftUI
+
+struct AppToolbar: View {
+    @EnvironmentObject var viewModel: DochiViewModel
+
+    var body: some View {
+        HStack(spacing: AppSpacing.s) {
+            connectionToggle
+
+            if viewModel.isConnected {
+                if isWakeWordActive {
+                    WakeWordIndicator(wakeWord: viewModel.settings.wakeWord)
+                } else {
+                    Text(stateLabel)
+                        .compact(AppFont.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Agent / Model / Workspace quick chips
+            agentModelWorkspace
+
+            Spacer(minLength: 8)
+
+            if let error = currentError { Text(error).compact(AppFont.caption).foregroundStyle(.red).lineLimit(1).minimumScaleFactor(0.8) }
+
+            Spacer()
+
+            if let _ = viewModel.actualContextUsage { contextUsageIndicator }
+
+            if viewModel.isConnected { autoEndToggle }
+
+            if isResponding { voiceIndicator }
+
+            if !viewModel.builtInToolService.activeAlarms.isEmpty { inlineAlarms }
+        }
+        .padding(.horizontal)
+        .padding(.vertical, verticalPadding)
+        .background(.ultraThinMaterial)
+        .overlay(alignment: .bottom) { Rectangle().fill(AppColor.border).frame(height: 1) }
+        .frame(height: barHeight)
+    }
+
+    // MARK: - Subviews
+
+    private var connectionToggle: some View {
+        Button { viewModel.toggleConnection() } label: {
+            HStack(spacing: AppSpacing.xs) {
+                Circle()
+                    .fill(connectionColor)
+                    .frame(width: 8, height: 8)
+                Text(connectionLabel).compact(AppFont.caption)
+            }
+        }
+        .buttonStyle(.borderless)
+    }
+
+    private var autoEndToggle: some View {
+        Button { viewModel.autoEndSession.toggle() } label: {
+            HStack(spacing: AppSpacing.xs) {
+                Image(systemName: viewModel.autoEndSession ? "timer" : "timer.circle")
+                    .font(.caption)
+                Text("자동종료").compact(AppFont.caption)
+            }
+            .foregroundStyle(viewModel.autoEndSession ? .primary : .tertiary)
+        }
+        .buttonStyle(.borderless)
+        .help(viewModel.autoEndSession ? "자동종료 켜짐: 무응답 시 대화 종료" : "자동종료 꺼짐: 무응답 시 계속 듣기")
+    }
+
+    private var voiceIndicator: some View {
+        HStack(spacing: AppSpacing.xs) {
+            AudioBarsView()
+            Text("응답 중").compact(AppFont.caption).foregroundStyle(.blue)
+        }
+        .frame(height: 16)
+    }
+
+    // MARK: - Helpers
+
+    private var agentModelWorkspace: some View {
+            HStack(spacing: AppSpacing.s) {
+                HStack(spacing: 6) {
+                    Image(systemName: "person.fill").foregroundStyle(.blue)
+                    Text(viewModel.settings.activeAgentName).compact(AppFont.caption).lineLimit(1).minimumScaleFactor(0.8)
+                }
+                .padding(.horizontal, 8).padding(.vertical, 4)
+                .background(Color.primary.opacity(0.06), in: Capsule())
+
+                HStack(spacing: 6) {
+                    Image(systemName: "brain.head.profile").foregroundStyle(.purple)
+                    Text("\(viewModel.settings.llmProvider.displayName)/\(viewModel.settings.llmModel)")
+                        .compact(AppFont.caption)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
+                .padding(.horizontal, 8).padding(.vertical, 4)
+                .background(Color.primary.opacity(0.06), in: Capsule())
+
+                if let supabase = viewModel.supabaseServiceForView, case .signedIn(_, _) = supabase.authState, let ws = supabase.selectedWorkspace {
+                    HStack(spacing: 6) {
+                        Image(systemName: "person.3.fill").foregroundStyle(.teal)
+                        Text(ws.name).compact(AppFont.caption).lineLimit(1).minimumScaleFactor(0.8)
+                    }
+                    .padding(.horizontal, 8).padding(.vertical, 4)
+                    .background(Color.primary.opacity(0.06), in: Capsule())
+                }
+            }
+    }
+
+    private var connectionColor: Color {
+        switch viewModel.supertonicService.state {
+        case .unloaded: return .red
+        case .loading: return .yellow
+        case .ready:
+            switch viewModel.state {
+            case .idle: return .green
+            case .listening: return .orange
+            case .processing: return .blue
+            case .executingTool: return .cyan
+            case .speaking: return .purple
+            }
+        case .synthesizing: return .blue
+        case .playing: return .purple
+        }
+    }
+
+    private var connectionLabel: String {
+        switch viewModel.supertonicService.state {
+        case .unloaded: return "연결"
+        case .loading: return "로딩 중..."
+        case .ready, .synthesizing, .playing: return "연결됨"
+        }
+    }
+
+    private var stateLabel: String {
+        switch viewModel.state {
+        case .idle: return "대기 중"
+        case .listening: return "듣는 중..."
+        case .processing: return "응답 생성 중..."
+        case .executingTool(let name): return "\(name) 실행 중..."
+        case .speaking: return "음성 재생 중..."
+        }
+    }
+
+    private var currentError: String? {
+        viewModel.errorMessage ?? viewModel.llmService.error ?? viewModel.supertonicService.error
+    }
+
+    private var isWakeWordActive: Bool {
+        viewModel.speechService.state == .waitingForWakeWord
+    }
+
+    private var isResponding: Bool {
+        switch viewModel.state {
+        case .processing, .executingTool, .speaking: return true
+        case .idle, .listening: return false
+        }
+    }
+
+    private var contextUsageIndicator: some View {
+        let info = viewModel.actualContextUsage!
+        return HStack(spacing: AppSpacing.xs) {
+            Image(systemName: "gauge")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.secondary.opacity(0.15))
+                Capsule().fill(info.percent < 0.8 ? Color.blue.opacity(0.6) : (info.percent < 1.0 ? Color.orange.opacity(0.7) : Color.red.opacity(0.7)))
+                    .frame(width: max(0, CGFloat(info.percent)) * 90)
+            }
+            .frame(width: 90, height: 8)
+            Text("\(Int(info.percent * 100))%")
+                .compact(AppFont.caption.monospacedDigit())
+                .foregroundStyle(info.percent < 0.8 ? Color.secondary : (info.percent < 1.0 ? Color.orange : Color.red))
+        }
+        .accessibilityIdentifier("indicator.contextUsage")
+    }
+
+    private var inlineAlarms: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "alarm.fill").foregroundStyle(.orange).font(.caption)
+            ForEach(viewModel.builtInToolService.activeAlarms) { alarm in
+                HStack(spacing: 4) {
+                    Text(alarm.label).compact(AppFont.caption)
+                    Text(remainingText(alarm.fireDate))
+                        .compact(AppFont.caption.monospacedDigit())
+                        .foregroundStyle(.orange)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(.orange.opacity(0.1), in: Capsule())
+            }
+        }
+    }
+
+    private func remainingText(_ fireDate: Date) -> String {
+        let remaining = max(0, Int(fireDate.timeIntervalSinceNow))
+        if remaining >= 3600 {
+            let h = remaining / 3600
+            let m = (remaining % 3600) / 60
+            return "\(h):\(String(format: "%02d", m)):\(String(format: "%02d", remaining % 60))"
+        } else if remaining >= 60 {
+            let m = remaining / 60
+            let s = remaining % 60
+            return "\(m):\(String(format: "%02d", s))"
+        } else {
+            return "\(remaining)초"
+        }
+    }
+
+    private var verticalPadding: CGFloat { AppSpacing.xs }
+    private var barHeight: CGFloat { 34 }
+}

--- a/Dochi/Components/InputBar.swift
+++ b/Dochi/Components/InputBar.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+struct InputBar: View {
+    @EnvironmentObject var viewModel: DochiViewModel
+
+    @State private var inputText: String = ""
+    @State private var glowPulse = false
+    @State private var glowFlash = false
+    @State private var previousTranscript = ""
+
+    var body: some View {
+        HStack(spacing: AppSpacing.m) {
+            if viewModel.isConnected { micButton }
+
+            if isListening {
+                listeningContent
+            } else {
+                textInputContent
+            }
+        }
+        .padding(barPadding)
+        .background(.ultraThinMaterial)
+        .overlay(listeningGlow)
+        .animation(.easeInOut(duration: 0.3), value: isListening)
+        .onChange(of: isListening) { _, newValue in
+            if newValue {
+                withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                    glowPulse = true
+                }
+                previousTranscript = ""
+            } else {
+                glowPulse = false
+                glowFlash = false
+            }
+        }
+        .onChange(of: viewModel.speechService.transcript) { oldValue, newValue in
+            guard isListening, !newValue.isEmpty, newValue != oldValue else { return }
+            glowFlash = true
+            withAnimation(.easeOut(duration: 0.3)) { glowFlash = false }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var micButton: some View {
+        Button {
+            if isListening { viewModel.stopListening() } else { viewModel.startListening() }
+        } label: {
+            ZStack {
+                if isListening {
+                    Circle()
+                        .fill(Color.orange.opacity(0.2))
+                        .frame(width: 36, height: 36)
+                        .scaleEffect(glowPulse ? 1.4 : 1.0)
+                        .opacity(glowPulse ? 0.0 : 0.6)
+                }
+                Image(systemName: isListening ? "mic.fill" : "mic")
+                    .font(.title2)
+                    .foregroundStyle(isListening ? .orange : .secondary)
+            }
+            .frame(width: 36, height: 36)
+        }
+        .buttonStyle(.borderless)
+    }
+
+    private var listeningContent: some View {
+        HStack(spacing: AppSpacing.m) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("듣는 중...").compact(AppFont.caption).foregroundStyle(.secondary)
+                if !viewModel.speechService.transcript.isEmpty {
+                    Text(viewModel.speechService.transcript)
+                        .font(.body)
+                        .lineLimit(3)
+                        .truncationMode(.head)
+                }
+            }
+            Spacer()
+            AudioBarsView()
+        }
+    }
+
+    private var textInputContent: some View {
+        HStack(spacing: AppSpacing.m) {
+            TextField("메시지를 입력하세요...", text: $inputText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...5)
+                .onSubmit { submitText() }
+                .accessibilityIdentifier("input.textField")
+
+            if isResponding {
+                Button { viewModel.cancelResponse() } label: {
+                    Image(systemName: "stop.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.borderless)
+                .help("응답 취소")
+            } else {
+                Button { submitText() } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(
+                            inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                ? Color.secondary : Color.blue
+                        )
+                }
+                .buttonStyle(.borderless)
+                .disabled(sendDisabled)
+                .accessibilityIdentifier("input.send")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var listeningGlow: some View {
+        if isListening {
+            RoundedRectangle(cornerRadius: AppRadius.large)
+                .fill(Color.orange.opacity(0.06))
+                .shadow(
+                    color: .orange.opacity(glowFlash ? 0.6 : (glowPulse ? 0.4 : 0.1)),
+                    radius: glowFlash ? 16 : (glowPulse ? 12 : 4)
+                )
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var isListening: Bool { viewModel.state == .listening }
+
+    private var isResponding: Bool {
+        switch viewModel.state {
+        case .processing, .executingTool, .speaking: return true
+        case .idle, .listening: return false
+        }
+    }
+
+    private var sendDisabled: Bool {
+        let empty = inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let provider = viewModel.settings.llmProvider
+        let hasKey = !viewModel.settings.apiKey(for: provider).isEmpty
+        return empty || !hasKey || viewModel.state == .processing
+    }
+
+    private func submitText() {
+        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        inputText = ""
+        viewModel.sendMessage(text)
+    }
+
+    private var barPadding: CGFloat { viewModel.settings.uiDensity == .compact ? AppSpacing.s : 16 }
+}

--- a/Dochi/Components/SectionCard.swift
+++ b/Dochi/Components/SectionCard.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct SectionCard<Content: View>: View {
+    @EnvironmentObject var viewModel: DochiViewModel
+    let title: String?
+    var icon: String? = nil
+    var trailing: AnyView? = nil
+    @ViewBuilder var content: Content
+
+    init(_ title: String?, icon: String? = nil, trailing: AnyView? = nil, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.icon = icon
+        self.trailing = trailing
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            if let title {
+                HStack(spacing: AppSpacing.s) {
+                    if let icon { Image(systemName: icon).foregroundStyle(.secondary).font(.caption) }
+                    Text(title)
+                        .compact(AppFont.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    if let trailing { trailing }
+                }
+                .padding(.bottom, headerBottomPadding)
+            }
+
+            content
+        }
+        .padding(cardPadding)
+        .background(
+            RoundedRectangle(cornerRadius: AppRadius.large)
+                .fill(.ultraThinMaterial)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: AppRadius.large)
+                .stroke(AppColor.border, lineWidth: 1)
+        )
+    }
+
+    private var spacing: CGFloat { viewModel.settings.uiDensity == .compact ? AppSpacing.xs : AppSpacing.s }
+    private var headerBottomPadding: CGFloat { viewModel.settings.uiDensity == .compact ? AppSpacing.xs : AppSpacing.xs }
+    private var cardPadding: CGFloat { viewModel.settings.uiDensity == .compact ? AppSpacing.s : AppSpacing.m }
+}

--- a/Dochi/Components/SectionHeader.swift
+++ b/Dochi/Components/SectionHeader.swift
@@ -21,7 +21,6 @@ struct SectionHeader: View {
         }
         .padding(.horizontal, AppSpacing.s)
         .padding(.vertical, compact ? AppSpacing.xs : AppSpacing.s)
-        .background(AppColor.background)
+        .background(Color.clear)
     }
 }
-

--- a/Dochi/DochiApp.swift
+++ b/Dochi/DochiApp.swift
@@ -27,6 +27,8 @@ struct DochiApp: App {
             ContentView()
                 .environmentObject(viewModel)
         }
+        .windowStyle(.hiddenTitleBar)
+        .windowToolbarStyle(.unifiedCompact)
         .windowResizability(.contentMinSize)
         .defaultSize(width: 900, height: 650)
         .commands {

--- a/Dochi/Models/Settings.swift
+++ b/Dochi/Models/Settings.swift
@@ -44,6 +44,9 @@ final class AppSettings: ObservableObject {
     @Published var chatFontSize: Double {
         didSet { defaults.set(chatFontSize, forKey: Keys.chatFontSize) }
     }
+    @Published var uiDensity: UIDensity {
+        didSet { defaults.set(uiDensity.rawValue, forKey: Keys.uiDensity) }
+    }
 
     // STT settings
     @Published var sttSilenceTimeout: Double {
@@ -123,6 +126,7 @@ final class AppSettings: ObservableObject {
         static let ttsSpeed = "settings.ttsSpeed"
         static let ttsDiffusionSteps = "settings.ttsDiffusionSteps"
         static let chatFontSize = "settings.chatFontSize"
+        static let uiDensity = "settings.uiDensity"
         static let sttSilenceTimeout = "settings.sttSilenceTimeout"
         static let contextAutoCompress = "settings.contextAutoCompress"
         static let contextMaxSize = "settings.contextMaxSize"
@@ -175,6 +179,11 @@ final class AppSettings: ObservableObject {
         self.ttsDiffusionSteps = defaults.object(forKey: Keys.ttsDiffusionSteps) as? Int ?? Constants.Defaults.ttsDiffusionSteps
 
         self.chatFontSize = defaults.object(forKey: Keys.chatFontSize) as? Double ?? Constants.Defaults.chatFontSize
+        if let densityRaw = defaults.string(forKey: Keys.uiDensity), let d = UIDensity(rawValue: densityRaw) {
+            self.uiDensity = d
+        } else {
+            self.uiDensity = .standard
+        }
         self.sttSilenceTimeout = defaults.object(forKey: Keys.sttSilenceTimeout) as? Double ?? Constants.Defaults.sttSilenceTimeout
         self.contextAutoCompress = defaults.object(forKey: Keys.contextAutoCompress) as? Bool ?? true
         self.contextMaxSize = defaults.object(forKey: Keys.contextMaxSize) as? Int ?? Constants.Defaults.contextMaxSize

--- a/Dochi/Models/UIDensity.swift
+++ b/Dochi/Models/UIDensity.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum UIDensity: String, CaseIterable, Identifiable, Hashable {
+    case standard
+    case compact
+
+    var id: String { rawValue }
+    var displayName: String {
+        switch self {
+        case .standard: return "기본"
+        case .compact: return "컴팩트"
+        }
+    }
+}

--- a/Dochi/Views/CloudSettingsView.swift
+++ b/Dochi/Views/CloudSettingsView.swift
@@ -11,7 +11,7 @@ struct CloudSettingsView: View {
     @State private var isLoading = false
 
     var body: some View {
-        Section("클라우드") {
+        VStack(alignment: .leading, spacing: 8) {
             if !supabaseService.isConfigured {
                 configurationNeededView
             } else {

--- a/Dochi/Views/CommandPaletteView.swift
+++ b/Dochi/Views/CommandPaletteView.swift
@@ -31,7 +31,7 @@ struct CommandPaletteView: View {
                     .accessibilityIdentifier("palette.search")
             }
             .padding(AppSpacing.s)
-            .background(AppColor.surface)
+            .background(.ultraThinMaterial)
 
             Divider()
 
@@ -51,9 +51,9 @@ struct CommandPaletteView: View {
             .listStyle(.bordered)
             .frame(width: 600, height: 420)
         }
-        .background(AppColor.background)
+        .background(.ultraThinMaterial)
         .clipShape(RoundedRectangle(cornerRadius: AppRadius.large))
-        .shadow(radius: 16)
+        .shadow(color: .black.opacity(0.12), radius: 16, y: 6)
         .overlay(
             RoundedRectangle(cornerRadius: AppRadius.large)
                 .stroke(AppColor.border.opacity(0.6), lineWidth: 1)

--- a/Dochi/Views/ConversationView.swift
+++ b/Dochi/Views/ConversationView.swift
@@ -8,7 +8,7 @@ struct ConversationView: View {
         ZStack {
             ScrollViewReader { proxy in
                 ScrollView {
-                    LazyVStack(spacing: AppSpacing.m) {
+                    LazyVStack(spacing: itemSpacing) {
                         if viewModel.messages.isEmpty && !viewModel.isConnected {
                             emptyState
                         } else if viewModel.messages.isEmpty && viewModel.isConnected {
@@ -60,10 +60,10 @@ struct ConversationView: View {
 
                         // 하단 여백 — 마지막 메시지가 충분히 위로 올라오도록
                         Spacer()
-                            .frame(height: 120)
+                            .frame(height: bottomSpacerHeight)
                             .id("bottom")
                     }
-                    .padding(AppSpacing.m)
+                    .padding(stackPadding)
                 }
                 .onChange(of: viewModel.messages.count) {
                     withAnimation {
@@ -135,26 +135,26 @@ struct ConversationView: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text("도치").compact(AppFont.caption).foregroundStyle(.secondary)
                 ThinkingDotsView()
-                    .padding(AppSpacing.m)
+                    .padding(bubblePadding)
                     .background(AppColor.surface)
                     .clipShape(RoundedRectangle(cornerRadius: AppRadius.large))
             }
-            Spacer(minLength: 60)
+            Spacer(minLength: sideSpacer)
         }
     }
 
     private func liveBubble(label: String, text: String, color: Color, alignment: HorizontalAlignment) -> some View {
         HStack(alignment: .top) {
-            if alignment == .trailing { Spacer(minLength: 60) }
+            if alignment == .trailing { Spacer(minLength: sideSpacer) }
             VStack(alignment: alignment == .trailing ? .trailing : .leading, spacing: 4) {
                 Text(label).compact(AppFont.caption).foregroundStyle(.secondary)
                 Text(text)
                     .font(.system(size: viewModel.settings.chatFontSize))
-                    .padding(AppSpacing.m)
+                    .padding(bubblePadding)
                     .background(color)
                     .clipShape(RoundedRectangle(cornerRadius: AppRadius.large))
             }
-            if alignment == .leading { Spacer(minLength: 60) }
+            if alignment == .leading { Spacer(minLength: sideSpacer) }
         }
     }
 }
@@ -485,7 +485,7 @@ struct MessageBubbleView: View {
 
     var body: some View {
         HStack(alignment: .top) {
-            if message.role == .user { Spacer(minLength: 60) }
+            if message.role == .user { Spacer(minLength: sideSpacerLocal) }
             VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 4) {
                 Text(message.role == .user ? "나" : "도치")
                     .font(.caption)
@@ -506,7 +506,7 @@ struct MessageBubbleView: View {
                             }
                     }
                 }
-                .padding(AppSpacing.m)
+                .padding(bubblePaddingLocal)
                 .background(
                     message.role == .user
                         ? Color.blue.opacity(0.15)
@@ -514,12 +514,28 @@ struct MessageBubbleView: View {
                 )
                 .clipShape(RoundedRectangle(cornerRadius: AppRadius.large))
             }
-            if message.role == .assistant { Spacer(minLength: 60) }
+            if message.role == .assistant { Spacer(minLength: sideSpacerLocal) }
         }
         .sheet(item: $expandedImageURL) { url in
             ImagePreviewView(url: url)
         }
     }
+
+    // Density-aware locals (MessageBubbleView scope)
+    private var isCompactLocal: Bool { viewModel.settings.uiDensity == .compact }
+    private var bubblePaddingLocal: CGFloat { isCompactLocal ? AppSpacing.s : AppSpacing.m }
+    private var sideSpacerLocal: CGFloat { isCompactLocal ? 36 : 60 }
+}
+
+// MARK: - Density Helpers
+
+private extension ConversationView {
+    var isCompact: Bool { viewModel.settings.uiDensity == .compact }
+    var itemSpacing: CGFloat { isCompact ? AppSpacing.s : AppSpacing.m }
+    var bubblePadding: CGFloat { isCompact ? AppSpacing.s : AppSpacing.m }
+    var stackPadding: CGFloat { isCompact ? AppSpacing.s : AppSpacing.m }
+    var bottomSpacerHeight: CGFloat { isCompact ? 80 : 120 }
+    var sideSpacer: CGFloat { isCompact ? 36 : 60 }
 }
 
 // MARK: - Generated Image View

--- a/Dochi/Views/DeviceSettingsView.swift
+++ b/Dochi/Views/DeviceSettingsView.swift
@@ -8,7 +8,7 @@ struct DeviceSettingsView: View {
     @State private var newName = ""
 
     var body: some View {
-        Section("디바이스") {
+        VStack(alignment: .leading, spacing: 8) {
             if devices.isEmpty {
                 Text("등록된 디바이스가 없습니다.")
                     .foregroundStyle(.tertiary)

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -35,405 +35,323 @@ struct SettingsView: View {
                     .keyboardShortcut(.escape)
             }
             .padding()
+            .background(.ultraThinMaterial)
+            .overlay(alignment: .bottom) { Rectangle().fill(AppColor.border).frame(height: 1) }
 
-            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: AppSpacing.m) {
+                    // API Keys
+                    SectionCard("API 키", icon: "key.fill") {
+                        SecureField("OpenAI API 키", text: $openaiKey)
+                            .onChange(of: openaiKey) { _, newValue in viewModel.settings.apiKey = newValue }
+                        SecureField("Anthropic API 키", text: $anthropicKey)
+                            .onChange(of: anthropicKey) { _, newValue in viewModel.settings.anthropicApiKey = newValue }
+                        SecureField("Z.AI API 키", text: $zaiKey)
+                            .onChange(of: zaiKey) { _, newValue in viewModel.settings.zaiApiKey = newValue }
+                        SecureField("Tavily API 키 (웹검색)", text: $tavilyKey)
+                            .onChange(of: tavilyKey) { _, newValue in viewModel.settings.tavilyApiKey = newValue }
+                        SecureField("Fal.ai API 키 (이미지생성)", text: $falaiKey)
+                            .onChange(of: falaiKey) { _, newValue in viewModel.settings.falaiApiKey = newValue }
+                    }
 
-            Form {
-                SectionHeader("General")
-                // MARK: - API Keys
-                Section("API 키") {
-                    SecureField("OpenAI API 키", text: $openaiKey)
-                        .onChange(of: openaiKey) { _, newValue in
-                            viewModel.settings.apiKey = newValue
-                        }
-                    SecureField("Anthropic API 키", text: $anthropicKey)
-                        .onChange(of: anthropicKey) { _, newValue in
-                            viewModel.settings.anthropicApiKey = newValue
-                        }
-                    SecureField("Z.AI API 키", text: $zaiKey)
-                        .onChange(of: zaiKey) { _, newValue in
-                            viewModel.settings.zaiApiKey = newValue
-                        }
-                    SecureField("Tavily API 키 (웹검색)", text: $tavilyKey)
-                        .onChange(of: tavilyKey) { _, newValue in
-                            viewModel.settings.tavilyApiKey = newValue
-                        }
-                    SecureField("Fal.ai API 키 (이미지생성)", text: $falaiKey)
-                        .onChange(of: falaiKey) { _, newValue in
-                            viewModel.settings.falaiApiKey = newValue
-                        }
-                }
-
-                // MARK: - LLM
-                SectionHeader("Models")
-                Section("LLM") {
-                    Picker("제공자", selection: $viewModel.settings.llmProvider) {
-                        ForEach(LLMProvider.allCases, id: \.self) { provider in
-                            Text(provider.displayName).tag(provider)
-                        }
-                    }
-                    Picker("모델", selection: $viewModel.settings.llmModel) {
-                        ForEach(viewModel.settings.llmProvider.models, id: \.self) { model in
-                            Text(model).tag(model)
-                        }
-                    }
-                    Toggle("자동 모델 선택 (베타)", isOn: $viewModel.settings.autoModelRoutingEnabled)
-                    Text("짧은 대화는 경량 모델, 복잡/긴 요청은 고급 모델로 자동 선택합니다.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                // MARK: - Display
-                SectionHeader("Display")
-                Section("표시") {
-                    HStack {
-                        Text("글자 크기")
-                        Slider(value: $viewModel.settings.chatFontSize, in: 12...28, step: 1)
-                        Text("\(Int(viewModel.settings.chatFontSize))pt")
-                            .font(.caption.monospacedDigit())
-                            .frame(width: 36)
-                    }
-                    Text("가나다라마바사 ABC 123")
-                        .font(.system(size: viewModel.settings.chatFontSize))
-                        .foregroundStyle(.secondary)
-                }
-
-                // MARK: - STT
-                SectionHeader("STT")
-                Section("STT") {
-                    HStack {
-                        Text("무음 대기")
-                        Slider(value: $viewModel.settings.sttSilenceTimeout, in: 0.5...3.0, step: 0.5)
-                        Text(String(format: "%.1f초", viewModel.settings.sttSilenceTimeout))
-                            .font(.caption.monospacedDigit())
-                            .frame(width: 36)
-                    }
-                }
-
-                // MARK: - TTS
-                SectionHeader("TTS")
-                Section("TTS") {
-                    Picker("음성", selection: $viewModel.settings.supertonicVoice) {
-                        ForEach(SupertonicVoice.allCases, id: \.self) { voice in
-                            Text(voice.displayName).tag(voice)
-                        }
-                    }
-                    HStack {
-                        Text("속도")
-                        Slider(value: $viewModel.settings.ttsSpeed, in: 0.8...1.5, step: 0.05)
-                        Text(String(format: "%.2f", viewModel.settings.ttsSpeed))
-                            .font(.caption.monospacedDigit())
-                            .frame(width: 36)
-                    }
-                    HStack {
-                        Text("표현력")
-                        Slider(value: diffusionStepsBinding, in: 4...20, step: 2)
-                        Text("\(viewModel.settings.ttsDiffusionSteps)")
-                            .font(.caption.monospacedDigit())
-                            .frame(width: 20)
-                    }
-                }
-
-                // MARK: - System Prompt
-                SectionHeader("Context & Memory")
-                Section("시스템 프롬프트") {
-                    VStack(alignment: .leading) {
-                        let system = contextService.loadSystem()
-                        Text(system.isEmpty
-                             ? "페르소나와 행동 지침이 설정되지 않았습니다."
-                             : system)
-                            .font(.body)
-                            .foregroundStyle(system.isEmpty ? .tertiary : .primary)
-                            .lineLimit(3)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        HStack {
-                            Button("편집") {
-                                showSystemEditor = true
+                    // LLM
+                    SectionCard("LLM", icon: "brain.head.profile") {
+                        Picker("제공자", selection: $viewModel.settings.llmProvider) {
+                            ForEach(LLMProvider.allCases, id: \.self) { provider in
+                                Text(provider.displayName).tag(provider)
                             }
-                            Spacer()
-                            Text("system.md")
-                                .font(.caption)
-                                .foregroundStyle(.tertiary)
                         }
+                        Picker("모델", selection: $viewModel.settings.llmModel) {
+                            ForEach(viewModel.settings.llmProvider.models, id: \.self) { model in
+                                Text(model).tag(model)
+                            }
+                        }
+                        Toggle("자동 모델 선택 (베타)", isOn: $viewModel.settings.autoModelRoutingEnabled)
+                        Text("짧은 대화는 경량 모델, 복잡/긴 요청은 고급 모델로 자동 선택합니다.")
+                            .compact(AppFont.caption)
+                            .foregroundStyle(.secondary)
                     }
-                }
 
-                // MARK: - User Memory
-                Section("사용자 기억") {
-                    VStack(alignment: .leading) {
-                        let memory = contextService.loadMemory()
-                        Text(memory.isEmpty
-                             ? "저장된 기억이 없습니다. 대화 종료 시 자동으로 추가됩니다."
-                             : memory)
-                            .font(.body)
-                            .foregroundStyle(memory.isEmpty ? .tertiary : .primary)
-                            .lineLimit(5)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                    // Display
+                    SectionCard("표시", icon: "textformat.size") {
                         HStack {
-                            Button("편집") {
-                                showMemoryEditor = true
-                            }
-                            if !memory.isEmpty {
-                                Button("초기화", role: .destructive) {
-                                    contextService.saveMemory("")
-                                }
-                            }
-                            Spacer()
-                            Text("\(contextService.memorySize / 1024)KB / \(viewModel.settings.contextMaxSize / 1024)KB")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    Toggle("자동 압축", isOn: $viewModel.settings.contextAutoCompress)
-                    if viewModel.settings.contextAutoCompress {
-                        HStack {
-                            Text("최대 크기")
-                            Slider(value: contextMaxSizeBinding, in: 5...50, step: 5)
-                            Text("\(viewModel.settings.contextMaxSize / 1024)KB")
+                            Text("글자 크기")
+                            Slider(value: $viewModel.settings.chatFontSize, in: 12...28, step: 1)
+                            Text("\(Int(viewModel.settings.chatFontSize))pt")
                                 .font(.caption.monospacedDigit())
-                                .frame(width: 40)
+                                .frame(width: 36)
+                        }
+                        Text("가나다라마바사 ABC 123")
+                            .font(.system(size: viewModel.settings.chatFontSize))
+                            .foregroundStyle(.secondary)
+
+                        Picker("밀도", selection: $viewModel.settings.uiDensity) {
+                            ForEach(UIDensity.allCases) { d in
+                                Text(d.displayName).tag(d)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
+                    // STT
+                    SectionCard("STT", icon: "waveform") {
+                        HStack {
+                            Text("무음 대기")
+                            Slider(value: $viewModel.settings.sttSilenceTimeout, in: 0.5...3.0, step: 0.5)
+                            Text(String(format: "%.1f초", viewModel.settings.sttSilenceTimeout))
+                                .font(.caption.monospacedDigit())
+                                .frame(width: 36)
                         }
                     }
-                }
 
-                // MARK: - Family Profiles
-                SectionHeader("Profiles")
-                Section("가족 구성원") {
-                    let profiles = contextService.loadProfiles()
-                    if profiles.isEmpty {
-                        Text("가족 구성원을 추가하면 사용자별 기억이 분리됩니다.")
-                            .font(.caption)
-                            .foregroundStyle(.tertiary)
-                    } else {
-                        ForEach(profiles) { profile in
+                    // TTS
+                    SectionCard("TTS", icon: "speaker.wave.2") {
+                        Picker("음성", selection: $viewModel.settings.supertonicVoice) {
+                            ForEach(SupertonicVoice.allCases, id: \.self) { voice in
+                                Text(voice.displayName).tag(voice)
+                            }
+                        }
+                        HStack {
+                            Text("속도")
+                            Slider(value: $viewModel.settings.ttsSpeed, in: 0.8...1.5, step: 0.05)
+                            Text(String(format: "%.2f", viewModel.settings.ttsSpeed))
+                                .font(.caption.monospacedDigit())
+                                .frame(width: 36)
+                        }
+                        HStack {
+                            Text("표현력")
+                            Slider(value: diffusionStepsBinding, in: 4...20, step: 2)
+                            Text("\(viewModel.settings.ttsDiffusionSteps)")
+                                .font(.caption.monospacedDigit())
+                                .frame(width: 20)
+                        }
+                    }
+
+                    // System Prompt
+                    SectionCard("시스템 프롬프트", icon: "rectangle.and.pencil.and.ellipsis") {
+                        VStack(alignment: .leading) {
+                            let system = contextService.loadSystem()
+                            Text(system.isEmpty ? "페르소나와 행동 지침이 설정되지 않았습니다." : system)
+                                .font(.body)
+                                .foregroundStyle(system.isEmpty ? .tertiary : .primary)
+                                .lineLimit(3)
+                                .frame(maxWidth: .infinity, alignment: .leading)
                             HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    HStack(spacing: 6) {
-                                        Text(profile.name)
-                                            .font(.body)
-                                        if viewModel.settings.defaultUserId == profile.id {
-                                            Text("기본")
-                                                .font(.caption2)
-                                                .padding(.horizontal, 4)
-                                                .padding(.vertical, 1)
-                                                .background(.blue.opacity(0.15), in: Capsule())
-                                                .foregroundStyle(.blue)
-                                        }
-                                    }
-                                    if !profile.aliases.isEmpty {
-                                        Text("별칭: \(profile.aliases.joined(separator: ", "))")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    if !profile.description.isEmpty {
-                                        Text(profile.description)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
+                                Button("편집") { showSystemEditor = true }
+                                Spacer()
+                                Text("system.md")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                    }
+
+                    // User Memory
+                    SectionCard("사용자 기억", icon: "brain.head.profile") {
+                        VStack(alignment: .leading) {
+                            let memory = contextService.loadMemory()
+                            Text(memory.isEmpty ? "저장된 기억이 없습니다. 대화 종료 시 자동으로 추가됩니다." : memory)
+                                .font(.body)
+                                .foregroundStyle(memory.isEmpty ? .tertiary : .primary)
+                                .lineLimit(5)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            HStack {
+                                Button("편집") { showMemoryEditor = true }
+                                if !memory.isEmpty {
+                                    Button("초기화", role: .destructive) { contextService.saveMemory("") }
                                 }
                                 Spacer()
-                                Button {
-                                    editingUserMemoryProfile = profile
-                                } label: {
-                                    Image(systemName: "brain")
-                                        .font(.caption)
-                                }
-                                .buttonStyle(.borderless)
-                                .help("개인 기억 편집")
-                                Button(role: .destructive) {
-                                    deleteProfile(profile)
-                                } label: {
-                                    Image(systemName: "trash")
-                                        .font(.caption)
-                                }
-                                .buttonStyle(.borderless)
+                                Text("\(contextService.memorySize / 1024)KB / \(viewModel.settings.contextMaxSize / 1024)KB")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
                             }
                         }
-
-                        Picker("기본 사용자", selection: defaultUserBinding) {
-                            Text("없음").tag(nil as UUID?)
-                            ForEach(profiles) { profile in
-                                Text(profile.name).tag(profile.id as UUID?)
-                            }
-                        }
-
-                        Button {
-                            showFamilyMemoryEditor = true
-                        } label: {
+                        Toggle("자동 압축", isOn: $viewModel.settings.contextAutoCompress)
+                        if viewModel.settings.contextAutoCompress {
                             HStack {
-                                Image(systemName: "house")
-                                Text("가족 공유 기억 편집")
+                                Text("최대 크기")
+                                Slider(value: contextMaxSizeBinding, in: 5...50, step: 5)
+                                Text("\(viewModel.settings.contextMaxSize / 1024)KB")
+                                    .font(.caption.monospacedDigit())
+                                    .frame(width: 40)
                             }
                         }
                     }
 
-                    Button {
-                        showAddProfile = true
-                    } label: {
-                        Label("구성원 추가", systemImage: "plus.circle")
-                    }
-                }
-
-                // MARK: - MCP Servers
-                SectionHeader("Tools & MCP")
-                Section("MCP 서버") {
-                    if viewModel.settings.mcpServers.isEmpty {
-                        Text("등록된 MCP 서버가 없습니다.")
-                            .foregroundStyle(.tertiary)
-                    } else {
-                        ForEach(viewModel.settings.mcpServers) { server in
-                            MCPServerRow(
-                                server: server,
-                                isConnected: viewModel.mcpService.connectedServers[server.id] != nil,
-                                onToggle: { enabled in
-                                    var updated = server
-                                    updated.isEnabled = enabled
-                                    viewModel.settings.updateMCPServer(updated)
-                                    if enabled {
-                                        Task {
-                                            do {
-                                                try await viewModel.mcpService.connect(config: updated)
-                                            } catch {
-                                                Log.mcp.error("MCP 서버 연결 실패 (\(updated.name, privacy: .public)): \(error, privacy: .public)")
+                    // Profiles
+                    SectionCard("가족 구성원", icon: "person.2") {
+                        let profiles = contextService.loadProfiles()
+                        if profiles.isEmpty {
+                            Text("가족 구성원을 추가하면 사용자별 기억이 분리됩니다.")
+                                .compact(AppFont.caption)
+                                .foregroundStyle(.tertiary)
+                        } else {
+                            ForEach(profiles) { profile in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        HStack(spacing: 6) {
+                                            Text(profile.name).font(.body)
+                                            if viewModel.settings.defaultUserId == profile.id {
+                                                Text("기본")
+                                                    .font(.caption2)
+                                                    .padding(.horizontal, 4)
+                                                    .padding(.vertical, 1)
+                                                    .background(.blue.opacity(0.15), in: Capsule())
+                                                    .foregroundStyle(.blue)
                                             }
                                         }
-                                    } else {
-                                        Task {
-                                            await viewModel.mcpService.disconnect(serverId: server.id)
+                                        if !profile.aliases.isEmpty {
+                                            Text("별칭: \(profile.aliases.joined(separator: ", "))").font(.caption).foregroundStyle(.secondary)
+                                        }
+                                        if !profile.description.isEmpty {
+                                            Text(profile.description).font(.caption).foregroundStyle(.secondary)
                                         }
                                     }
-                                },
-                                onDelete: {
-                                    Task {
-                                        await viewModel.mcpService.disconnect(serverId: server.id)
-                                    }
-                                    viewModel.settings.removeMCPServer(id: server.id)
+                                    Spacer()
+                                    Button { editingUserMemoryProfile = profile } label: { Image(systemName: "brain").font(.caption) }
+                                        .buttonStyle(.borderless)
+                                        .help("개인 기억 편집")
+                                    Button(role: .destructive) { deleteProfile(profile) } label: { Image(systemName: "trash").font(.caption) }
+                                        .buttonStyle(.borderless)
                                 }
-                            )
+                            }
+
+                            Picker("기본 사용자", selection: defaultUserBinding) {
+                                Text("없음").tag(nil as UUID?)
+                                ForEach(profiles) { profile in Text(profile.name).tag(profile.id as UUID?) }
+                            }
+
+                            Button { showFamilyMemoryEditor = true } label: {
+                                HStack { Image(systemName: "house"); Text("가족 공유 기억 편집") }
+                            }
                         }
-                    }
-                    Button {
-                        showAddMCPServer = true
-                    } label: {
-                        Label("서버 추가", systemImage: "plus.circle")
+
+                        Button { showAddProfile = true } label: { Label("구성원 추가", systemImage: "plus.circle") }
                     }
 
-                    if !viewModel.mcpService.availableTools.isEmpty {
-                        DisclosureGroup("사용 가능한 도구 (\(viewModel.mcpService.availableTools.count)개)") {
-                            ForEach(viewModel.mcpService.availableTools) { tool in
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(tool.name)
-                                        .font(.body.monospaced())
-                                    if let desc = tool.description {
-                                        Text(desc)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                            .lineLimit(2)
+                    // Tools & MCP
+                    SectionCard("MCP 서버", icon: "shippingbox") {
+                        if viewModel.settings.mcpServers.isEmpty {
+                            Text("등록된 MCP 서버가 없습니다.").foregroundStyle(.tertiary)
+                        } else {
+                            ForEach(viewModel.settings.mcpServers) { server in
+                                MCPServerRow(
+                                    server: server,
+                                    isConnected: viewModel.mcpService.connectedServers[server.id] != nil,
+                                    onToggle: { enabled in
+                                        var updated = server
+                                        updated.isEnabled = enabled
+                                        viewModel.settings.updateMCPServer(updated)
+                                        if enabled {
+                                            Task { do { try await viewModel.mcpService.connect(config: updated) } catch { Log.mcp.error("MCP 서버 연결 실패 (\(updated.name, privacy: .public)): \(error, privacy: .public)") } }
+                                        } else {
+                                            Task { await viewModel.mcpService.disconnect(serverId: server.id) }
+                                        }
+                                    },
+                                    onDelete: {
+                                        Task { await viewModel.mcpService.disconnect(serverId: server.id) }
+                                        viewModel.settings.removeMCPServer(id: server.id)
                                     }
+                                )
+                            }
+                        }
+                        Button { showAddMCPServer = true } label: { Label("서버 추가", systemImage: "plus.circle") }
+                        if !viewModel.mcpService.availableTools.isEmpty {
+                            DisclosureGroup("사용 가능한 도구 (\(viewModel.mcpService.availableTools.count)개)") {
+                                ForEach(viewModel.mcpService.availableTools) { tool in
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(tool.name).font(.body.monospaced())
+                                        if let desc = tool.description { Text(desc).font(.caption).foregroundStyle(.secondary).lineLimit(2) }
+                                    }
+                                    .padding(.vertical, 2)
                                 }
-                                .padding(.vertical, 2)
                             }
                         }
                     }
-                }
 
-                // MARK: - Wake Word
-                Section("웨이크워드") {
-                    Toggle("웨이크워드 활성화", isOn: wakeWordBinding)
-                    if viewModel.settings.wakeWordEnabled {
-                        HStack {
-                            Text("웨이크워드")
-                            Spacer()
-                            TextField("웨이크워드", text: $viewModel.settings.wakeWord)
-                                .textFieldStyle(.roundedBorder)
-                                .frame(width: 150)
-                        }
-                    }
-                }
-
-                // MARK: - Cloud
-                if let supabase = viewModel.supabaseServiceForView {
-                    CloudSettingsView(supabaseService: supabase)
-                }
-
-                if case .signedIn = viewModel.supabaseService.authState,
-                   let device = viewModel.deviceServiceForView {
-                    DeviceSettingsView(deviceService: device)
-                }
-
-                // MARK: - Messenger
-                Section("메신저") {
-                    Toggle("텔레그램 봇 활성화", isOn: $viewModel.settings.telegramEnabled)
-                        .accessibilityIdentifier("integrations.telegram.toggle")
-                    Toggle("텔레그램 스트리밍 응답 사용", isOn: $viewModel.settings.telegramStreamReplies)
-                        .accessibilityIdentifier("integrations.telegram.streaming")
-                    SecureField("Telegram Bot Token", text: Binding(
-                        get: { viewModel.settings.telegramBotToken },
-                        set: { viewModel.settings.telegramBotToken = $0 }
-                    ))
-                    .accessibilityIdentifier("integrations.telegram.token")
-                    HStack {
-                        Button("연결 테스트") {
-                            Task {
-                                if viewModel.settings.telegramBotToken.isEmpty { return }
-                                let svc = TelegramService(conversationService: ConversationService())
-                                do {
-                                    let name = try await svc.getMe(token: viewModel.settings.telegramBotToken)
-                                    Log.telegram.info("봇 확인: @\(name)")
-                                } catch {
-                                    Log.telegram.error("봇 확인 실패: \(error.localizedDescription, privacy: .public)")
-                                }
+                    // Wake Word
+                    SectionCard("웨이크워드", icon: "ear") {
+                        Toggle("웨이크워드 활성화", isOn: wakeWordBinding)
+                        if viewModel.settings.wakeWordEnabled {
+                            HStack {
+                                Text("웨이크워드")
+                                Spacer()
+                                TextField("웨이크워드", text: $viewModel.settings.wakeWord)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 150)
                             }
                         }
-                        .disabled(viewModel.settings.telegramBotToken.isEmpty)
-                        Spacer()
-                        let running = viewModel.telegramService?.running == true
-                        Text(running ? "수신 대기 중" : (viewModel.settings.telegramEnabled ? "대기 중(락 대기)" : "비활성"))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .accessibilityIdentifier("integrations.telegram.status")
                     }
-                    if let err = viewModel.telegramService?.lastErrorMessage, !err.isEmpty {
-                        Text("최근 오류: \(err)")
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                    }
-                    if let t = viewModel.telegramService?.lastDMAt {
-                        Text("최근 DM: \(DateFormatter.localizedString(from: t, dateStyle: .short, timeStyle: .short))")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
 
-                // MARK: - Claude Code UI (Sandbox + External)
-                ClaudeUISettingsSection(viewModel: viewModel)
-
-                // MARK: - About
-                SectionHeader("About")
-                Section("정보") {
-                    HStack {
-                        Text("버전")
-                        Spacer()
-                        Text("v\(changelogService.currentVersion) (\(changelogService.currentBuild))")
-                            .foregroundStyle(.secondary)
+                    // Cloud
+                    if let supabase = viewModel.supabaseServiceForView {
+                        SectionCard(nil) { CloudSettingsView(supabaseService: supabase) }
                     }
-                    Button {
-                        showChangelog = true
-                    } label: {
+
+                    // Device
+                    if case .signedIn = viewModel.supabaseService.authState, let device = viewModel.deviceServiceForView {
+                        SectionCard(nil) { DeviceSettingsView(deviceService: device) }
+                    }
+
+                    // Messenger
+                    SectionCard("메신저", icon: "paperplane") {
+                        Toggle("텔레그램 봇 활성화", isOn: $viewModel.settings.telegramEnabled)
+                            .accessibilityIdentifier("integrations.telegram.toggle")
+                        Toggle("텔레그램 스트리밍 응답 사용", isOn: $viewModel.settings.telegramStreamReplies)
+                            .accessibilityIdentifier("integrations.telegram.streaming")
+                        SecureField("Telegram Bot Token", text: Binding(get: { viewModel.settings.telegramBotToken }, set: { viewModel.settings.telegramBotToken = $0 }))
+                            .accessibilityIdentifier("integrations.telegram.token")
                         HStack {
-                            Text("새로운 기능")
+                            Button("연결 테스트") {
+                                Task {
+                                    if viewModel.settings.telegramBotToken.isEmpty { return }
+                                    let svc = TelegramService(conversationService: ConversationService())
+                                    do { let name = try await svc.getMe(token: viewModel.settings.telegramBotToken); Log.telegram.info("봇 확인: @\(name)") }
+                                    catch { Log.telegram.error("봇 확인 실패: \(error.localizedDescription, privacy: .public)") }
+                                }
+                            }
+                            .disabled(viewModel.settings.telegramBotToken.isEmpty)
                             Spacer()
-                            Image(systemName: "chevron.right")
+                            let running = viewModel.telegramService?.running == true
+                            Text(running ? "수신 대기 중" : (viewModel.settings.telegramEnabled ? "대기 중(락 대기)" : "비활성"))
                                 .font(.caption)
-                                .foregroundStyle(.tertiary)
+                                .foregroundStyle(.secondary)
+                                .accessibilityIdentifier("integrations.telegram.status")
+                        }
+                        if let err = viewModel.telegramService?.lastErrorMessage, !err.isEmpty {
+                            Text("최근 오류: \(err)").font(.caption).foregroundStyle(.red)
+                        }
+                        if let t = viewModel.telegramService?.lastDMAt {
+                            Text("최근 DM: \(DateFormatter.localizedString(from: t, dateStyle: .short, timeStyle: .short))").font(.caption).foregroundStyle(.secondary)
                         }
                     }
-                    .buttonStyle(.plain)
+
+                    // Claude Code UI
+                    SectionCard(nil) { ClaudeUISettingsSection(viewModel: viewModel) }
+
+                    // About
+                    SectionCard("정보", icon: "info.circle") {
+                        HStack {
+                            Text("버전")
+                            Spacer()
+                            Text("v\(changelogService.currentVersion) (\(changelogService.currentBuild))")
+                                .foregroundStyle(.secondary)
+                        }
+                        Button { showChangelog = true } label: {
+                            HStack {
+                                Text("새로운 기능")
+                                Spacer()
+                                Image(systemName: "chevron.right").font(.caption).foregroundStyle(.tertiary)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
+                .padding(AppSpacing.m)
             }
-            .formStyle(.grouped)
         }
         .frame(width: 500, height: 750)
+        .background(.ultraThinMaterial)
         .onAppear {
             openaiKey = viewModel.settings.apiKey
             anthropicKey = viewModel.settings.anthropicApiKey
@@ -674,7 +592,7 @@ private struct ClaudeUISettingsSection: View {
     @State private var busy: Bool = false
 
     var body: some View {
-        Section("Claude Code UI") {
+        VStack(alignment: .leading, spacing: 8) {
             Toggle("샌드박스 모드(launchd)", isOn: $viewModel.settings.claudeUISandboxEnabled)
                 .onChange(of: viewModel.settings.claudeUISandboxEnabled) { _, newValue in
                     Task { await onSandboxToggle(newValue) }


### PR DESCRIPTION
- Replace right inspector with left accordion (Home removed; focus on Chats/Agents/Memory/Tools/Cloud/Devices)
- New AppToolbar (1-line, glass, agent/model/workspace + alarms inline)
- Sidebar uses regular panel tone (no cards), top overlap fixed
- Tools section: full catalog with enable toggles; MCP count summary
- Settings: glass cards, density switch (compact/basic) applied across UI
- Conversation: spacing and side spacers density-aware; header spacing fixed
- Window style: hidden title bar + unified compact toolbar

Notes:
- ActiveAlarmsBar removed; alarms shown inline in AppToolbar
- Kept existing accessibility IDs where present