### PR TITLE
feat: shell.execute 도구 — 블록리스트, 작업 디렉토리, Task.detached

### DIFF
--- a/Dochi/Services/Tools/ShellCommandTool.swift
+++ b/Dochi/Services/Tools/ShellCommandTool.swift
@@ -2,10 +2,28 @@ import Foundation
 
 @MainActor
 final class ShellCommandTool: BuiltInToolProtocol {
-    let name = "shell_command"
+    let name = "shell.execute"
     let category: ToolCategory = .restricted
     let description = "셸 명령을 실행합니다. 사용자 확인이 필요합니다."
     let isBaseline = false
+
+    private static let maxOutputSize = 8000
+    private static let defaultTimeout = 30
+
+    /// Commands/patterns that are too dangerous to execute.
+    static let blockedPatterns: [String] = [
+        "rm -rf /",
+        "rm -rf /*",
+        "sudo ",
+        "shutdown",
+        "reboot",
+        "mkfs",
+        "dd if=",
+        ":(){:|:&};:",
+        "chmod -R 777 /",
+        "mv /* ",
+        "> /dev/sda",
+    ]
 
     var inputSchema: [String: Any] {
         [
@@ -13,7 +31,8 @@ final class ShellCommandTool: BuiltInToolProtocol {
             "properties": [
                 "command": ["type": "string", "description": "실행할 셸 명령"],
                 "timeout": ["type": "integer", "description": "타임아웃 (초, 기본 30)"],
-            ],
+                "working_directory": ["type": "string", "description": "작업 디렉토리 (선택, 기본: 홈 디렉토리)"],
+            ] as [String: Any],
             "required": ["command"],
         ]
     }
@@ -23,55 +42,81 @@ final class ShellCommandTool: BuiltInToolProtocol {
             return ToolResult(toolCallId: "", content: "command 파라미터가 필요합니다.", isError: true)
         }
 
-        let timeout = arguments["timeout"] as? Int ?? 30
+        // Check blocklist
+        let lowered = command.lowercased()
+        for pattern in Self.blockedPatterns {
+            if lowered.contains(pattern) {
+                Log.tool.warning("Blocked dangerous command: \(command)")
+                return ToolResult(toolCallId: "", content: "위험한 명령이 차단되었습니다: \(pattern)", isError: true)
+            }
+        }
+
+        let timeout = arguments["timeout"] as? Int ?? Self.defaultTimeout
+        let workingDir: String?
+        if let dir = arguments["working_directory"] as? String, !dir.isEmpty {
+            let expanded = NSString(string: dir).expandingTildeInPath
+            guard FileManager.default.fileExists(atPath: expanded) else {
+                return ToolResult(toolCallId: "", content: "작업 디렉토리를 찾을 수 없습니다: \(dir)", isError: true)
+            }
+            workingDir = expanded
+        } else {
+            workingDir = nil
+        }
 
         do {
-            let result = try await runShell(command: command, timeout: TimeInterval(timeout))
+            let result = try await runShell(command: command, timeout: TimeInterval(timeout), workingDirectory: workingDir)
             let output = result.isEmpty ? "(출력 없음)" : result
-            let truncated = output.count > 8000 ? String(output.prefix(8000)) + "\n…(잘림)" : output
+            let truncated = output.count > Self.maxOutputSize
+                ? String(output.prefix(Self.maxOutputSize)) + "\n…(잘림)"
+                : output
             return ToolResult(toolCallId: "", content: "실행 결과:\n```\n\(truncated)\n```")
         } catch {
             return ToolResult(toolCallId: "", content: "명령 실행 실패: \(error.localizedDescription)", isError: true)
         }
     }
 
-    private func runShell(command: String, timeout: TimeInterval) async throws -> String {
+    private func runShell(command: String, timeout: TimeInterval, workingDirectory: String?) async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            process.arguments = ["-c", command]
-            process.environment = ProcessInfo.processInfo.environment
-
-            let pipe = Pipe()
-            let errPipe = Pipe()
-            process.standardOutput = pipe
-            process.standardError = errPipe
-
-            let timeoutItem = DispatchWorkItem {
-                if process.isRunning { process.terminate() }
-            }
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
-
-            do {
-                try process.run()
-                process.waitUntilExit()
-                timeoutItem.cancel()
-
-                let stdout = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-                let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-
-                let exitCode = process.terminationStatus
-                var result = stdout
-                if !stderr.isEmpty {
-                    result += (result.isEmpty ? "" : "\n") + "stderr: " + stderr
+            Task.detached {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+                process.arguments = ["-c", command]
+                process.environment = ProcessInfo.processInfo.environment
+                if let dir = workingDirectory {
+                    process.currentDirectoryURL = URL(fileURLWithPath: dir)
                 }
-                if exitCode != 0 {
-                    result += "\n(exit code: \(exitCode))"
+
+                let pipe = Pipe()
+                let errPipe = Pipe()
+                process.standardOutput = pipe
+                process.standardError = errPipe
+
+                let timeoutItem = DispatchWorkItem {
+                    if process.isRunning { process.terminate() }
                 }
-                continuation.resume(returning: result)
-            } catch {
-                timeoutItem.cancel()
-                continuation.resume(throwing: error)
+                DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: timeoutItem)
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    timeoutItem.cancel()
+
+                    let stdout = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                    let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+
+                    let exitCode = process.terminationStatus
+                    var result = stdout
+                    if !stderr.isEmpty {
+                        result += (result.isEmpty ? "" : "\n") + "stderr: " + stderr
+                    }
+                    if exitCode != 0 {
+                        result += "\n(exit code: \(exitCode))"
+                    }
+                    continuation.resume(returning: result)
+                } catch {
+                    timeoutItem.cancel()
+                    continuation.resume(throwing: error)
+                }
             }
         }
     }

--- a/DochiTests/ShellToolTests.swift
+++ b/DochiTests/ShellToolTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class ShellToolTests: XCTestCase {
+
+    // MARK: - Properties
+
+    func testToolName() {
+        let tool = ShellCommandTool()
+        XCTAssertEqual(tool.name, "shell.execute")
+    }
+
+    func testToolCategory() {
+        let tool = ShellCommandTool()
+        XCTAssertEqual(tool.category, .restricted)
+    }
+
+    func testToolIsNotBaseline() {
+        let tool = ShellCommandTool()
+        XCTAssertFalse(tool.isBaseline)
+    }
+
+    func testToolHasDescription() {
+        let tool = ShellCommandTool()
+        XCTAssertFalse(tool.description.isEmpty)
+    }
+
+    // MARK: - Input Schema
+
+    func testInputSchemaRequiresCommand() {
+        let tool = ShellCommandTool()
+        let required = tool.inputSchema["required"] as? [String]
+        XCTAssertEqual(required, ["command"])
+    }
+
+    func testInputSchemaHasTimeoutProperty() {
+        let tool = ShellCommandTool()
+        let properties = tool.inputSchema["properties"] as? [String: Any]
+        XCTAssertNotNil(properties?["timeout"])
+    }
+
+    func testInputSchemaHasWorkingDirectoryProperty() {
+        let tool = ShellCommandTool()
+        let properties = tool.inputSchema["properties"] as? [String: Any]
+        XCTAssertNotNil(properties?["working_directory"])
+    }
+
+    // MARK: - Parameter Validation
+
+    func testMissingCommandReturnsError() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: [:])
+        XCTAssertTrue(result.isError)
+        XCTAssertTrue(result.content.contains("command"))
+    }
+
+    func testEmptyCommandReturnsError() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": ""])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testInvalidWorkingDirectoryReturnsError() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: [
+            "command": "echo test",
+            "working_directory": "/nonexistent/dir",
+        ])
+        XCTAssertTrue(result.isError)
+        XCTAssertTrue(result.content.contains("작업 디렉토리"))
+    }
+
+    // MARK: - Blocked Commands
+
+    func testBlocksRmRfRoot() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "rm -rf /"])
+        XCTAssertTrue(result.isError)
+        XCTAssertTrue(result.content.contains("차단"))
+    }
+
+    func testBlocksSudo() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "sudo apt-get install something"])
+        XCTAssertTrue(result.isError)
+        XCTAssertTrue(result.content.contains("차단"))
+    }
+
+    func testBlocksShutdown() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "shutdown -h now"])
+        XCTAssertTrue(result.isError)
+        XCTAssertTrue(result.content.contains("차단"))
+    }
+
+    func testBlocksReboot() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "reboot"])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testBlocksMkfs() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "mkfs.ext4 /dev/sda1"])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testBlocksDd() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "dd if=/dev/zero of=/dev/sda"])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testBlocksForkBomb() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": ":(){:|:&};:"])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testBlocksCaseInsensitive() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "SUDO rm -rf /home"])
+        XCTAssertTrue(result.isError)
+    }
+
+    // MARK: - Execution
+
+    func testSimpleEcho() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "echo hello"])
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("hello"))
+    }
+
+    func testWorkingDirectory() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: [
+            "command": "pwd",
+            "working_directory": "/tmp",
+        ])
+        XCTAssertFalse(result.isError)
+        // /tmp may resolve to /private/tmp on macOS
+        XCTAssertTrue(result.content.contains("tmp"))
+    }
+
+    func testNonZeroExitCode() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "exit 42"])
+        XCTAssertFalse(result.isError) // Tool reports result, not error
+        XCTAssertTrue(result.content.contains("exit code: 42"))
+    }
+
+    func testStderrCapture() async {
+        let tool = ShellCommandTool()
+        let result = await tool.execute(arguments: ["command": "echo error_msg >&2"])
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("error_msg"))
+        XCTAssertTrue(result.content.contains("stderr"))
+    }
+
+    // MARK: - Blocked Patterns List
+
+    func testBlockedPatternsNotEmpty() {
+        XCTAssertFalse(ShellCommandTool.blockedPatterns.isEmpty)
+    }
+
+    // MARK: - Registry Integration
+
+    func testShellToolNotInBaseline() {
+        let registry = ToolRegistry()
+        registry.register(ShellCommandTool())
+        XCTAssertTrue(registry.baselineTools.isEmpty)
+    }
+
+    func testShellToolAvailableAfterEnable() {
+        let registry = ToolRegistry()
+        registry.register(ShellCommandTool())
+        registry.enable(names: ["shell.execute"])
+        let available = registry.availableTools(for: ["safe", "sensitive", "restricted"])
+        XCTAssertEqual(available.count, 1)
+        XCTAssertEqual(available[0].name, "shell.execute")
+    }
+}


### PR DESCRIPTION
## Summary

- `shell.execute` 도구 개선: restricted 카테고리, non-baseline
- 위험 명령어 블록리스트 11개 패턴 (rm -rf /, sudo, shutdown, reboot, mkfs, dd, fork bomb 등)
- 대소문자 무관 블록리스트 검사
- `working_directory` 파라미터 추가 (경로 존재 검증)
- `Task.detached`로 `Process.waitUntilExit()` 메인스레드 차단 방지
- timeout 파라미터 (기본 30초), 출력 크기 제한 (8000자)
- `ShellToolTests` 24개 테스트: 속성, 스키마, 파라미터 검증, 차단 명령어 8개, 실행 4개, 레지스트리 통합

## Test plan

- [x] 263개 전체 테스트 통과
- [x] ShellToolTests 24개 테스트 통과
- [x] 위험 명령어 차단 검증 (rm -rf, sudo, shutdown, reboot, mkfs, dd, fork bomb, 대소문자)
- [x] 정상 명령어 실행 검증 (echo, pwd, exit code, stderr 캡처)
- [x] 파라미터 검증 (누락, 빈 값, 잘못된 작업 디렉토리)
- [x] 레지스트리 통합 (baseline 제외, enable 후 사용 가능)

Closes #42