### PR TITLE
feat: API 키 티어 관리 — 프로바이더별 프리미엄/경제 키

### DIFF
--- a/Dochi/Models/APIKeyTier.swift
+++ b/Dochi/Models/APIKeyTier.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// API key tier for cost/quality trade-off routing.
+enum APIKeyTier: String, Codable, CaseIterable, Sendable {
+    case premium   // 고성능 키 (높은 rate limit, 고급 모델 전용)
+    case standard  // 기본 키
+    case economy   // 경제적 키 (경량 모델 전용)
+
+    var displayName: String {
+        switch self {
+        case .premium: "프리미엄"
+        case .standard: "기본"
+        case .economy: "경제"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .premium: "고급 모델 전용, 높은 rate limit"
+        case .standard: "기본 API 키"
+        case .economy: "경량 모델 전용, 비용 절감"
+        }
+    }
+
+    /// Keychain account suffix for this tier.
+    var keychainSuffix: String {
+        switch self {
+        case .standard: "" // No suffix for backwards compatibility
+        case .premium: "_premium"
+        case .economy: "_economy"
+        }
+    }
+
+    /// Map from TaskComplexity to preferred API key tier.
+    static func preferredTier(for complexity: TaskComplexity) -> APIKeyTier {
+        switch complexity {
+        case .heavy: .premium
+        case .standard: .standard
+        case .light: .economy
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `APIKeyTier` 모델 (premium/standard/economy) + 키체인 suffix 규칙
- `ModelRouter.resolveAPIKey` 확장 — 티어별 키 우선 사용, 기본 키로 폴백
- API 키 설정 UI: 티어별 키 관리 섹션 추가 (OpenAI/Anthropic 프리미엄/경제)
- 용도별 모델 라우팅과 연동: heavy→premium, light→economy 키 자동 선택

Closes #59

## Test plan
- [x] `xcodebuild test` 전체 통과 (352 tests)
- [x] APIKeyTier suffix/preferredTier 테스트 2건
- [x] ModelRouter 티어별 키 우선 사용 테스트 3건
- [x] 기존 테스트 setUp 개선 (UserDefaults 누출 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)