### PR TITLE
feat: 텔레그램 웹훅 모드 지원

### DIFF
--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -86,6 +86,18 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(telegramStreamReplies, forKey: "telegramStreamReplies") }
     }
 
+    var telegramConnectionMode: String = UserDefaults.standard.string(forKey: "telegramConnectionMode") ?? TelegramConnectionMode.polling.rawValue {
+        didSet { UserDefaults.standard.set(telegramConnectionMode, forKey: "telegramConnectionMode") }
+    }
+
+    var telegramWebhookURL: String = UserDefaults.standard.string(forKey: "telegramWebhookURL") ?? "" {
+        didSet { UserDefaults.standard.set(telegramWebhookURL, forKey: "telegramWebhookURL") }
+    }
+
+    var telegramWebhookPort: Int = UserDefaults.standard.object(forKey: "telegramWebhookPort") as? Int ?? 8443 {
+        didSet { UserDefaults.standard.set(telegramWebhookPort, forKey: "telegramWebhookPort") }
+    }
+
     var currentWorkspaceId: String = UserDefaults.standard.string(forKey: "currentWorkspaceId") ?? "00000000-0000-0000-0000-000000000000" {
         didSet { UserDefaults.standard.set(currentWorkspaceId, forKey: "currentWorkspaceId") }
     }

--- a/Dochi/Services/Protocols/TelegramServiceProtocol.swift
+++ b/Dochi/Services/Protocols/TelegramServiceProtocol.swift
@@ -6,11 +6,39 @@ struct TelegramMediaItem: Sendable {
     let caption: String?
 }
 
+/// Connection mode for Telegram bot.
+enum TelegramConnectionMode: String, Codable, Sendable, CaseIterable {
+    case polling
+    case webhook
+
+    var displayName: String {
+        switch self {
+        case .polling: "폴링"
+        case .webhook: "웹훅"
+        }
+    }
+}
+
+/// Webhook configuration info returned by getWebhookInfo.
+struct TelegramWebhookInfo: Sendable {
+    let url: String
+    let hasCustomCertificate: Bool
+    let pendingUpdateCount: Int
+    let lastErrorDate: Int?
+    let lastErrorMessage: String?
+}
+
 @MainActor
 protocol TelegramServiceProtocol {
     var isPolling: Bool { get }
+    var isWebhookActive: Bool { get }
     func startPolling(token: String)
     func stopPolling()
+    func startWebhook(token: String, url: String, port: UInt16) async throws
+    func stopWebhook() async throws
+    func setWebhook(token: String, url: String) async throws
+    func deleteWebhook(token: String) async throws
+    func getWebhookInfo(token: String) async throws -> TelegramWebhookInfo
     func sendMessage(chatId: Int64, text: String) async throws -> Int64
     func editMessage(chatId: Int64, messageId: Int64, text: String) async throws
     func sendChatAction(chatId: Int64, action: String) async throws

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -320,6 +320,7 @@ final class MockSoundService: SoundServiceProtocol {
 @MainActor
 final class MockTelegramService: TelegramServiceProtocol {
     var isPolling = false
+    var isWebhookActive = false
     var onMessage: (@MainActor @Sendable (TelegramUpdate) -> Void)?
 
     var sentMessages: [(chatId: Int64, text: String)] = []
@@ -327,10 +328,30 @@ final class MockTelegramService: TelegramServiceProtocol {
     var chatActions: [(chatId: Int64, action: String)] = []
     var sentPhotos: [(chatId: Int64, filePath: String, caption: String?)] = []
     var sentMediaGroups: [(chatId: Int64, items: [TelegramMediaItem])] = []
+    var webhookCalls: [(token: String, url: String)] = []
     var nextMessageId: Int64 = 1000
 
     func startPolling(token: String) { isPolling = true }
     func stopPolling() { isPolling = false }
+
+    func startWebhook(token: String, url: String, port: UInt16) async throws {
+        isWebhookActive = true
+        webhookCalls.append((token: token, url: url))
+    }
+
+    func stopWebhook() async throws {
+        isWebhookActive = false
+    }
+
+    func setWebhook(token: String, url: String) async throws {
+        webhookCalls.append((token: token, url: url))
+    }
+
+    func deleteWebhook(token: String) async throws {}
+
+    func getWebhookInfo(token: String) async throws -> TelegramWebhookInfo {
+        TelegramWebhookInfo(url: "", hasCustomCertificate: false, pendingUpdateCount: 0, lastErrorDate: nil, lastErrorMessage: nil)
+    }
 
     func sendMessage(chatId: Int64, text: String) async throws -> Int64 {
         let msgId = nextMessageId


### PR DESCRIPTION
## Summary
- `TelegramConnectionMode` (polling/webhook) 열거형으로 연결 모드 전환
- `setWebhook`/`deleteWebhook`/`getWebhookInfo` Telegram Bot API 메서드 추가
- `NWListener` 기반 로컬 HTTP 서버로 웹훅 업데이트 수신
- 앱 시작 시 설정된 모드에 따라 자동 연결, 웹훅 실패 시 폴링 폴백
- 설정 UI: 연결 모드 선택기 + 웹훅 URL/포트 입력 + 상태 표시

## Test plan
- [x] 450개 전체 단위 테스트 통과
- [x] TelegramConnectionMode Codable 라운드트립
- [x] MockTelegramService 웹훅 메서드 테스트 (start/stop/set/delete/info)
- [x] 웹훅 설정 기본값 검증
- [x] HTTP body 추출 유틸리티 테스트 (정상/분리자 없음/빈 바디)
- [x] TelegramWebhookInfo 모델 테스트

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)