### PR TITLE
feat: 에이전트 워크플로우 엔진 (다단계 도구 체이닝)

### DIFF
--- a/Dochi/Models/Workflow.swift
+++ b/Dochi/Models/Workflow.swift
@@ -1,0 +1,336 @@
+import Foundation
+
+// MARK: - Workflow Step
+
+/// A single step in a workflow, mapping to a tool call.
+struct WorkflowStep: Codable, Identifiable, Sendable {
+    let id: UUID
+    var action: String              // Tool name (e.g., "web.search", "kanban.add_card")
+    var inputTemplate: [String: String]  // Input arguments, may contain {{variable}} placeholders
+    var outputKey: String           // Key to store this step's result in the workflow context
+    var description: String
+
+    init(
+        id: UUID = UUID(),
+        action: String,
+        inputTemplate: [String: String] = [:],
+        outputKey: String = "",
+        description: String = ""
+    ) {
+        self.id = id
+        self.action = action
+        self.inputTemplate = inputTemplate
+        self.outputKey = outputKey
+        self.description = description
+    }
+}
+
+// MARK: - Workflow Trigger
+
+enum WorkflowTrigger: Codable, Sendable {
+    case manual
+    case schedule(cron: String)       // Cron expression for periodic execution
+    case keyword(pattern: String)     // Keyword trigger from conversation
+
+    enum CodingKeys: String, CodingKey {
+        case type, cron, pattern
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "schedule":
+            let cron = try container.decode(String.self, forKey: .cron)
+            self = .schedule(cron: cron)
+        case "keyword":
+            let pattern = try container.decode(String.self, forKey: .pattern)
+            self = .keyword(pattern: pattern)
+        default:
+            self = .manual
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .manual:
+            try container.encode("manual", forKey: .type)
+        case .schedule(let cron):
+            try container.encode("schedule", forKey: .type)
+            try container.encode(cron, forKey: .cron)
+        case .keyword(let pattern):
+            try container.encode("keyword", forKey: .type)
+            try container.encode(pattern, forKey: .pattern)
+        }
+    }
+}
+
+// MARK: - Workflow
+
+struct Workflow: Codable, Identifiable, Sendable {
+    let id: UUID
+    var name: String
+    var description: String
+    var steps: [WorkflowStep]
+    var trigger: WorkflowTrigger
+    var enabled: Bool
+    let createdAt: Date
+    var updatedAt: Date
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        description: String = "",
+        steps: [WorkflowStep] = [],
+        trigger: WorkflowTrigger = .manual,
+        enabled: Bool = true,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.steps = steps
+        self.trigger = trigger
+        self.enabled = enabled
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - Workflow Run
+
+enum WorkflowStepStatus: String, Codable, Sendable {
+    case pending
+    case running
+    case completed
+    case failed
+    case skipped
+}
+
+struct WorkflowStepResult: Codable, Sendable {
+    let stepId: UUID
+    let action: String
+    var status: WorkflowStepStatus
+    var output: String
+    let startedAt: Date
+    var completedAt: Date?
+}
+
+struct WorkflowRun: Codable, Identifiable, Sendable {
+    let id: UUID
+    let workflowId: UUID
+    let workflowName: String
+    var stepResults: [WorkflowStepResult]
+    var context: [String: String]    // Accumulated step outputs
+    let startedAt: Date
+    var completedAt: Date?
+    var success: Bool
+
+    init(
+        id: UUID = UUID(),
+        workflowId: UUID,
+        workflowName: String,
+        startedAt: Date = Date()
+    ) {
+        self.id = id
+        self.workflowId = workflowId
+        self.workflowName = workflowName
+        self.stepResults = []
+        self.context = [:]
+        self.startedAt = startedAt
+        self.completedAt = nil
+        self.success = false
+    }
+}
+
+// MARK: - Workflow Manager
+
+@MainActor
+final class WorkflowManager {
+    static let shared = WorkflowManager()
+
+    private(set) var workflows: [UUID: Workflow] = [:]
+    private(set) var runs: [WorkflowRun] = []
+    private let storageDir: URL
+
+    private init() {
+        storageDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Dochi/workflows", isDirectory: true)
+        try? FileManager.default.createDirectory(at: storageDir, withIntermediateDirectories: true)
+        loadAll()
+    }
+
+    /// Testable initializer with custom storage directory.
+    init(storageDir: URL) {
+        self.storageDir = storageDir
+        try? FileManager.default.createDirectory(at: storageDir, withIntermediateDirectories: true)
+        loadAll()
+    }
+
+    // MARK: - CRUD
+
+    @discardableResult
+    func createWorkflow(name: String, description: String = "", steps: [WorkflowStep] = [], trigger: WorkflowTrigger = .manual) -> Workflow {
+        let workflow = Workflow(name: name, description: description, steps: steps, trigger: trigger)
+        workflows[workflow.id] = workflow
+        save(workflow)
+        Log.tool.info("Created workflow: \(name) with \(steps.count) steps")
+        return workflow
+    }
+
+    func listWorkflows() -> [Workflow] {
+        Array(workflows.values).sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func workflow(id: UUID) -> Workflow? {
+        workflows[id]
+    }
+
+    func workflow(name: String) -> Workflow? {
+        workflows.values.first { $0.name.localizedCaseInsensitiveContains(name) }
+    }
+
+    func updateWorkflow(id: UUID, name: String? = nil, description: String? = nil, steps: [WorkflowStep]? = nil, trigger: WorkflowTrigger? = nil, enabled: Bool? = nil) -> Bool {
+        guard var workflow = workflows[id] else { return false }
+        if let name { workflow.name = name }
+        if let description { workflow.description = description }
+        if let steps { workflow.steps = steps }
+        if let trigger { workflow.trigger = trigger }
+        if let enabled { workflow.enabled = enabled }
+        workflow.updatedAt = Date()
+        workflows[id] = workflow
+        save(workflow)
+        return true
+    }
+
+    func addStep(workflowId: UUID, step: WorkflowStep) -> Bool {
+        guard var workflow = workflows[workflowId] else { return false }
+        workflow.steps.append(step)
+        workflow.updatedAt = Date()
+        workflows[workflowId] = workflow
+        save(workflow)
+        return true
+    }
+
+    func deleteWorkflow(id: UUID) {
+        let name = workflows[id]?.name ?? "unknown"
+        workflows.removeValue(forKey: id)
+        let file = storageDir.appendingPathComponent("\(id.uuidString).json")
+        do {
+            try FileManager.default.removeItem(at: file)
+            Log.tool.info("Deleted workflow: \(name)")
+        } catch {
+            Log.tool.error("Failed to delete workflow file: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Execution
+
+    /// Resolves template variables in a string. {{key}} is replaced with context[key].
+    static func resolveTemplate(_ template: String, context: [String: String]) -> String {
+        var result = template
+        for (key, value) in context {
+            result = result.replacingOccurrences(of: "{{\(key)}}", with: value)
+        }
+        return result
+    }
+
+    /// Resolves all template variables in a step's input template.
+    static func resolveInputs(_ inputTemplate: [String: String], context: [String: String]) -> [String: String] {
+        var resolved: [String: String] = [:]
+        for (key, value) in inputTemplate {
+            resolved[key] = resolveTemplate(value, context: context)
+        }
+        return resolved
+    }
+
+    /// Executes a workflow sequentially, calling the provided tool executor for each step.
+    /// Executor type: receives tool name and resolved string arguments, returns result.
+    typealias ToolExecutor = @MainActor (String, [String: String]) async -> ToolResult
+
+    func executeWorkflow(
+        id: UUID,
+        initialContext: [String: String] = [:],
+        toolExecutor: ToolExecutor
+    ) async -> WorkflowRun? {
+        guard let workflow = workflows[id], workflow.enabled else { return nil }
+
+        var run = WorkflowRun(workflowId: workflow.id, workflowName: workflow.name)
+        run.context = initialContext
+
+        Log.tool.info("Starting workflow: \(workflow.name) (\(workflow.steps.count) steps)")
+
+        for step in workflow.steps {
+            let resolvedInputs: [String: String] = Self.resolveInputs(step.inputTemplate, context: run.context)
+            var stepResult = WorkflowStepResult(
+                stepId: step.id,
+                action: step.action,
+                status: .running,
+                output: "",
+                startedAt: Date()
+            )
+
+            let toolResult = await toolExecutor(step.action, resolvedInputs)
+
+            stepResult.completedAt = Date()
+            if toolResult.isError {
+                stepResult.status = .failed
+                stepResult.output = toolResult.content
+                run.stepResults.append(stepResult)
+                Log.tool.warning("Workflow step failed: \(step.action) — \(toolResult.content)")
+                break
+            } else {
+                stepResult.status = .completed
+                stepResult.output = toolResult.content
+                if !step.outputKey.isEmpty {
+                    run.context[step.outputKey] = toolResult.content
+                }
+                run.stepResults.append(stepResult)
+                Log.tool.debug("Workflow step completed: \(step.action)")
+            }
+        }
+
+        let allCompleted = run.stepResults.allSatisfy { $0.status == .completed }
+        run.success = allCompleted && run.stepResults.count == workflow.steps.count
+        run.completedAt = Date()
+
+        runs.append(run)
+        // Keep only last 50 runs
+        if runs.count > 50 { runs.removeFirst(runs.count - 50) }
+
+        Log.tool.info("Workflow \(workflow.name) \(run.success ? "succeeded" : "failed") (\(run.stepResults.count)/\(workflow.steps.count) steps)")
+        return run
+    }
+
+    // MARK: - Persistence
+
+    private func save(_ workflow: Workflow) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let data = try encoder.encode(workflow)
+            let file = storageDir.appendingPathComponent("\(workflow.id.uuidString).json")
+            try data.write(to: file)
+        } catch {
+            Log.tool.error("Failed to save workflow: \(error.localizedDescription)")
+        }
+    }
+
+    private func loadAll() {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let files = try? FileManager.default.contentsOfDirectory(at: storageDir, includingPropertiesForKeys: nil) else { return }
+        for file in files where file.pathExtension == "json" {
+            do {
+                let data = try Data(contentsOf: file)
+                let workflow = try decoder.decode(Workflow.self, from: data)
+                workflows[workflow.id] = workflow
+            } catch {
+                Log.tool.warning("Failed to load workflow from \(file.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/Dochi/Services/Tools/BuiltInToolService.swift
+++ b/Dochi/Services/Tools/BuiltInToolService.swift
@@ -178,6 +178,21 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
         registry.register(KanbanDeleteCardTool())
         registry.register(KanbanCardHistoryTool())
 
+        // Workflow (baseline, safe/sensitive)
+        registry.register(WorkflowCreateTool())
+        registry.register(WorkflowListTool())
+        registry.register(WorkflowRunTool(toolExecutor: { [weak self] name, args in
+            guard let self else {
+                return ToolResult(toolCallId: "", content: "서비스를 사용할 수 없습니다.", isError: true)
+            }
+            // Convert [String: String] to [String: Any] for tool execution
+            let toolArgs: [String: Any] = Dictionary(uniqueKeysWithValues: args.map { ($0.key, $0.value as Any) })
+            return await self.execute(name: name, arguments: toolArgs)
+        }))
+        registry.register(WorkflowDeleteTool())
+        registry.register(WorkflowAddStepTool())
+        registry.register(WorkflowHistoryTool())
+
         // Git (conditional, safe/restricted)
         registry.register(GitStatusTool())
         registry.register(GitLogTool())

--- a/Dochi/Services/Tools/WorkflowTool.swift
+++ b/Dochi/Services/Tools/WorkflowTool.swift
@@ -1,0 +1,338 @@
+import Foundation
+import os
+
+// MARK: - Create Workflow
+
+@MainActor
+final class WorkflowCreateTool: BuiltInToolProtocol {
+    let name = "workflow.create"
+    let category: ToolCategory = .safe
+    let description = "다단계 자동화 워크플로우를 생성합니다. 단계별로 도구를 체이닝하여 복잡한 작업을 자동화할 수 있습니다."
+    let isBaseline = true
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "name": ["type": "string", "description": "워크플로우 이름"],
+                "description": ["type": "string", "description": "워크플로우 설명"],
+                "steps": [
+                    "type": "array",
+                    "items": [
+                        "type": "object",
+                        "properties": [
+                            "action": ["type": "string", "description": "도구 이름 (예: kanban.add_card)"],
+                            "input": [
+                                "type": "object",
+                                "description": "도구 입력. {{변수명}}으로 이전 단계 결과 참조",
+                                "additionalProperties": ["type": "string"],
+                            ] as [String: Any],
+                            "output_key": ["type": "string", "description": "이 단계 결과를 저장할 변수명"],
+                            "description": ["type": "string", "description": "단계 설명"],
+                        ] as [String: Any],
+                        "required": ["action"],
+                    ] as [String: Any],
+                    "description": "워크플로우 단계 목록 (순서대로 실행)",
+                ] as [String: Any],
+                "trigger": [
+                    "type": "string",
+                    "enum": ["manual", "keyword"],
+                    "description": "트리거 유형 (기본: manual)",
+                ],
+                "trigger_pattern": ["type": "string", "description": "keyword 트리거 시 감지할 패턴"],
+            ] as [String: Any],
+            "required": ["name", "steps"],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        guard let name = arguments["name"] as? String, !name.isEmpty else {
+            return ToolResult(toolCallId: "", content: "name 파라미터가 필요합니다.", isError: true)
+        }
+        guard let stepsRaw = arguments["steps"] as? [[String: Any]], !stepsRaw.isEmpty else {
+            return ToolResult(toolCallId: "", content: "steps 파라미터가 필요합니다 (최소 1단계).", isError: true)
+        }
+
+        var steps: [WorkflowStep] = []
+        for (idx, stepDict) in stepsRaw.enumerated() {
+            guard let action = stepDict["action"] as? String, !action.isEmpty else {
+                return ToolResult(toolCallId: "", content: "단계 \(idx + 1)에 action이 필요합니다.", isError: true)
+            }
+            let inputDict = stepDict["input"] as? [String: String] ?? [:]
+            let outputKey = stepDict["output_key"] as? String ?? ""
+            let desc = stepDict["description"] as? String ?? ""
+            steps.append(WorkflowStep(action: action, inputTemplate: inputDict, outputKey: outputKey, description: desc))
+        }
+
+        let triggerType = arguments["trigger"] as? String ?? "manual"
+        let trigger: WorkflowTrigger
+        if triggerType == "keyword", let pattern = arguments["trigger_pattern"] as? String {
+            trigger = .keyword(pattern: pattern)
+        } else {
+            trigger = .manual
+        }
+
+        let desc = arguments["description"] as? String ?? ""
+        let workflow = WorkflowManager.shared.createWorkflow(name: name, description: desc, steps: steps, trigger: trigger)
+
+        var output = "워크플로우 생성: \(name) [\(workflow.id.uuidString.prefix(8))]\n"
+        output += "단계 \(steps.count)개:\n"
+        for (idx, step) in steps.enumerated() {
+            output += "  \(idx + 1). \(step.action)"
+            if !step.description.isEmpty { output += " — \(step.description)" }
+            if !step.outputKey.isEmpty { output += " → {{\(step.outputKey)}}" }
+            output += "\n"
+        }
+
+        return ToolResult(toolCallId: "", content: output)
+    }
+}
+
+// MARK: - List Workflows
+
+@MainActor
+final class WorkflowListTool: BuiltInToolProtocol {
+    let name = "workflow.list"
+    let category: ToolCategory = .safe
+    let description = "등록된 워크플로우 목록을 조회합니다."
+    let isBaseline = true
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [:] as [String: Any],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        let workflows = WorkflowManager.shared.listWorkflows()
+        guard !workflows.isEmpty else {
+            return ToolResult(toolCallId: "", content: "등록된 워크플로우가 없습니다. workflow.create로 생성하세요.")
+        }
+
+        let lines = workflows.map { wf in
+            let status = wf.enabled ? "✅" : "⏸️"
+            let triggerStr: String
+            switch wf.trigger {
+            case .manual: triggerStr = "수동"
+            case .schedule(let cron): triggerStr = "스케줄(\(cron))"
+            case .keyword(let pattern): triggerStr = "키워드(\(pattern))"
+            }
+            return "\(status) \(wf.name) [\(wf.id.uuidString.prefix(8))] — \(wf.steps.count)단계, \(triggerStr)"
+        }
+
+        return ToolResult(toolCallId: "", content: "워크플로우 (\(workflows.count)개):\n\(lines.joined(separator: "\n"))")
+    }
+}
+
+// MARK: - Run Workflow
+
+@MainActor
+final class WorkflowRunTool: BuiltInToolProtocol {
+    let name = "workflow.run"
+    let category: ToolCategory = .sensitive
+    let description = "워크플로우를 실행합니다. 각 단계의 도구를 순서대로 호출하고 결과를 체이닝합니다."
+    let isBaseline = true
+
+    private let toolExecutor: WorkflowManager.ToolExecutor
+
+    init(toolExecutor: @escaping WorkflowManager.ToolExecutor) {
+        self.toolExecutor = toolExecutor
+    }
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "workflow_name": ["type": "string", "description": "워크플로우 이름 (부분 일치)"],
+                "workflow_id": ["type": "string", "description": "워크플로우 ID (8자 prefix)"],
+                "context": [
+                    "type": "object",
+                    "description": "초기 컨텍스트 변수 (예: {\"topic\": \"AI 뉴스\"})",
+                    "additionalProperties": ["type": "string"],
+                ] as [String: Any],
+            ] as [String: Any],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        let workflow: Workflow?
+        if let idPrefix = arguments["workflow_id"] as? String {
+            workflow = WorkflowManager.shared.listWorkflows().first {
+                $0.id.uuidString.lowercased().hasPrefix(idPrefix.lowercased())
+            }
+        } else if let name = arguments["workflow_name"] as? String {
+            workflow = WorkflowManager.shared.workflow(name: name)
+        } else {
+            return ToolResult(toolCallId: "", content: "workflow_name 또는 workflow_id가 필요합니다.", isError: true)
+        }
+
+        guard let workflow else {
+            return ToolResult(toolCallId: "", content: "워크플로우를 찾을 수 없습니다.", isError: true)
+        }
+
+        let initialContext = (arguments["context"] as? [String: String]) ?? [:]
+
+        guard let run = await WorkflowManager.shared.executeWorkflow(
+            id: workflow.id,
+            initialContext: initialContext,
+            toolExecutor: toolExecutor
+        ) else {
+            return ToolResult(toolCallId: "", content: "워크플로우 실행 실패 (비활성 또는 존재하지 않음).", isError: true)
+        }
+
+        var output = run.success ? "✅ 워크플로우 완료: \(workflow.name)\n" : "❌ 워크플로우 실패: \(workflow.name)\n"
+        for (idx, result) in run.stepResults.enumerated() {
+            let icon: String
+            switch result.status {
+            case .completed: icon = "✅"
+            case .failed: icon = "❌"
+            case .running: icon = "🔄"
+            case .pending: icon = "⏳"
+            case .skipped: icon = "⏭️"
+            }
+            let preview = String(result.output.prefix(100))
+            output += "  \(idx + 1). \(icon) \(result.action): \(preview)\n"
+        }
+
+        return ToolResult(toolCallId: "", content: output)
+    }
+}
+
+// MARK: - Delete Workflow
+
+@MainActor
+final class WorkflowDeleteTool: BuiltInToolProtocol {
+    let name = "workflow.delete"
+    let category: ToolCategory = .safe
+    let description = "워크플로우를 삭제합니다."
+    let isBaseline = true
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "workflow_name": ["type": "string", "description": "워크플로우 이름 (부분 일치)"],
+                "workflow_id": ["type": "string", "description": "워크플로우 ID (8자 prefix)"],
+            ] as [String: Any],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        let workflow: Workflow?
+        if let idPrefix = arguments["workflow_id"] as? String {
+            workflow = WorkflowManager.shared.listWorkflows().first {
+                $0.id.uuidString.lowercased().hasPrefix(idPrefix.lowercased())
+            }
+        } else if let name = arguments["workflow_name"] as? String {
+            workflow = WorkflowManager.shared.workflow(name: name)
+        } else {
+            return ToolResult(toolCallId: "", content: "workflow_name 또는 workflow_id가 필요합니다.", isError: true)
+        }
+
+        guard let workflow else {
+            return ToolResult(toolCallId: "", content: "워크플로우를 찾을 수 없습니다.", isError: true)
+        }
+
+        WorkflowManager.shared.deleteWorkflow(id: workflow.id)
+        return ToolResult(toolCallId: "", content: "워크플로우 삭제: \(workflow.name)")
+    }
+}
+
+// MARK: - Add Step
+
+@MainActor
+final class WorkflowAddStepTool: BuiltInToolProtocol {
+    let name = "workflow.add_step"
+    let category: ToolCategory = .safe
+    let description = "기존 워크플로우에 단계를 추가합니다."
+    let isBaseline = true
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "workflow_name": ["type": "string", "description": "워크플로우 이름"],
+                "action": ["type": "string", "description": "도구 이름"],
+                "input": [
+                    "type": "object",
+                    "description": "도구 입력 ({{변수명}}으로 이전 단계 결과 참조)",
+                    "additionalProperties": ["type": "string"],
+                ] as [String: Any],
+                "output_key": ["type": "string", "description": "결과를 저장할 변수명"],
+                "description": ["type": "string", "description": "단계 설명"],
+            ] as [String: Any],
+            "required": ["workflow_name", "action"],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        guard let wfName = arguments["workflow_name"] as? String else {
+            return ToolResult(toolCallId: "", content: "workflow_name 파라미터가 필요합니다.", isError: true)
+        }
+        guard let action = arguments["action"] as? String, !action.isEmpty else {
+            return ToolResult(toolCallId: "", content: "action 파라미터가 필요합니다.", isError: true)
+        }
+        guard let workflow = WorkflowManager.shared.workflow(name: wfName) else {
+            return ToolResult(toolCallId: "", content: "'\(wfName)' 워크플로우를 찾을 수 없습니다.", isError: true)
+        }
+
+        let inputTemplate = arguments["input"] as? [String: String] ?? [:]
+        let outputKey = arguments["output_key"] as? String ?? ""
+        let desc = arguments["description"] as? String ?? ""
+
+        let step = WorkflowStep(action: action, inputTemplate: inputTemplate, outputKey: outputKey, description: desc)
+        guard WorkflowManager.shared.addStep(workflowId: workflow.id, step: step) else {
+            return ToolResult(toolCallId: "", content: "단계 추가 실패.", isError: true)
+        }
+
+        let stepCount = WorkflowManager.shared.workflow(id: workflow.id)?.steps.count ?? 0
+        return ToolResult(toolCallId: "", content: "단계 추가: \(action) → \(workflow.name) (총 \(stepCount)단계)")
+    }
+}
+
+// MARK: - Workflow History
+
+@MainActor
+final class WorkflowHistoryTool: BuiltInToolProtocol {
+    let name = "workflow.history"
+    let category: ToolCategory = .safe
+    let description = "워크플로우 실행 기록을 조회합니다."
+    let isBaseline = true
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "workflow_name": ["type": "string", "description": "워크플로우 이름 (생략하면 전체)"],
+                "limit": ["type": "integer", "description": "최대 조회 수 (기본: 5)"],
+            ] as [String: Any],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        let limit = arguments["limit"] as? Int ?? 5
+        var runs = WorkflowManager.shared.runs
+
+        if let name = arguments["workflow_name"] as? String {
+            runs = runs.filter { $0.workflowName.localizedCaseInsensitiveContains(name) }
+        }
+
+        let recent = runs.suffix(limit)
+        guard !recent.isEmpty else {
+            return ToolResult(toolCallId: "", content: "실행 기록이 없습니다.")
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd HH:mm"
+
+        let lines = recent.map { run in
+            let icon = run.success ? "✅" : "❌"
+            let time = formatter.string(from: run.startedAt)
+            let steps = "\(run.stepResults.filter { $0.status == .completed }.count)/\(run.stepResults.count)"
+            return "\(icon) \(run.workflowName) [\(time)] — \(steps) 단계 완료"
+        }
+
+        return ToolResult(toolCallId: "", content: "실행 기록:\n\(lines.joined(separator: "\n"))")
+    }
+}

--- a/DochiTests/WorkflowTests.swift
+++ b/DochiTests/WorkflowTests.swift
@@ -1,0 +1,396 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class WorkflowTests: XCTestCase {
+    private var tempDir: URL!
+    private var manager: WorkflowManager!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkflowTests_\(UUID().uuidString)")
+        manager = WorkflowManager(storageDir: tempDir)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    // MARK: - WorkflowStep Model
+
+    func testWorkflowStepInit() {
+        let step = WorkflowStep(action: "kanban.add_card", inputTemplate: ["title": "{{task}}"], outputKey: "result")
+        XCTAssertEqual(step.action, "kanban.add_card")
+        XCTAssertEqual(step.inputTemplate["title"], "{{task}}")
+        XCTAssertEqual(step.outputKey, "result")
+    }
+
+    func testWorkflowStepDefaults() {
+        let step = WorkflowStep(action: "test.tool")
+        XCTAssertTrue(step.inputTemplate.isEmpty)
+        XCTAssertEqual(step.outputKey, "")
+        XCTAssertEqual(step.description, "")
+    }
+
+    // MARK: - WorkflowTrigger Codable
+
+    func testManualTriggerCodable() throws {
+        let trigger = WorkflowTrigger.manual
+        let data = try JSONEncoder().encode(trigger)
+        let decoded = try JSONDecoder().decode(WorkflowTrigger.self, from: data)
+        if case .manual = decoded {} else { XCTFail("Expected manual trigger") }
+    }
+
+    func testScheduleTriggerCodable() throws {
+        let trigger = WorkflowTrigger.schedule(cron: "0 9 * * *")
+        let data = try JSONEncoder().encode(trigger)
+        let decoded = try JSONDecoder().decode(WorkflowTrigger.self, from: data)
+        if case .schedule(let cron) = decoded {
+            XCTAssertEqual(cron, "0 9 * * *")
+        } else {
+            XCTFail("Expected schedule trigger")
+        }
+    }
+
+    func testKeywordTriggerCodable() throws {
+        let trigger = WorkflowTrigger.keyword(pattern: "뉴스 요약")
+        let data = try JSONEncoder().encode(trigger)
+        let decoded = try JSONDecoder().decode(WorkflowTrigger.self, from: data)
+        if case .keyword(let pattern) = decoded {
+            XCTAssertEqual(pattern, "뉴스 요약")
+        } else {
+            XCTFail("Expected keyword trigger")
+        }
+    }
+
+    // MARK: - Workflow Model
+
+    func testWorkflowInitDefaults() {
+        let workflow = Workflow(name: "테스트")
+        XCTAssertEqual(workflow.name, "테스트")
+        XCTAssertTrue(workflow.steps.isEmpty)
+        XCTAssertTrue(workflow.enabled)
+        if case .manual = workflow.trigger {} else { XCTFail("Expected manual trigger") }
+    }
+
+    func testWorkflowCodableRoundtrip() throws {
+        let step = WorkflowStep(action: "test.tool", inputTemplate: ["key": "value"], outputKey: "out")
+        let workflow = Workflow(
+            name: "인코딩 테스트",
+            description: "설명",
+            steps: [step],
+            trigger: .keyword(pattern: "시작")
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(workflow)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Workflow.self, from: data)
+
+        XCTAssertEqual(decoded.name, "인코딩 테스트")
+        XCTAssertEqual(decoded.description, "설명")
+        XCTAssertEqual(decoded.steps.count, 1)
+        XCTAssertEqual(decoded.steps[0].action, "test.tool")
+        XCTAssertEqual(decoded.steps[0].outputKey, "out")
+        if case .keyword(let pattern) = decoded.trigger {
+            XCTAssertEqual(pattern, "시작")
+        } else {
+            XCTFail("Expected keyword trigger")
+        }
+    }
+
+    // MARK: - WorkflowRun Model
+
+    func testWorkflowRunInit() {
+        let run = WorkflowRun(workflowId: UUID(), workflowName: "테스트")
+        XCTAssertTrue(run.stepResults.isEmpty)
+        XCTAssertTrue(run.context.isEmpty)
+        XCTAssertFalse(run.success)
+        XCTAssertNil(run.completedAt)
+    }
+
+    // MARK: - Manager CRUD
+
+    func testCreateWorkflow() {
+        let wf = manager.createWorkflow(name: "프로젝트 워크플로우")
+        XCTAssertEqual(wf.name, "프로젝트 워크플로우")
+        XCTAssertEqual(manager.listWorkflows().count, 1)
+    }
+
+    func testCreateWorkflowWithSteps() {
+        let steps = [
+            WorkflowStep(action: "step1"),
+            WorkflowStep(action: "step2"),
+        ]
+        let wf = manager.createWorkflow(name: "다단계", steps: steps)
+        XCTAssertEqual(wf.steps.count, 2)
+    }
+
+    func testListWorkflowsSorted() {
+        let w1 = manager.createWorkflow(name: "First")
+        let w2 = manager.createWorkflow(name: "Second")
+        let list = manager.listWorkflows()
+        XCTAssertEqual(list.count, 2)
+        XCTAssertEqual(list[0].id, w1.id)
+        XCTAssertEqual(list[1].id, w2.id)
+    }
+
+    func testWorkflowById() {
+        let wf = manager.createWorkflow(name: "Find")
+        XCTAssertNotNil(manager.workflow(id: wf.id))
+        XCTAssertNil(manager.workflow(id: UUID()))
+    }
+
+    func testWorkflowByName() {
+        _ = manager.createWorkflow(name: "모닝 브리핑")
+        XCTAssertNotNil(manager.workflow(name: "모닝"))
+        XCTAssertNotNil(manager.workflow(name: "모닝 브리핑"))
+        XCTAssertNil(manager.workflow(name: "없는"))
+    }
+
+    func testUpdateWorkflow() {
+        let wf = manager.createWorkflow(name: "원본")
+        let result = manager.updateWorkflow(id: wf.id, name: "수정됨", enabled: false)
+        XCTAssertTrue(result)
+
+        let updated = manager.workflow(id: wf.id)!
+        XCTAssertEqual(updated.name, "수정됨")
+        XCTAssertFalse(updated.enabled)
+    }
+
+    func testUpdateWorkflowNonExistent() {
+        let result = manager.updateWorkflow(id: UUID(), name: "실패")
+        XCTAssertFalse(result)
+    }
+
+    func testAddStep() {
+        let wf = manager.createWorkflow(name: "빈 워크플로우")
+        XCTAssertEqual(wf.steps.count, 0)
+
+        let step = WorkflowStep(action: "test.action")
+        let result = manager.addStep(workflowId: wf.id, step: step)
+        XCTAssertTrue(result)
+        XCTAssertEqual(manager.workflow(id: wf.id)!.steps.count, 1)
+    }
+
+    func testAddStepNonExistent() {
+        let step = WorkflowStep(action: "test")
+        let result = manager.addStep(workflowId: UUID(), step: step)
+        XCTAssertFalse(result)
+    }
+
+    func testDeleteWorkflow() {
+        let wf = manager.createWorkflow(name: "삭제할 워크플로우")
+        XCTAssertEqual(manager.listWorkflows().count, 1)
+        manager.deleteWorkflow(id: wf.id)
+        XCTAssertEqual(manager.listWorkflows().count, 0)
+    }
+
+    // MARK: - Template Resolution
+
+    func testResolveTemplateSimple() {
+        let result = WorkflowManager.resolveTemplate("Hello {{name}}!", context: ["name": "World"])
+        XCTAssertEqual(result, "Hello World!")
+    }
+
+    func testResolveTemplateMultiple() {
+        let result = WorkflowManager.resolveTemplate(
+            "{{greeting}} {{name}}, today is {{day}}",
+            context: ["greeting": "Hi", "name": "도치", "day": "금요일"]
+        )
+        XCTAssertEqual(result, "Hi 도치, today is 금요일")
+    }
+
+    func testResolveTemplateNoPlaceholders() {
+        let result = WorkflowManager.resolveTemplate("plain text", context: ["key": "value"])
+        XCTAssertEqual(result, "plain text")
+    }
+
+    func testResolveTemplateMissingKey() {
+        let result = WorkflowManager.resolveTemplate("Hello {{missing}}", context: [:])
+        XCTAssertEqual(result, "Hello {{missing}}") // unreplaced
+    }
+
+    func testResolveInputs() {
+        let inputs = WorkflowManager.resolveInputs(
+            ["query": "{{topic}} 뉴스", "limit": "10"],
+            context: ["topic": "AI"]
+        )
+        XCTAssertEqual(inputs["query"], "AI 뉴스")
+        XCTAssertEqual(inputs["limit"], "10")
+    }
+
+    // MARK: - Execution
+
+    func testExecuteWorkflowSuccess() async {
+        let steps = [
+            WorkflowStep(action: "tool.a", outputKey: "resultA"),
+            WorkflowStep(action: "tool.b", inputTemplate: ["input": "{{resultA}}"], outputKey: "resultB"),
+        ]
+        let wf = manager.createWorkflow(name: "성공 워크플로우", steps: steps)
+
+        let run = await manager.executeWorkflow(id: wf.id) { action, args in
+            if action == "tool.a" {
+                return ToolResult(toolCallId: "", content: "출력A")
+            } else if action == "tool.b" {
+                let input = args["input"] ?? ""
+                return ToolResult(toolCallId: "", content: "출력B(\(input))")
+            }
+            return ToolResult(toolCallId: "", content: "unknown", isError: true)
+        }
+
+        XCTAssertNotNil(run)
+        XCTAssertTrue(run!.success)
+        XCTAssertEqual(run!.stepResults.count, 2)
+        XCTAssertEqual(run!.stepResults[0].status, .completed)
+        XCTAssertEqual(run!.stepResults[1].status, .completed)
+        XCTAssertEqual(run!.context["resultA"], "출력A")
+        XCTAssertEqual(run!.context["resultB"], "출력B(출력A)")
+    }
+
+    func testExecuteWorkflowFailsOnError() async {
+        let steps = [
+            WorkflowStep(action: "tool.ok", outputKey: "ok"),
+            WorkflowStep(action: "tool.fail"),
+            WorkflowStep(action: "tool.unreached"),
+        ]
+        let wf = manager.createWorkflow(name: "실패 워크플로우", steps: steps)
+
+        let run = await manager.executeWorkflow(id: wf.id) { action, _ in
+            if action == "tool.fail" {
+                return ToolResult(toolCallId: "", content: "에러 발생", isError: true)
+            }
+            return ToolResult(toolCallId: "", content: "ok")
+        }
+
+        XCTAssertNotNil(run)
+        XCTAssertFalse(run!.success)
+        XCTAssertEqual(run!.stepResults.count, 2) // stops after failure
+        XCTAssertEqual(run!.stepResults[0].status, .completed)
+        XCTAssertEqual(run!.stepResults[1].status, .failed)
+    }
+
+    func testExecuteDisabledWorkflow() async {
+        let wf = manager.createWorkflow(name: "비활성")
+        _ = manager.updateWorkflow(id: wf.id, enabled: false)
+
+        let run = await manager.executeWorkflow(id: wf.id) { _, _ in
+            ToolResult(toolCallId: "", content: "should not run")
+        }
+        XCTAssertNil(run)
+    }
+
+    func testExecuteNonExistentWorkflow() async {
+        let run = await manager.executeWorkflow(id: UUID()) { _, _ in
+            ToolResult(toolCallId: "", content: "nope")
+        }
+        XCTAssertNil(run)
+    }
+
+    func testExecuteWithInitialContext() async {
+        let steps = [
+            WorkflowStep(action: "tool.echo", inputTemplate: ["text": "{{greeting}} {{name}}"], outputKey: "msg"),
+        ]
+        let wf = manager.createWorkflow(name: "컨텍스트 테스트", steps: steps)
+
+        let run = await manager.executeWorkflow(
+            id: wf.id,
+            initialContext: ["greeting": "안녕", "name": "도치"]
+        ) { _, args in
+            let text = args["text"] ?? ""
+            return ToolResult(toolCallId: "", content: text)
+        }
+
+        XCTAssertNotNil(run)
+        XCTAssertTrue(run!.success)
+        XCTAssertEqual(run!.context["msg"], "안녕 도치")
+    }
+
+    func testRunHistoryTracked() async {
+        let wf = manager.createWorkflow(
+            name: "히스토리 테스트",
+            steps: [WorkflowStep(action: "tool.noop")]
+        )
+
+        _ = await manager.executeWorkflow(id: wf.id) { _, _ in
+            ToolResult(toolCallId: "", content: "ok")
+        }
+        _ = await manager.executeWorkflow(id: wf.id) { _, _ in
+            ToolResult(toolCallId: "", content: "ok")
+        }
+
+        XCTAssertEqual(manager.runs.count, 2)
+    }
+
+    // MARK: - Persistence
+
+    func testPersistenceRoundtrip() {
+        let steps = [WorkflowStep(action: "test.tool", inputTemplate: ["key": "val"], outputKey: "out")]
+        _ = manager.createWorkflow(name: "영속성", description: "설명", steps: steps, trigger: .keyword(pattern: "시작"))
+
+        let manager2 = WorkflowManager(storageDir: tempDir)
+        let loaded = manager2.listWorkflows()
+        XCTAssertEqual(loaded.count, 1)
+        XCTAssertEqual(loaded[0].name, "영속성")
+        XCTAssertEqual(loaded[0].steps.count, 1)
+        XCTAssertEqual(loaded[0].steps[0].action, "test.tool")
+        if case .keyword(let pattern) = loaded[0].trigger {
+            XCTAssertEqual(pattern, "시작")
+        } else {
+            XCTFail("Expected keyword trigger")
+        }
+    }
+
+    func testDeleteRemovesFile() {
+        let wf = manager.createWorkflow(name: "삭제 파일 테스트")
+        let file = tempDir.appendingPathComponent("\(wf.id.uuidString).json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: file.path))
+        manager.deleteWorkflow(id: wf.id)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: file.path))
+    }
+
+    // MARK: - Tool Tests
+
+    func testWorkflowCreateToolMissingName() async {
+        let tool = WorkflowCreateTool()
+        let result = await tool.execute(arguments: ["steps": [["action": "test"]]])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testWorkflowCreateToolMissingSteps() async {
+        let tool = WorkflowCreateTool()
+        let result = await tool.execute(arguments: ["name": "test"])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testWorkflowListToolEmpty() async {
+        let tool = WorkflowListTool()
+        let result = await tool.execute(arguments: [:])
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("없습니다"))
+    }
+
+    func testWorkflowDeleteToolMissingParams() async {
+        let tool = WorkflowDeleteTool()
+        let result = await tool.execute(arguments: [:])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testWorkflowAddStepToolMissingWorkflow() async {
+        let tool = WorkflowAddStepTool()
+        let result = await tool.execute(arguments: ["workflow_name": "없는워크플로우_\(UUID())", "action": "test"])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testWorkflowHistoryToolEmpty() async {
+        let tool = WorkflowHistoryTool()
+        let result = await tool.execute(arguments: [:])
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("없습니다"))
+    }
+}


### PR DESCRIPTION
## Summary
- 다단계 도구 체이닝 워크플로우 엔진 구현
- `Workflow` 모델: 순차 단계(WorkflowStep), 트리거(manual/schedule/keyword), 실행 기록(WorkflowRun)
- `WorkflowManager`: CRUD + 순차 실행 엔진, 단계 간 `{{변수명}}` 템플릿으로 데이터 전달
- 6개 LLM 도구: `workflow.create`, `workflow.list`, `workflow.run`, `workflow.delete`, `workflow.add_step`, `workflow.history`
- JSON 파일 영속성 + 실행 기록 추적 (최근 50건)

## Test plan
- [x] 436개 전체 단위 테스트 통과
- [x] Workflow/Step/Trigger 모델 Codable 라운드트립
- [x] WorkflowManager CRUD 테스트 (생성/조회/수정/삭제)
- [x] 템플릿 변수 치환 테스트 (단일/다중/누락)
- [x] 순차 실행 성공/실패/비활성 테스트
- [x] 초기 컨텍스트 전달 + 단계 간 체이닝 검증
- [x] 영속성 라운드트립 테스트

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)