### PR TITLE
feat: Telegram 미디어 그룹 + 사진 전송

### DIFF
--- a/Dochi/Services/Protocols/TelegramServiceProtocol.swift
+++ b/Dochi/Services/Protocols/TelegramServiceProtocol.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+/// An image to send in a Telegram media group.
+struct TelegramMediaItem: Sendable {
+    let filePath: String
+    let caption: String?
+}
+
 @MainActor
 protocol TelegramServiceProtocol {
     var isPolling: Bool { get }
@@ -8,6 +14,8 @@ protocol TelegramServiceProtocol {
     func sendMessage(chatId: Int64, text: String) async throws -> Int64
     func editMessage(chatId: Int64, messageId: Int64, text: String) async throws
     func sendChatAction(chatId: Int64, action: String) async throws
+    func sendPhoto(chatId: Int64, filePath: String, caption: String?) async throws -> Int64
+    func sendMediaGroup(chatId: Int64, items: [TelegramMediaItem]) async throws
     func getMe(token: String) async throws -> TelegramUser
     var onMessage: (@MainActor @Sendable (TelegramUpdate) -> Void)? { get set }
 }

--- a/Dochi/Services/Tools/BuiltInToolService.swift
+++ b/Dochi/Services/Tools/BuiltInToolService.swift
@@ -108,6 +108,8 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
         registry.register(TelegramSetTokenTool(keychainService: keychainService, telegramService: telegramService, settings: settings))
         registry.register(TelegramGetMeTool(keychainService: keychainService, telegramService: telegramService, settings: settings))
         registry.register(TelegramSendMessageTool(keychainService: keychainService, telegramService: telegramService, settings: settings))
+        registry.register(TelegramSendPhotoTool(telegramService: telegramService))
+        registry.register(TelegramSendMediaGroupTool(telegramService: telegramService))
 
         // Clipboard (conditional: read=safe, write=sensitive)
         registry.register(ClipboardReadTool())

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -325,6 +325,8 @@ final class MockTelegramService: TelegramServiceProtocol {
     var sentMessages: [(chatId: Int64, text: String)] = []
     var editedMessages: [(chatId: Int64, messageId: Int64, text: String)] = []
     var chatActions: [(chatId: Int64, action: String)] = []
+    var sentPhotos: [(chatId: Int64, filePath: String, caption: String?)] = []
+    var sentMediaGroups: [(chatId: Int64, items: [TelegramMediaItem])] = []
     var nextMessageId: Int64 = 1000
 
     func startPolling(token: String) { isPolling = true }
@@ -343,6 +345,17 @@ final class MockTelegramService: TelegramServiceProtocol {
 
     func sendChatAction(chatId: Int64, action: String) async throws {
         chatActions.append((chatId: chatId, action: action))
+    }
+
+    func sendPhoto(chatId: Int64, filePath: String, caption: String?) async throws -> Int64 {
+        let msgId = nextMessageId
+        nextMessageId += 1
+        sentPhotos.append((chatId: chatId, filePath: filePath, caption: caption))
+        return msgId
+    }
+
+    func sendMediaGroup(chatId: Int64, items: [TelegramMediaItem]) async throws {
+        sentMediaGroups.append((chatId: chatId, items: items))
     }
 
     func getMe(token: String) async throws -> TelegramUser {

--- a/DochiTests/TelegramStreamingTests.swift
+++ b/DochiTests/TelegramStreamingTests.swift
@@ -98,6 +98,49 @@ final class TelegramStreamingTests: XCTestCase {
         XCTAssertEqual(hexPart.count, 16) // 8 bytes = 16 hex chars
     }
 
+    // MARK: - Media Group
+
+    func testMockSendPhotoTracked() async throws {
+        let tg = MockTelegramService()
+        let msgId = try await tg.sendPhoto(chatId: 42, filePath: "/tmp/test.png", caption: "테스트")
+        XCTAssertEqual(tg.sentPhotos.count, 1)
+        XCTAssertEqual(tg.sentPhotos[0].chatId, 42)
+        XCTAssertEqual(tg.sentPhotos[0].filePath, "/tmp/test.png")
+        XCTAssertEqual(tg.sentPhotos[0].caption, "테스트")
+        XCTAssertEqual(msgId, 1000)
+    }
+
+    func testMockSendPhotoNilCaption() async throws {
+        let tg = MockTelegramService()
+        _ = try await tg.sendPhoto(chatId: 1, filePath: "/tmp/a.png", caption: nil)
+        XCTAssertNil(tg.sentPhotos[0].caption)
+    }
+
+    func testMockSendMediaGroupTracked() async throws {
+        let tg = MockTelegramService()
+        let items = [
+            TelegramMediaItem(filePath: "/tmp/a.png", caption: "A"),
+            TelegramMediaItem(filePath: "/tmp/b.png", caption: nil),
+        ]
+        try await tg.sendMediaGroup(chatId: 99, items: items)
+        XCTAssertEqual(tg.sentMediaGroups.count, 1)
+        XCTAssertEqual(tg.sentMediaGroups[0].chatId, 99)
+        XCTAssertEqual(tg.sentMediaGroups[0].items.count, 2)
+        XCTAssertEqual(tg.sentMediaGroups[0].items[0].caption, "A")
+        XCTAssertNil(tg.sentMediaGroups[0].items[1].caption)
+    }
+
+    func testTelegramMediaItemInit() {
+        let item = TelegramMediaItem(filePath: "/tmp/photo.jpg", caption: "테스트 캡션")
+        XCTAssertEqual(item.filePath, "/tmp/photo.jpg")
+        XCTAssertEqual(item.caption, "테스트 캡션")
+    }
+
+    func testTelegramMediaItemNilCaption() {
+        let item = TelegramMediaItem(filePath: "/tmp/photo.jpg", caption: nil)
+        XCTAssertNil(item.caption)
+    }
+
     // Helper: replicates TelegramService.offsetKey logic for testing
     private func offsetKey(for token: String) -> String {
         let hash = SHA256.hash(data: Data(token.utf8))


### PR DESCRIPTION
## Summary
- `TelegramMediaItem` 모델 (filePath + caption)
- `sendPhoto()` — 단일 사진 multipart/form-data 업로드
- `sendMediaGroup()` — 2-10장 미디어 그룹 전송 (1장이면 자동 sendPhoto)
- `telegram.send_photo`, `telegram.send_media_group` 도구 등록
- 캡션 지원, 파일 존재 검증

Closes #70

## Test plan
- [x] `xcodebuild test` 전체 통과 (357 tests)
- [x] MockTelegramService: sendPhoto/sendMediaGroup 추적 테스트 5건
- [x] TelegramMediaItem 초기화 테스트 2건

🤖 Generated with [Claude Code](https://claude.com/claude-code)