### PR TITLE
feat: 용도별 모델 라우팅 — 작업 복잡도 자동 선택

### DIFF
--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -134,6 +134,28 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(fallbackLLMModel, forKey: "fallbackLLMModel") }
     }
 
+    // MARK: - Task Complexity Routing
+
+    var taskRoutingEnabled: Bool = UserDefaults.standard.object(forKey: "taskRoutingEnabled") as? Bool ?? false {
+        didSet { UserDefaults.standard.set(taskRoutingEnabled, forKey: "taskRoutingEnabled") }
+    }
+
+    var lightModelProvider: String = UserDefaults.standard.string(forKey: "lightModelProvider") ?? "" {
+        didSet { UserDefaults.standard.set(lightModelProvider, forKey: "lightModelProvider") }
+    }
+
+    var lightModelName: String = UserDefaults.standard.string(forKey: "lightModelName") ?? "" {
+        didSet { UserDefaults.standard.set(lightModelName, forKey: "lightModelName") }
+    }
+
+    var heavyModelProvider: String = UserDefaults.standard.string(forKey: "heavyModelProvider") ?? "" {
+        didSet { UserDefaults.standard.set(heavyModelProvider, forKey: "heavyModelProvider") }
+    }
+
+    var heavyModelName: String = UserDefaults.standard.string(forKey: "heavyModelName") ?? "" {
+        didSet { UserDefaults.standard.set(heavyModelName, forKey: "heavyModelName") }
+    }
+
     // MARK: - Avatar
 
     var avatarEnabled: Bool = UserDefaults.standard.object(forKey: "avatarEnabled") as? Bool ?? false {

--- a/Dochi/Models/TaskComplexity.swift
+++ b/Dochi/Models/TaskComplexity.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Represents the complexity tier for routing to different models.
+enum TaskComplexity: String, Codable, CaseIterable, Sendable {
+    case light    // 일상 대화, 간단한 질문
+    case standard // 일반적인 작업 (기본값)
+    case heavy    // 코딩, 분석, 긴 문서 작업
+
+    var displayName: String {
+        switch self {
+        case .light: "경량"
+        case .standard: "표준"
+        case .heavy: "고급"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .light: "인사, 간단한 질문, 일상 대화"
+        case .standard: "일반 작업 (기본 모델 사용)"
+        case .heavy: "코딩, 데이터 분석, 복잡한 추론"
+        }
+    }
+}
+
+/// Classifies user input into a task complexity tier using keyword heuristics.
+enum TaskComplexityClassifier {
+
+    /// Keywords/patterns that suggest heavy (complex) tasks.
+    private static let heavyPatterns: [String] = [
+        "코드", "코딩", "프로그래밍", "함수", "클래스", "버그", "디버그",
+        "분석", "비교", "요약해", "정리해", "계산",
+        "작성해", "만들어", "구현", "설계",
+        "code", "debug", "implement", "analyze", "refactor",
+        "algorithm", "database", "sql", "api",
+        "번역해", "translate",
+    ]
+
+    /// Keywords/patterns that suggest light (simple) tasks.
+    private static let lightPatterns: [String] = [
+        "안녕", "고마워", "감사", "ㅎㅎ", "ㅋㅋ", "네", "응",
+        "오늘 날씨", "몇 시", "뭐 해",
+        "hello", "hi", "thanks", "ok", "yes", "no",
+        "좋아", "알겠어", "그래",
+    ]
+
+    /// Classify the complexity of a user message.
+    static func classify(_ text: String) -> TaskComplexity {
+        let lowered = text.lowercased()
+        let length = text.count
+
+        // Very short messages are likely casual
+        if length < 10 {
+            // But check for heavy keywords even in short messages
+            if heavyPatterns.contains(where: { lowered.contains($0) }) {
+                return .heavy
+            }
+            return .light
+        }
+
+        // Check for heavy patterns
+        let heavyScore = heavyPatterns.reduce(0) { score, pattern in
+            score + (lowered.contains(pattern) ? 1 : 0)
+        }
+
+        // Check for light patterns
+        let lightScore = lightPatterns.reduce(0) { score, pattern in
+            score + (lowered.contains(pattern) ? 1 : 0)
+        }
+
+        // Long messages (>200 chars) with tool-use indicators lean heavy
+        let longBonus = length > 200 ? 1 : 0
+
+        if heavyScore + longBonus >= 2 {
+            return .heavy
+        } else if heavyScore > lightScore {
+            return .heavy
+        } else if lightScore > 0 && heavyScore == 0 && length < 30 {
+            return .light
+        }
+
+        return .standard
+    }
+}

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -857,7 +857,12 @@ final class DochiViewModel {
             workspaceId: sessionContext.workspaceId,
             agentName: settings.activeAgentName
         )
-        guard let primaryModel = router.resolvePrimary(agentConfig: agentConfig) else {
+
+        // Classify task complexity from last user message
+        let lastUserText = conversation.messages.last(where: { $0.role == .user })?.content ?? ""
+        let complexity = TaskComplexityClassifier.classify(lastUserText)
+
+        guard let primaryModel = router.resolveForComplexity(complexity, agentConfig: agentConfig) else {
             handleError(LLMError.noAPIKey)
             return
         }

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -384,6 +384,70 @@ struct ModelSettingsView: View {
                         .monospacedDigit()
                 }
             }
+
+            Section("용도별 모델 라우팅") {
+                Toggle("자동 모델 선택", isOn: Binding(
+                    get: { settings.taskRoutingEnabled },
+                    set: { settings.taskRoutingEnabled = $0 }
+                ))
+                .help("메시지 복잡도에 따라 경량/고급 모델을 자동 선택합니다")
+
+                if settings.taskRoutingEnabled {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("경량 모델 (일상 대화)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        HStack(spacing: 8) {
+                            Picker("프로바이더", selection: Binding(
+                                get: { settings.lightModelProvider },
+                                set: { settings.lightModelProvider = $0 }
+                            )) {
+                                Text("기본 모델 사용").tag("")
+                                ForEach(LLMProvider.allCases, id: \.self) { p in
+                                    Text(p.displayName).tag(p.rawValue)
+                                }
+                            }
+                            .frame(width: 140)
+
+                            TextField("모델명", text: Binding(
+                                get: { settings.lightModelName },
+                                set: { settings.lightModelName = $0 }
+                            ))
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 12, design: .monospaced))
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("고급 모델 (코딩, 분석)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        HStack(spacing: 8) {
+                            Picker("프로바이더", selection: Binding(
+                                get: { settings.heavyModelProvider },
+                                set: { settings.heavyModelProvider = $0 }
+                            )) {
+                                Text("기본 모델 사용").tag("")
+                                ForEach(LLMProvider.allCases, id: \.self) { p in
+                                    Text(p.displayName).tag(p.rawValue)
+                                }
+                            }
+                            .frame(width: 140)
+
+                            TextField("모델명", text: Binding(
+                                get: { settings.heavyModelName },
+                                set: { settings.heavyModelName = $0 }
+                            ))
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 12, design: .monospaced))
+                        }
+                    }
+
+                    Text("표준 복잡도 메시지는 위에서 선택한 기본 모델을 사용합니다")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
         .formStyle(.grouped)
         .padding()


### PR DESCRIPTION
## Summary
- `TaskComplexity` 모델 (light/standard/heavy) + `TaskComplexityClassifier` 키워드 휴리스틱 분류기
- `ModelRouter.resolveForComplexity()` — 복잡도에 따라 경량/고급 모델 자동 선택
- ViewModel에서 마지막 사용자 메시지 기반 복잡도 분류 후 모델 라우팅
- 설정 UI: 자동 모델 선택 토글 + 경량/고급 모델 프로바이더·모델명 설정
- AppSettings: `taskRoutingEnabled`, `lightModel*`, `heavyModel*` 추가

Closes #60

## Test plan
- [x] `xcodebuild test` 전체 통과 (347 tests)
- [x] TaskComplexityClassifier: 경량/표준/고급 분류 테스트 8건
- [x] ModelRouter: 복잡도 라우팅 비활성/활성/폴백 테스트 6건
- [x] 기존 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)