### PR TITLE
feat: Heartbeat 백그라운드 에이전트 강화

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -94,8 +94,11 @@ struct DochiApp: App {
 
         contextService.migrateIfNeeded()
 
-        heartbeatService.setProactiveHandler { message in
+        heartbeatService.configure(contextService: contextService, sessionContext: sessionContext)
+        heartbeatService.setProactiveHandler { [weak viewModel] message in
+            guard let viewModel else { return }
             Log.app.info("Heartbeat proactive message: \(message)")
+            viewModel.injectProactiveMessage(message)
         }
 
         // Start Telegram polling if enabled
@@ -205,7 +208,8 @@ struct DochiApp: App {
                 telegramService: telegramService,
                 mcpService: mcpService,
                 supabaseService: supabaseService,
-                toolService: toolService
+                toolService: toolService,
+                heartbeatService: heartbeatService
             )
         }
         .commands {

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -638,6 +638,19 @@ final class DochiViewModel {
         return stripped
     }
 
+    // MARK: - Proactive Message Injection
+
+    /// Inject a proactive message from the heartbeat service into the current conversation.
+    func injectProactiveMessage(_ message: String) {
+        guard var conversation = currentConversation else { return }
+        let systemMessage = Message(role: .assistant, content: message)
+        conversation.messages.append(systemMessage)
+        conversation.updatedAt = Date()
+        currentConversation = conversation
+        conversationService.save(conversation: conversation)
+        Log.app.info("Injected proactive message into conversation")
+    }
+
     // MARK: - Telegram Message Handling
 
     func handleTelegramMessage(_ update: TelegramUpdate) async {

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -10,10 +10,11 @@ struct SettingsView: View {
     var mcpService: MCPServiceProtocol?
     var supabaseService: SupabaseServiceProtocol?
     var toolService: BuiltInToolService?
+    var heartbeatService: HeartbeatService?
 
     var body: some View {
         TabView {
-            GeneralSettingsView(settings: settings)
+            GeneralSettingsView(settings: settings, heartbeatService: heartbeatService)
                 .tabItem {
                     Label("일반", systemImage: "gear")
                 }
@@ -86,6 +87,7 @@ struct SettingsView: View {
 
 struct GeneralSettingsView: View {
     var settings: AppSettings
+    var heartbeatService: HeartbeatService?
 
     var body: some View {
         Form {
@@ -205,6 +207,64 @@ struct GeneralSettingsView: View {
                     ),
                     in: 0...23
                 )
+            }
+
+            if let heartbeatService {
+                Section("하트비트 상태") {
+                    if let lastTick = heartbeatService.lastTickDate {
+                        HStack {
+                            Text("마지막 실행")
+                            Spacer()
+                            Text(lastTick, style: .relative)
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Text("아직 실행되지 않음")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let result = heartbeatService.lastTickResult {
+                        HStack {
+                            Text("점검 항목")
+                            Spacer()
+                            Text(result.checksPerformed.joined(separator: ", "))
+                                .foregroundStyle(.secondary)
+                                .font(.caption)
+                        }
+                        HStack {
+                            Text("발견 항목")
+                            Spacer()
+                            Text("\(result.itemsFound)건")
+                                .foregroundStyle(result.itemsFound > 0 ? .primary : .secondary)
+                        }
+                        if result.notificationSent {
+                            Text("알림 전송됨")
+                                .foregroundStyle(.green)
+                                .font(.caption)
+                        }
+                        if let error = result.error {
+                            Text("오류: \(error)")
+                                .foregroundStyle(.red)
+                                .font(.caption)
+                        }
+                    }
+
+                    HStack {
+                        Text("실행 이력")
+                        Spacer()
+                        Text("\(heartbeatService.tickHistory.count)건")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if heartbeatService.consecutiveErrors > 0 {
+                        HStack {
+                            Text("연속 오류")
+                            Spacer()
+                            Text("\(heartbeatService.consecutiveErrors)회")
+                                .foregroundStyle(.red)
+                        }
+                    }
+                }
             }
         }
         .formStyle(.grouped)

--- a/DochiTests/HeartbeatServiceTests.swift
+++ b/DochiTests/HeartbeatServiceTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class HeartbeatServiceTests: XCTestCase {
+
+    // MARK: - HeartbeatTickResult
+
+    func testTickResultStoresAllFields() {
+        let result = HeartbeatTickResult(
+            timestamp: Date(),
+            checksPerformed: ["calendar", "kanban"],
+            itemsFound: 3,
+            notificationSent: true,
+            error: nil
+        )
+        XCTAssertEqual(result.checksPerformed.count, 2)
+        XCTAssertEqual(result.itemsFound, 3)
+        XCTAssertTrue(result.notificationSent)
+        XCTAssertNil(result.error)
+    }
+
+    func testTickResultWithError() {
+        let result = HeartbeatTickResult(
+            timestamp: Date(),
+            checksPerformed: [],
+            itemsFound: 0,
+            notificationSent: false,
+            error: "Test error"
+        )
+        XCTAssertEqual(result.error, "Test error")
+        XCTAssertFalse(result.notificationSent)
+    }
+
+    // MARK: - HeartbeatService Init
+
+    func testServiceInitialization() {
+        let settings = AppSettings()
+        let service = HeartbeatService(settings: settings)
+        XCTAssertNil(service.lastTickDate)
+        XCTAssertNil(service.lastTickResult)
+        XCTAssertTrue(service.tickHistory.isEmpty)
+        XCTAssertEqual(service.consecutiveErrors, 0)
+    }
+
+    func testMaxHistoryCount() {
+        XCTAssertEqual(HeartbeatService.maxHistoryCount, 20)
+    }
+
+    // MARK: - Start/Stop
+
+    func testStartWithDisabledSettingsDoesNothing() {
+        let settings = AppSettings()
+        settings.heartbeatEnabled = false
+        let service = HeartbeatService(settings: settings)
+        service.start()
+        // Should not crash, no tick should happen
+        XCTAssertNil(service.lastTickDate)
+    }
+
+    func testStopIsIdempotent() {
+        let settings = AppSettings()
+        let service = HeartbeatService(settings: settings)
+        service.stop()
+        service.stop() // Should not crash
+        XCTAssertNil(service.lastTickDate)
+    }
+
+    func testRestartCyclesCleanly() {
+        let settings = AppSettings()
+        settings.heartbeatEnabled = false
+        let service = HeartbeatService(settings: settings)
+        service.restart()
+        service.restart()
+        XCTAssertNil(service.lastTickDate)
+    }
+
+    // MARK: - Configure
+
+    func testConfigureAcceptsDependencies() {
+        let settings = AppSettings()
+        let service = HeartbeatService(settings: settings)
+        let contextService = MockContextService()
+        let sessionContext = SessionContext(workspaceId: UUID())
+        service.configure(contextService: contextService, sessionContext: sessionContext)
+        // Should not crash
+    }
+
+    // MARK: - Proactive Handler
+
+    func testProactiveHandlerIsCalled() {
+        let settings = AppSettings()
+        let service = HeartbeatService(settings: settings)
+
+        var receivedMessage: String?
+        service.setProactiveHandler { message in
+            receivedMessage = message
+        }
+
+        // Directly verify handler is set by replacing it
+        service.setProactiveHandler { message in
+            receivedMessage = message
+        }
+        XCTAssertNil(receivedMessage) // Not called yet
+    }
+
+    // MARK: - ViewModel integration
+
+    func testInjectProactiveMessageAddsToConversation() {
+        let contextService = MockContextService()
+        let settings = AppSettings()
+        let keychainService = MockKeychainService()
+        keychainService.store["openai_api_key"] = "sk-test"
+        let sessionContext = SessionContext(workspaceId: UUID())
+
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: contextService,
+            conversationService: MockConversationService(),
+            keychainService: keychainService,
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: sessionContext
+        )
+
+        // Create a conversation manually (newConversation() sets it to nil)
+        viewModel.currentConversation = Conversation(title: "테스트")
+        XCTAssertNotNil(viewModel.currentConversation)
+
+        let messageBefore = viewModel.currentConversation?.messages.count ?? 0
+        viewModel.injectProactiveMessage("테스트 알림")
+        let messageAfter = viewModel.currentConversation?.messages.count ?? 0
+
+        XCTAssertEqual(messageAfter, messageBefore + 1)
+        XCTAssertEqual(viewModel.currentConversation?.messages.last?.content, "테스트 알림")
+        XCTAssertEqual(viewModel.currentConversation?.messages.last?.role, .assistant)
+    }
+
+    func testInjectProactiveMessageWithNoConversationDoesNothing() {
+        let settings = AppSettings()
+        let keychainService = MockKeychainService()
+        keychainService.store["openai_api_key"] = "sk-test"
+
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: keychainService,
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: SessionContext(workspaceId: UUID())
+        )
+
+        // Don't create a conversation
+        viewModel.injectProactiveMessage("no conversation")
+        // Should not crash
+        XCTAssertNil(viewModel.currentConversation)
+    }
+}


### PR DESCRIPTION
## Summary
- 실행 이력 추적: `HeartbeatTickResult` 구조체, `tickHistory` 최근 20건 보관
- 메모리 크기 점검: 워크스페이스/에이전트 메모리 3000자 초과 시 경고
- ViewModel 통합: 프로액티브 메시지가 현재 대화에 assistant 메시지로 삽입
- 연속 오류 카운터: `consecutiveErrors` 추적
- 설정 UI: 하트비트 상태 섹션 (마지막 실행, 점검 항목, 발견 항목, 이력 수, 오류)

Closes #14

## Test plan
- [x] HeartbeatTickResult 필드 검증
- [x] HeartbeatService 초기화 상태 검증
- [x] start/stop/restart 안전성
- [x] configure 의존성 주입
- [x] injectProactiveMessage 대화 삽입 확인
- [x] 대화 없이 inject 시 안전 처리
- [x] 전체 테스트 스위트 306건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)