### PR TITLE
feat: 디바이스 멀티 워크스페이스 등록 + 하트비트

### DIFF
--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -90,6 +90,10 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(currentWorkspaceId, forKey: "currentWorkspaceId") }
     }
 
+    var deviceId: String = UserDefaults.standard.string(forKey: "deviceId") ?? "" {
+        didSet { UserDefaults.standard.set(deviceId, forKey: "deviceId") }
+    }
+
     var hasSeenPermissionInfo: Bool = UserDefaults.standard.object(forKey: "hasSeenPermissionInfo") as? Bool ?? false {
         didSet { UserDefaults.standard.set(hasSeenPermissionInfo, forKey: "hasSeenPermissionInfo") }
     }

--- a/Dochi/Services/Cloud/DeviceHeartbeatService.swift
+++ b/Dochi/Services/Cloud/DeviceHeartbeatService.swift
@@ -1,0 +1,83 @@
+import Foundation
+import os
+
+/// Manages device registration and periodic heartbeat pings to Supabase.
+/// Sends a heartbeat every 30 seconds to keep the device marked as online.
+@MainActor
+final class DeviceHeartbeatService {
+    private let supabaseService: SupabaseServiceProtocol
+    private let settings: AppSettings
+
+    private var heartbeatTask: Task<Void, Never>?
+    private(set) var currentDeviceId: UUID?
+    private(set) var isRunning = false
+
+    static let heartbeatIntervalSeconds: Int = 30
+
+    init(supabaseService: SupabaseServiceProtocol, settings: AppSettings) {
+        self.supabaseService = supabaseService
+        self.settings = settings
+    }
+
+    /// Register this device and start sending heartbeats.
+    func startHeartbeat(workspaceIds: [UUID]) async {
+        guard supabaseService.isConfigured, supabaseService.authState.userId != nil else {
+            Log.cloud.debug("DeviceHeartbeat: skipping — not configured or not signed in")
+            return
+        }
+
+        // Register the device
+        let deviceName = Host.current().localizedName ?? "Mac"
+        do {
+            let device = try await supabaseService.registerDevice(
+                name: deviceName,
+                workspaceIds: workspaceIds
+            )
+            currentDeviceId = device.id
+            settings.deviceId = device.id.uuidString
+            Log.cloud.info("Device registered: \(deviceName) (\(device.id))")
+        } catch {
+            Log.cloud.error("Device registration failed: \(error.localizedDescription)")
+            return
+        }
+
+        isRunning = true
+        heartbeatTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(Self.heartbeatIntervalSeconds))
+                guard !Task.isCancelled else { break }
+                await self?.sendHeartbeat()
+            }
+        }
+    }
+
+    /// Stop sending heartbeats.
+    func stopHeartbeat() {
+        heartbeatTask?.cancel()
+        heartbeatTask = nil
+        isRunning = false
+        Log.cloud.info("DeviceHeartbeat stopped")
+    }
+
+    /// Update this device's workspace list.
+    func updateWorkspaces(_ workspaceIds: [UUID]) async {
+        guard let deviceId = currentDeviceId else { return }
+        do {
+            try await supabaseService.updateDeviceWorkspaces(
+                deviceId: deviceId,
+                workspaceIds: workspaceIds
+            )
+        } catch {
+            Log.cloud.error("Failed to update device workspaces: \(error.localizedDescription)")
+        }
+    }
+
+    private func sendHeartbeat() async {
+        guard let deviceId = currentDeviceId else { return }
+        do {
+            try await supabaseService.updateDeviceHeartbeat(deviceId: deviceId)
+        } catch {
+            Log.cloud.warning("Device heartbeat failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Dochi/Services/Protocols/SupabaseServiceProtocol.swift
+++ b/Dochi/Services/Protocols/SupabaseServiceProtocol.swift
@@ -21,6 +21,13 @@ protocol SupabaseServiceProtocol {
     func listWorkspaces() async throws -> [Workspace]
     func regenerateInviteCode(workspaceId: UUID) async throws -> String
 
+    // Devices
+    func registerDevice(name: String, workspaceIds: [UUID]) async throws -> Device
+    func updateDeviceHeartbeat(deviceId: UUID) async throws
+    func updateDeviceWorkspaces(deviceId: UUID, workspaceIds: [UUID]) async throws
+    func listDevices() async throws -> [Device]
+    func removeDevice(id: UUID) async throws
+
     // Sync
     func syncContext() async throws
     func syncConversations() async throws

--- a/DochiTests/DeviceRegistrationTests.swift
+++ b/DochiTests/DeviceRegistrationTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class DeviceRegistrationTests: XCTestCase {
+
+    // MARK: - Device Model
+
+    func testDeviceDefaultValues() {
+        let device = Device(userId: UUID(), name: "Test Mac")
+        XCTAssertEqual(device.platform, "macos")
+        XCTAssertTrue(device.workspaceIds.isEmpty)
+        XCTAssertTrue(device.isOnline) // Just created, should be online
+    }
+
+    func testDeviceIsOfflineAfterTimeout() {
+        let device = Device(
+            userId: UUID(),
+            name: "Old Mac",
+            lastHeartbeat: Date().addingTimeInterval(-300) // 5 minutes ago
+        )
+        XCTAssertFalse(device.isOnline)
+    }
+
+    func testDeviceIsOnlineWithinThreshold() {
+        let device = Device(
+            userId: UUID(),
+            name: "Recent Mac",
+            lastHeartbeat: Date().addingTimeInterval(-60) // 1 minute ago
+        )
+        XCTAssertTrue(device.isOnline)
+    }
+
+    func testDeviceCodingKeys() throws {
+        let device = Device(
+            userId: UUID(),
+            name: "Encoded Mac",
+            workspaceIds: [UUID()]
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(device)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        XCTAssertNotNil(json["user_id"])
+        XCTAssertNotNil(json["last_heartbeat"])
+        XCTAssertNotNil(json["workspace_ids"])
+        XCTAssertNil(json["userId"]) // Should use snake_case
+    }
+
+    func testDeviceRoundTrip() throws {
+        let wsId = UUID()
+        let original = Device(
+            userId: UUID(),
+            name: "Roundtrip Mac",
+            workspaceIds: [wsId]
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Device.self, from: data)
+
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.userId, original.userId)
+        XCTAssertEqual(decoded.name, original.name)
+        XCTAssertEqual(decoded.platform, original.platform)
+        XCTAssertEqual(decoded.workspaceIds, [wsId])
+    }
+
+    // MARK: - MockSupabaseService Device Methods
+
+    func testMockRegisterDevice() async throws {
+        let mock = MockSupabaseService()
+        let device = try await mock.registerDevice(name: "Test", workspaceIds: [UUID()])
+        XCTAssertEqual(device.name, "Test")
+        XCTAssertEqual(mock.registeredDevices.count, 1)
+    }
+
+    func testMockUpdateHeartbeat() async throws {
+        let mock = MockSupabaseService()
+        let deviceId = UUID()
+        try await mock.updateDeviceHeartbeat(deviceId: deviceId)
+        XCTAssertEqual(mock.heartbeatCalls, [deviceId])
+    }
+
+    func testMockUpdateWorkspaces() async throws {
+        let mock = MockSupabaseService()
+        let device = try await mock.registerDevice(name: "Test", workspaceIds: [])
+        let wsId = UUID()
+        try await mock.updateDeviceWorkspaces(deviceId: device.id, workspaceIds: [wsId])
+        let updated = mock.registeredDevices.first(where: { $0.id == device.id })
+        XCTAssertEqual(updated?.workspaceIds, [wsId])
+    }
+
+    func testMockListDevices() async throws {
+        let mock = MockSupabaseService()
+        _ = try await mock.registerDevice(name: "A", workspaceIds: [])
+        _ = try await mock.registerDevice(name: "B", workspaceIds: [])
+        let devices = try await mock.listDevices()
+        XCTAssertEqual(devices.count, 2)
+    }
+
+    func testMockRemoveDevice() async throws {
+        let mock = MockSupabaseService()
+        let device = try await mock.registerDevice(name: "ToDelete", workspaceIds: [])
+        try await mock.removeDevice(id: device.id)
+        XCTAssertTrue(mock.removedDeviceIds.contains(device.id))
+        XCTAssertTrue(mock.registeredDevices.isEmpty)
+    }
+
+    // MARK: - DeviceHeartbeatService
+
+    func testHeartbeatServiceInit() {
+        let mock = MockSupabaseService()
+        let settings = AppSettings()
+        let service = DeviceHeartbeatService(supabaseService: mock, settings: settings)
+        XCTAssertNil(service.currentDeviceId)
+        XCTAssertFalse(service.isRunning)
+    }
+
+    func testHeartbeatStartRegistersDevice() async {
+        let mock = MockSupabaseService()
+        let settings = AppSettings()
+        let service = DeviceHeartbeatService(supabaseService: mock, settings: settings)
+
+        let wsId = UUID()
+        await service.startHeartbeat(workspaceIds: [wsId])
+
+        XCTAssertNotNil(service.currentDeviceId)
+        XCTAssertTrue(service.isRunning)
+        XCTAssertEqual(mock.registeredDevices.count, 1)
+        XCTAssertEqual(mock.registeredDevices.first?.workspaceIds, [wsId])
+
+        service.stopHeartbeat()
+        XCTAssertFalse(service.isRunning)
+    }
+
+    func testHeartbeatSkipsWhenNotConfigured() async {
+        let mock = MockSupabaseService()
+        mock.isConfigured = false
+        let settings = AppSettings()
+        let service = DeviceHeartbeatService(supabaseService: mock, settings: settings)
+
+        await service.startHeartbeat(workspaceIds: [])
+        XCTAssertNil(service.currentDeviceId)
+        XCTAssertFalse(service.isRunning)
+    }
+
+    func testHeartbeatSkipsWhenNotAuthenticated() async {
+        let mock = MockSupabaseService()
+        mock.authState = .signedOut
+        let settings = AppSettings()
+        let service = DeviceHeartbeatService(supabaseService: mock, settings: settings)
+
+        await service.startHeartbeat(workspaceIds: [])
+        XCTAssertNil(service.currentDeviceId)
+        XCTAssertFalse(service.isRunning)
+    }
+
+    func testHeartbeatUpdateWorkspaces() async {
+        let mock = MockSupabaseService()
+        let settings = AppSettings()
+        let service = DeviceHeartbeatService(supabaseService: mock, settings: settings)
+
+        await service.startHeartbeat(workspaceIds: [])
+        let newWsId = UUID()
+        await service.updateWorkspaces([newWsId])
+
+        let device = mock.registeredDevices.first(where: { $0.id == service.currentDeviceId })
+        XCTAssertEqual(device?.workspaceIds, [newWsId])
+
+        service.stopHeartbeat()
+    }
+
+    func testHeartbeatIntervalIs30Seconds() {
+        XCTAssertEqual(DeviceHeartbeatService.heartbeatIntervalSeconds, 30)
+    }
+
+    // MARK: - AppSettings deviceId
+
+    func testDeviceIdSetting() {
+        let settings = AppSettings()
+        XCTAssertEqual(settings.deviceId, UserDefaults.standard.string(forKey: "deviceId") ?? "")
+    }
+}


### PR DESCRIPTION
## Summary
- `SupabaseServiceProtocol`에 디바이스 CRUD 5개 메서드 추가
- `SupabaseService`에 Supabase devices 테이블 연동 구현
- `DeviceHeartbeatService`: 디바이스 등록 + 30초 주기 하트비트 ping
- `AppSettings.deviceId`: 등록된 디바이스 ID 영속화
- `MockSupabaseService` + 전체 디바이스/하트비트 테스트 17건

Closes #58

## Test plan
- [x] Device 모델 기본값, 온/오프라인 판정, CodingKeys, round-trip
- [x] MockSupabaseService 디바이스 CRUD 동작
- [x] DeviceHeartbeatService 초기화, 등록, 미인증 스킵, 미설정 스킵
- [x] 워크스페이스 갱신, 하트비트 주기 확인
- [x] 전체 테스트 스위트 323건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)