### PR TITLE
feat: 에이전트별 모델 라우팅 (#61)

### DIFF
--- a/Dochi/Models/LLMProvider.swift
+++ b/Dochi/Models/LLMProvider.swift
@@ -33,6 +33,11 @@ enum LLMProvider: String, Codable, CaseIterable, Sendable {
         rawValue
     }
 
+    /// Find the provider that offers a given model name, or nil if unknown.
+    static func provider(forModel model: String) -> LLMProvider? {
+        allCases.first { $0.models.contains(model) }
+    }
+
     /// Context window size (max input tokens) per model.
     func contextWindowTokens(for model: String) -> Int {
         switch self {

--- a/Dochi/Services/LLM/ModelRouter.swift
+++ b/Dochi/Services/LLM/ModelRouter.swift
@@ -20,8 +20,20 @@ struct ModelRouter {
         self.keychainService = keychainService
     }
 
-    /// Resolve the primary model from current settings.
-    func resolvePrimary() -> ResolvedModel? {
+    /// Resolve the primary model from current settings, optionally overridden by agent config.
+    func resolvePrimary(agentConfig: AgentConfig? = nil) -> ResolvedModel? {
+        // Check agent-level model override
+        if let agentModel = agentConfig?.defaultModel, !agentModel.isEmpty,
+           let agentProvider = LLMProvider.provider(forModel: agentModel) {
+            if let apiKey = keychainService.load(account: agentProvider.keychainAccount),
+               !apiKey.isEmpty {
+                Log.llm.info("Using agent model: \(agentProvider.displayName)/\(agentModel)")
+                return ResolvedModel(provider: agentProvider, model: agentModel, apiKey: apiKey, isFallback: false)
+            }
+            Log.llm.warning("Agent model \(agentModel) configured but no API key for \(agentProvider.displayName), falling back to app settings")
+        }
+
+        // Fall back to app-level settings
         let provider = settings.currentProvider
         let model = settings.llmModel
         guard let apiKey = keychainService.load(account: provider.keychainAccount),

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -656,9 +656,13 @@ final class DochiViewModel {
         let systemPrompt = composeSystemPrompt()
         let messages = prepareMessages(from: conversation)
 
-        // Resolve model
+        // Resolve model (agent config applies to Telegram too)
         let router = ModelRouter(settings: settings, keychainService: keychainService)
-        guard let model = router.resolvePrimary() else {
+        let telegramAgentConfig = contextService.loadAgentConfig(
+            workspaceId: sessionContext.workspaceId,
+            agentName: settings.activeAgentName
+        )
+        guard let model = router.resolvePrimary(agentConfig: telegramAgentConfig) else {
             Log.telegram.error("No API key configured for Telegram response")
             return
         }
@@ -798,7 +802,11 @@ final class DochiViewModel {
 
         // Resolve model via router (primary + optional fallback)
         let router = ModelRouter(settings: settings, keychainService: keychainService)
-        guard let primaryModel = router.resolvePrimary() else {
+        let agentConfig = contextService.loadAgentConfig(
+            workspaceId: sessionContext.workspaceId,
+            agentName: settings.activeAgentName
+        )
+        guard let primaryModel = router.resolvePrimary(agentConfig: agentConfig) else {
             handleError(LLMError.noAPIKey)
             return
         }


### PR DESCRIPTION
## Summary
- `ModelRouter.resolvePrimary()`가 `AgentConfig.defaultModel`을 우선 사용하도록 변경
- 에이전트에 모델이 설정되어 있으면 해당 프로바이더/모델을 자동으로 선택하고, API 키가 없거나 모델이 미설정이면 앱 기본 설정으로 폴백
- `LLMProvider.provider(forModel:)` 헬퍼 추가로 모델명에서 프로바이더 자동 추론

## Changes
- `Dochi/Models/LLMProvider.swift`: `provider(forModel:)` static 메서드 추가
- `Dochi/Services/LLM/ModelRouter.swift`: `resolvePrimary(agentConfig:)` 파라미터 추가, 에이전트 모델 우선 해석
- `Dochi/ViewModels/DochiViewModel.swift`: `processLLMLoop()`과 `handleTelegramMessage()`에서 현재 에이전트 설정을 로드하여 라우터에 전달
- `DochiTests/ModelTests.swift`: `LLMProvider.provider(forModel:)` 테스트 4개 + `ModelRouterTests` 7개 추가

## Test plan
- [x] `LLMProvider.provider(forModel:)` — OpenAI/Anthropic/Z.AI/unknown 모델 매핑 검증
- [x] `ModelRouter.resolvePrimary()` — 에이전트 설정 없이 기존 동작 유지
- [x] `ModelRouter.resolvePrimary(agentConfig:)` — 에이전트 모델 설정 시 해당 모델 사용
- [x] 에이전트 모델의 API 키 없을 때 앱 기본값으로 폴백
- [x] `defaultModel`이 nil/empty/unknown일 때 앱 기본값으로 폴백
- [x] 전체 테스트 159개 통과

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)