### PR TITLE
feat: 클립보드 도구 카테고리/baseline 조정 (#47)

### DIFF
--- a/Dochi/Services/Tools/BuiltInToolService.swift
+++ b/Dochi/Services/Tools/BuiltInToolService.swift
@@ -102,7 +102,7 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
         registry.register(TelegramGetMeTool(keychainService: keychainService, telegramService: telegramService, settings: settings))
         registry.register(TelegramSendMessageTool(keychainService: keychainService, telegramService: telegramService, settings: settings))
 
-        // Clipboard (baseline, safe)
+        // Clipboard (conditional: read=safe, write=sensitive)
         registry.register(ClipboardReadTool())
         registry.register(ClipboardWriteTool())
 

--- a/Dochi/Services/Tools/ClipboardTool.swift
+++ b/Dochi/Services/Tools/ClipboardTool.swift
@@ -8,7 +8,7 @@ final class ClipboardReadTool: BuiltInToolProtocol {
     let name = "clipboard.read"
     let category: ToolCategory = .safe
     let description = "클립보드(복사된 텍스트)를 읽어옵니다."
-    let isBaseline = true
+    let isBaseline = false
 
     var inputSchema: [String: Any] {
         [
@@ -32,9 +32,9 @@ final class ClipboardReadTool: BuiltInToolProtocol {
 @MainActor
 final class ClipboardWriteTool: BuiltInToolProtocol {
     let name = "clipboard.write"
-    let category: ToolCategory = .safe
+    let category: ToolCategory = .sensitive
     let description = "텍스트를 클립보드에 복사합니다."
-    let isBaseline = true
+    let isBaseline = false
 
     var inputSchema: [String: Any] {
         [

--- a/DochiTests/ClipboardToolTests.swift
+++ b/DochiTests/ClipboardToolTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class ClipboardToolTests: XCTestCase {
+
+    // MARK: - ClipboardReadTool Properties
+
+    func testReadToolName() {
+        let tool = ClipboardReadTool()
+        XCTAssertEqual(tool.name, "clipboard.read")
+    }
+
+    func testReadToolCategory() {
+        let tool = ClipboardReadTool()
+        XCTAssertEqual(tool.category, .safe)
+    }
+
+    func testReadToolIsNotBaseline() {
+        let tool = ClipboardReadTool()
+        XCTAssertFalse(tool.isBaseline)
+    }
+
+    func testReadToolHasDescription() {
+        let tool = ClipboardReadTool()
+        XCTAssertFalse(tool.description.isEmpty)
+    }
+
+    // MARK: - ClipboardWriteTool Properties
+
+    func testWriteToolName() {
+        let tool = ClipboardWriteTool()
+        XCTAssertEqual(tool.name, "clipboard.write")
+    }
+
+    func testWriteToolCategory() {
+        let tool = ClipboardWriteTool()
+        XCTAssertEqual(tool.category, .sensitive)
+    }
+
+    func testWriteToolIsNotBaseline() {
+        let tool = ClipboardWriteTool()
+        XCTAssertFalse(tool.isBaseline)
+    }
+
+    func testWriteToolHasDescription() {
+        let tool = ClipboardWriteTool()
+        XCTAssertFalse(tool.description.isEmpty)
+    }
+
+    func testWriteToolRequiresTextParameter() {
+        let tool = ClipboardWriteTool()
+        let required = tool.inputSchema["required"] as? [String]
+        XCTAssertEqual(required, ["text"])
+    }
+
+    // MARK: - ClipboardWriteTool Execution
+
+    func testWriteToolMissingTextReturnsError() async {
+        let tool = ClipboardWriteTool()
+        let result = await tool.execute(arguments: [:])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testWriteToolEmptyTextReturnsError() async {
+        let tool = ClipboardWriteTool()
+        let result = await tool.execute(arguments: ["text": ""])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testWriteToolSuccess() async {
+        let tool = ClipboardWriteTool()
+        let result = await tool.execute(arguments: ["text": "테스트 텍스트"])
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("복사"))
+    }
+
+    // MARK: - ClipboardReadTool Execution
+
+    func testReadToolAfterWrite() async {
+        // Write first
+        let writeTool = ClipboardWriteTool()
+        _ = await writeTool.execute(arguments: ["text": "읽기 테스트"])
+
+        // Then read
+        let readTool = ClipboardReadTool()
+        let result = await readTool.execute(arguments: [:])
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("읽기 테스트"))
+    }
+
+    // MARK: - Registry Integration
+
+    func testClipboardToolsAreNonBaseline() {
+        let registry = ToolRegistry()
+        registry.register(ClipboardReadTool())
+        registry.register(ClipboardWriteTool())
+
+        // Non-baseline tools should not appear in baseline list
+        let baseline = registry.baselineTools
+        let clipboardBaseline = baseline.filter { $0.name.hasPrefix("clipboard.") }
+        XCTAssertTrue(clipboardBaseline.isEmpty)
+    }
+
+    func testClipboardToolsNotAvailableWithoutEnable() {
+        let registry = ToolRegistry()
+        registry.register(ClipboardReadTool())
+        registry.register(ClipboardWriteTool())
+
+        // Without enable, non-baseline tools are not available
+        let available = registry.availableTools(for: ["safe", "sensitive"])
+        let clipboardAvailable = available.filter { $0.name.hasPrefix("clipboard.") }
+        XCTAssertTrue(clipboardAvailable.isEmpty)
+    }
+
+    func testClipboardToolsAvailableAfterEnable() {
+        let registry = ToolRegistry()
+        registry.register(ClipboardReadTool())
+        registry.register(ClipboardWriteTool())
+
+        registry.enable(names: ["clipboard.read", "clipboard.write"])
+
+        let available = registry.availableTools(for: ["safe", "sensitive"])
+        let clipboardAvailable = available.filter { $0.name.hasPrefix("clipboard.") }
+        XCTAssertEqual(clipboardAvailable.count, 2)
+    }
+
+    func testClipboardToolsAppearInNonBaselineSummaries() {
+        let registry = ToolRegistry()
+        registry.register(ClipboardReadTool())
+        registry.register(ClipboardWriteTool())
+
+        let summaries = registry.nonBaselineToolSummaries
+        let clipboardSummaries = summaries.filter { $0.name.hasPrefix("clipboard.") }
+        XCTAssertEqual(clipboardSummaries.count, 2)
+
+        let readSummary = clipboardSummaries.first { $0.name == "clipboard.read" }
+        XCTAssertEqual(readSummary?.category, .safe)
+
+        let writeSummary = clipboardSummaries.first { $0.name == "clipboard.write" }
+        XCTAssertEqual(writeSummary?.category, .sensitive)
+    }
+}


### PR DESCRIPTION
## Summary
- `clipboard.read`/`clipboard.write` 도구를 non-baseline으로 변경 (LLM이 `tools.enable`으로 활성화)
- `clipboard.write`의 카테고리를 `.safe` -> `.sensitive`로 변경 (사용자 확인 필요)
- 테스트 17개 추가

## Changes
- `Dochi/Services/Tools/ClipboardTool.swift`: `isBaseline = false`, `clipboard.write` 카테고리를 `.sensitive`로 변경
- `Dochi/Services/Tools/BuiltInToolService.swift`: 등록 주석 업데이트
- `DochiTests/ClipboardToolTests.swift`: 17개 테스트 (속성 검증, 실행 로직, 레지스트리 통합)

## Test plan
- [x] 도구 이름/카테고리/baseline 속성 검증
- [x] clipboard.write 필수 파라미터 누락/빈값 에러 처리
- [x] clipboard.write 성공 + clipboard.read 읽기 확인
- [x] non-baseline이므로 enable 전 사용 불가, enable 후 사용 가능
- [x] nonBaselineToolSummaries에 표시 확인
- [x] 전체 192개 테스트 통과

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)