### PR TITLE
feat: Telegram 채팅 매핑 UI + 호스트 설정

### DIFF
--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -98,6 +98,16 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(ollamaBaseURL, forKey: "ollamaBaseURL") }
     }
 
+    /// JSON mapping of Telegram chat IDs to workspace IDs: {"chatId": "workspaceId", ...}
+    var telegramChatMappingJSON: String = UserDefaults.standard.string(forKey: "telegramChatMappingJSON") ?? "{}" {
+        didSet { UserDefaults.standard.set(telegramChatMappingJSON, forKey: "telegramChatMappingJSON") }
+    }
+
+    /// Whether this device acts as the Telegram host for its workspace.
+    var isTelegramHost: Bool = UserDefaults.standard.object(forKey: "isTelegramHost") as? Bool ?? true {
+        didSet { UserDefaults.standard.set(isTelegramHost, forKey: "isTelegramHost") }
+    }
+
     var hasSeenPermissionInfo: Bool = UserDefaults.standard.object(forKey: "hasSeenPermissionInfo") as? Bool ?? false {
         didSet { UserDefaults.standard.set(hasSeenPermissionInfo, forKey: "hasSeenPermissionInfo") }
     }

--- a/Dochi/Models/TelegramChatMapping.swift
+++ b/Dochi/Models/TelegramChatMapping.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Maps a Telegram chat ID to a workspace and stores metadata.
+struct TelegramChatMapping: Codable, Identifiable, Sendable {
+    var id: Int64 { chatId }
+    let chatId: Int64
+    var workspaceId: UUID?
+    var label: String   // Display name (username or chat title)
+    var enabled: Bool
+
+    init(chatId: Int64, workspaceId: UUID? = nil, label: String = "", enabled: Bool = true) {
+        self.chatId = chatId
+        self.workspaceId = workspaceId
+        self.label = label
+        self.enabled = enabled
+    }
+}
+
+/// Manages Telegram chat ↔ workspace mappings persisted in AppSettings.
+@MainActor
+struct TelegramChatMappingStore {
+
+    static func loadMappings(from settings: AppSettings) -> [TelegramChatMapping] {
+        guard let data = settings.telegramChatMappingJSON.data(using: .utf8),
+              let mappings = try? JSONDecoder().decode([TelegramChatMapping].self, from: data) else {
+            return []
+        }
+        return mappings
+    }
+
+    static func saveMappings(_ mappings: [TelegramChatMapping], to settings: AppSettings) {
+        guard let data = try? JSONEncoder().encode(mappings),
+              let json = String(data: data, encoding: .utf8) else {
+            return
+        }
+        settings.telegramChatMappingJSON = json
+    }
+
+    /// Add or update a mapping for a given chat ID.
+    static func upsert(chatId: Int64, label: String, workspaceId: UUID?, in settings: AppSettings) {
+        var mappings = loadMappings(from: settings)
+        if let idx = mappings.firstIndex(where: { $0.chatId == chatId }) {
+            mappings[idx].label = label
+            mappings[idx].workspaceId = workspaceId
+        } else {
+            mappings.append(TelegramChatMapping(chatId: chatId, workspaceId: workspaceId, label: label))
+        }
+        saveMappings(mappings, to: settings)
+    }
+
+    /// Remove a mapping by chat ID.
+    static func remove(chatId: Int64, from settings: AppSettings) {
+        var mappings = loadMappings(from: settings)
+        mappings.removeAll { $0.chatId == chatId }
+        saveMappings(mappings, to: settings)
+    }
+}


### PR DESCRIPTION
## Summary
- `TelegramChatMapping` 모델 + `TelegramChatMappingStore` 관리자
- 설정 UI: 채팅 매핑 목록 (활성/비활성 토글, 삭제)
- 호스트 디바이스 토글 (`isTelegramHost`)
- 새 Telegram 대화 시 자동 매핑 등록
- 매핑 JSON은 AppSettings (UserDefaults)에 저장

Closes #71

## Test plan
- [x] 단위 테스트 전체 통과 (362 tests)
- [x] TelegramChatMappingStore: upsert/load/remove 테스트 3건
- [x] TelegramChatMapping Codable 테스트 1건
- [x] isTelegramHost 기본값 테스트 1건

🤖 Generated with [Claude Code](https://claude.com/claude-code)