### PR TITLE
feat: 피어 메시지 라우팅 시스템

### DIFF
--- a/Dochi/Models/PeerMessage.swift
+++ b/Dochi/Models/PeerMessage.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+// MARK: - Message Types
+
+enum PeerMessageType: String, Codable, Sendable, CaseIterable {
+    case text
+    case ttsRequest = "tts_request"
+    case command
+    case notification
+    case taskResult = "task_result"
+
+    var displayName: String {
+        switch self {
+        case .text: "텍스트"
+        case .ttsRequest: "TTS 요청"
+        case .command: "명령"
+        case .notification: "알림"
+        case .taskResult: "태스크 결과"
+        }
+    }
+}
+
+enum PeerMessageStatus: String, Codable, Sendable {
+    case queued
+    case delivered
+    case processed
+    case expired
+    case failed
+}
+
+// MARK: - Peer Message Model
+
+struct PeerMessage: Codable, Identifiable, Sendable {
+    let id: UUID
+    let workspaceId: UUID
+    let senderDeviceId: UUID
+    let receiverDeviceId: UUID
+    var type: PeerMessageType
+    var payloadJSON: String
+    var status: PeerMessageStatus
+    let createdAt: Date
+    var deliveredAt: Date?
+    var processedAt: Date?
+    var expiresAt: Date?
+    var errorMessage: String?
+
+    init(
+        id: UUID = UUID(),
+        workspaceId: UUID,
+        senderDeviceId: UUID,
+        receiverDeviceId: UUID,
+        type: PeerMessageType,
+        payloadJSON: String = "{}",
+        status: PeerMessageStatus = .queued,
+        createdAt: Date = Date(),
+        deliveredAt: Date? = nil,
+        processedAt: Date? = nil,
+        expiresAt: Date? = nil,
+        errorMessage: String? = nil
+    ) {
+        self.id = id
+        self.workspaceId = workspaceId
+        self.senderDeviceId = senderDeviceId
+        self.receiverDeviceId = receiverDeviceId
+        self.type = type
+        self.payloadJSON = payloadJSON
+        self.status = status
+        self.createdAt = createdAt
+        self.deliveredAt = deliveredAt
+        self.processedAt = processedAt
+        self.expiresAt = expiresAt
+        self.errorMessage = errorMessage
+    }
+
+    var payload: [String: Any] {
+        guard let data = payloadJSON.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return dict
+    }
+
+    var isExpired: Bool {
+        guard let expiresAt else { return false }
+        return Date() > expiresAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case workspaceId = "workspace_id"
+        case senderDeviceId = "sender_device_id"
+        case receiverDeviceId = "receiver_device_id"
+        case type
+        case payloadJSON = "payload_json"
+        case status
+        case createdAt = "created_at"
+        case deliveredAt = "delivered_at"
+        case processedAt = "processed_at"
+        case expiresAt = "expires_at"
+        case errorMessage = "error_message"
+    }
+}
+
+// MARK: - Message Handler Protocol
+
+@MainActor
+protocol PeerMessageHandler {
+    func handle(message: PeerMessage) async -> Bool
+}
+
+// MARK: - Peer Message Router
+
+@MainActor
+final class PeerMessageRouter {
+    private(set) var inbox: [UUID: PeerMessage] = [:]      // received messages
+    private(set) var outbox: [UUID: PeerMessage] = [:]     // sent messages
+    private var handlers: [PeerMessageType: PeerMessageHandler] = [:]
+
+    let localDeviceId: UUID
+    let workspaceId: UUID
+    private let defaultTTL: TimeInterval   // seconds
+
+    init(localDeviceId: UUID, workspaceId: UUID, defaultTTL: TimeInterval = 86400) {
+        self.localDeviceId = localDeviceId
+        self.workspaceId = workspaceId
+        self.defaultTTL = defaultTTL
+    }
+
+    // MARK: - Handler Registration
+
+    func registerHandler(_ handler: PeerMessageHandler, for type: PeerMessageType) {
+        handlers[type] = handler
+    }
+
+    // MARK: - Send
+
+    @discardableResult
+    func send(
+        to receiverDeviceId: UUID,
+        type: PeerMessageType,
+        payloadJSON: String = "{}",
+        ttl: TimeInterval? = nil
+    ) -> PeerMessage {
+        let expiresAt = Date().addingTimeInterval(ttl ?? defaultTTL)
+        let message = PeerMessage(
+            workspaceId: workspaceId,
+            senderDeviceId: localDeviceId,
+            receiverDeviceId: receiverDeviceId,
+            type: type,
+            payloadJSON: payloadJSON,
+            expiresAt: expiresAt
+        )
+        outbox[message.id] = message
+        Log.cloud.info("Peer message queued: \(type.rawValue) → \(receiverDeviceId.uuidString.prefix(8))")
+        return message
+    }
+
+    // MARK: - Receive
+
+    /// Called when a message arrives (e.g., from Supabase Realtime).
+    func receive(message: PeerMessage) async {
+        // Skip if expired
+        if message.isExpired {
+            var expired = message
+            expired.status = .expired
+            inbox[message.id] = expired
+            Log.cloud.debug("Peer message expired on arrival: [\(message.id.uuidString.prefix(8))]")
+            return
+        }
+
+        var msg = message
+        msg.status = .delivered
+        msg.deliveredAt = Date()
+        inbox[msg.id] = msg
+
+        Log.cloud.info("Peer message received: \(msg.type.rawValue) from \(msg.senderDeviceId.uuidString.prefix(8))")
+
+        // Process with handler
+        if let handler = handlers[msg.type] {
+            let success = await handler.handle(message: msg)
+            msg.status = success ? .processed : .failed
+            if !success {
+                msg.errorMessage = "핸들러 처리 실패"
+            }
+            msg.processedAt = Date()
+        } else {
+            msg.status = .failed
+            msg.errorMessage = "등록된 핸들러 없음: \(msg.type.rawValue)"
+            Log.cloud.warning("No handler for peer message type: \(msg.type.rawValue)")
+        }
+        inbox[msg.id] = msg
+    }
+
+    /// Deliver queued messages for this device (called on reconnect).
+    func deliverQueued(messages: [PeerMessage]) async {
+        let pending = messages
+            .filter { $0.receiverDeviceId == localDeviceId && $0.status == .queued }
+            .sorted { $0.createdAt < $1.createdAt }
+
+        if !pending.isEmpty {
+            Log.cloud.info("Delivering \(pending.count) queued peer messages")
+        }
+
+        for message in pending {
+            await receive(message: message)
+        }
+    }
+
+    // MARK: - Query
+
+    func pendingOutbox() -> [PeerMessage] {
+        outbox.values
+            .filter { $0.status == .queued }
+            .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func recentInbox(limit: Int = 50) -> [PeerMessage] {
+        Array(
+            inbox.values
+                .sorted { $0.createdAt > $1.createdAt }
+                .prefix(limit)
+        )
+    }
+
+    func markSent(messageId: UUID) {
+        guard var msg = outbox[messageId] else { return }
+        msg.status = .delivered
+        msg.deliveredAt = Date()
+        outbox[messageId] = msg
+    }
+
+    // MARK: - Cleanup
+
+    func cleanupExpired() {
+        let now = Date()
+
+        // Expire queued messages past TTL
+        for (id, msg) in inbox where msg.status == .queued || msg.status == .delivered {
+            if let expiresAt = msg.expiresAt, expiresAt < now {
+                var expired = msg
+                expired.status = .expired
+                inbox[id] = expired
+            }
+        }
+
+        for (id, msg) in outbox where msg.status == .queued {
+            if let expiresAt = msg.expiresAt, expiresAt < now {
+                var expired = msg
+                expired.status = .expired
+                outbox[id] = expired
+            }
+        }
+    }
+
+    /// Removes processed/expired/failed messages older than cutoff.
+    func purge(olderThan interval: TimeInterval = 86400) {
+        let cutoff = Date().addingTimeInterval(-interval)
+        let terminalStatuses: Set<PeerMessageStatus> = [.processed, .expired, .failed]
+
+        inbox = inbox.filter { _, msg in
+            !(terminalStatuses.contains(msg.status) && msg.createdAt < cutoff)
+        }
+
+        outbox = outbox.filter { _, msg in
+            !(terminalStatuses.contains(msg.status) && msg.createdAt < cutoff)
+        }
+    }
+}

--- a/DochiTests/PeerMessageTests.swift
+++ b/DochiTests/PeerMessageTests.swift
@@ -1,0 +1,442 @@
+import XCTest
+@testable import Dochi
+
+// MARK: - Mock Handler
+
+@MainActor
+final class MockPeerMessageHandler: PeerMessageHandler {
+    var handledMessages: [PeerMessage] = []
+    var shouldSucceed = true
+
+    func handle(message: PeerMessage) async -> Bool {
+        handledMessages.append(message)
+        return shouldSucceed
+    }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class PeerMessageTests: XCTestCase {
+    private let deviceA = UUID()
+    private let deviceB = UUID()
+    private let workspace = UUID()
+    private var router: PeerMessageRouter!
+
+    override func setUp() {
+        super.setUp()
+        router = PeerMessageRouter(localDeviceId: deviceA, workspaceId: workspace)
+    }
+
+    // MARK: - PeerMessageType
+
+    func testMessageTypeDisplayNames() {
+        XCTAssertEqual(PeerMessageType.text.displayName, "텍스트")
+        XCTAssertEqual(PeerMessageType.ttsRequest.displayName, "TTS 요청")
+        XCTAssertEqual(PeerMessageType.command.displayName, "명령")
+        XCTAssertEqual(PeerMessageType.notification.displayName, "알림")
+        XCTAssertEqual(PeerMessageType.taskResult.displayName, "태스크 결과")
+    }
+
+    func testMessageTypeCodable() throws {
+        for type in PeerMessageType.allCases {
+            let data = try JSONEncoder().encode(type)
+            let decoded = try JSONDecoder().decode(PeerMessageType.self, from: data)
+            XCTAssertEqual(decoded, type)
+        }
+    }
+
+    // MARK: - PeerMessage Model
+
+    func testMessageInitDefaults() {
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceA,
+            receiverDeviceId: deviceB,
+            type: .text
+        )
+        XCTAssertEqual(msg.workspaceId, workspace)
+        XCTAssertEqual(msg.senderDeviceId, deviceA)
+        XCTAssertEqual(msg.receiverDeviceId, deviceB)
+        XCTAssertEqual(msg.type, .text)
+        XCTAssertEqual(msg.status, .queued)
+        XCTAssertNil(msg.deliveredAt)
+        XCTAssertNil(msg.processedAt)
+        XCTAssertNil(msg.errorMessage)
+    }
+
+    func testMessagePayloadParsing() {
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceA,
+            receiverDeviceId: deviceB,
+            type: .text,
+            payloadJSON: "{\"text\":\"hello\",\"lang\":\"ko\"}"
+        )
+        XCTAssertEqual(msg.payload["text"] as? String, "hello")
+        XCTAssertEqual(msg.payload["lang"] as? String, "ko")
+    }
+
+    func testMessagePayloadInvalidJSON() {
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceA,
+            receiverDeviceId: deviceB,
+            type: .text,
+            payloadJSON: "invalid"
+        )
+        XCTAssertTrue(msg.payload.isEmpty)
+    }
+
+    func testMessageIsExpired() {
+        let expired = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceA,
+            receiverDeviceId: deviceB,
+            type: .text,
+            expiresAt: Date().addingTimeInterval(-60)
+        )
+        XCTAssertTrue(expired.isExpired)
+
+        let notExpired = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceA,
+            receiverDeviceId: deviceB,
+            type: .text,
+            expiresAt: Date().addingTimeInterval(3600)
+        )
+        XCTAssertFalse(notExpired.isExpired)
+    }
+
+    func testMessageIsExpiredNoDeadline() {
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceA,
+            receiverDeviceId: deviceB,
+            type: .text
+        )
+        XCTAssertFalse(msg.isExpired)
+    }
+
+    func testMessageCodableRoundtrip() throws {
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceA,
+            receiverDeviceId: deviceB,
+            type: .ttsRequest,
+            payloadJSON: "{\"text\":\"안녕\"}",
+            expiresAt: Date().addingTimeInterval(3600)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(msg)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(PeerMessage.self, from: data)
+
+        XCTAssertEqual(decoded.id, msg.id)
+        XCTAssertEqual(decoded.workspaceId, workspace)
+        XCTAssertEqual(decoded.type, .ttsRequest)
+        XCTAssertEqual(decoded.status, .queued)
+        XCTAssertNotNil(decoded.expiresAt)
+    }
+
+    func testMessageCodingKeysSnakeCase() throws {
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceA,
+            receiverDeviceId: deviceB,
+            type: .command,
+            payloadJSON: "{}"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(msg)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertNotNil(json["workspace_id"])
+        XCTAssertNotNil(json["sender_device_id"])
+        XCTAssertNotNil(json["receiver_device_id"])
+        XCTAssertNotNil(json["payload_json"])
+        XCTAssertNotNil(json["created_at"])
+    }
+
+    // MARK: - Router: Send
+
+    func testSendAddsToOutbox() {
+        let msg = router.send(to: deviceB, type: .text, payloadJSON: "{\"text\":\"hi\"}")
+        XCTAssertEqual(msg.status, .queued)
+        XCTAssertEqual(msg.senderDeviceId, deviceA)
+        XCTAssertEqual(msg.receiverDeviceId, deviceB)
+        XCTAssertEqual(msg.workspaceId, workspace)
+        XCTAssertNotNil(msg.expiresAt)
+        XCTAssertEqual(router.pendingOutbox().count, 1)
+    }
+
+    func testSendMultiple() {
+        router.send(to: deviceB, type: .text)
+        router.send(to: deviceB, type: .ttsRequest)
+        router.send(to: deviceB, type: .notification)
+        XCTAssertEqual(router.pendingOutbox().count, 3)
+    }
+
+    func testSendCustomTTL() {
+        let msg = router.send(to: deviceB, type: .text, ttl: 60)
+        let expiresAt = msg.expiresAt!
+        // Should expire within ~60-62 seconds
+        let interval = expiresAt.timeIntervalSince(msg.createdAt)
+        XCTAssertEqual(interval, 60, accuracy: 2)
+    }
+
+    // MARK: - Router: Receive
+
+    func testReceiveWithHandler() async {
+        let handler = MockPeerMessageHandler()
+        router.registerHandler(handler, for: .text)
+
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .text,
+            payloadJSON: "{\"text\":\"hello\"}"
+        )
+        await router.receive(message: msg)
+
+        XCTAssertEqual(handler.handledMessages.count, 1)
+        let stored = router.inbox[msg.id]!
+        XCTAssertEqual(stored.status, .processed)
+        XCTAssertNotNil(stored.deliveredAt)
+        XCTAssertNotNil(stored.processedAt)
+    }
+
+    func testReceiveWithFailingHandler() async {
+        let handler = MockPeerMessageHandler()
+        handler.shouldSucceed = false
+        router.registerHandler(handler, for: .command)
+
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .command
+        )
+        await router.receive(message: msg)
+
+        let stored = router.inbox[msg.id]!
+        XCTAssertEqual(stored.status, .failed)
+        XCTAssertNotNil(stored.errorMessage)
+    }
+
+    func testReceiveNoHandler() async {
+        // No handler registered for .notification
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .notification
+        )
+        await router.receive(message: msg)
+
+        let stored = router.inbox[msg.id]!
+        XCTAssertEqual(stored.status, .failed)
+        XCTAssertTrue(stored.errorMessage?.contains("핸들러") ?? false)
+    }
+
+    func testReceiveExpiredMessage() async {
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .text,
+            expiresAt: Date().addingTimeInterval(-60) // already expired
+        )
+        await router.receive(message: msg)
+
+        let stored = router.inbox[msg.id]!
+        XCTAssertEqual(stored.status, .expired)
+    }
+
+    // MARK: - Router: Deliver Queued
+
+    func testDeliverQueuedMessages() async {
+        let handler = MockPeerMessageHandler()
+        router.registerHandler(handler, for: .text)
+        router.registerHandler(handler, for: .notification)
+
+        let messages = [
+            PeerMessage(
+                workspaceId: workspace,
+                senderDeviceId: deviceB,
+                receiverDeviceId: deviceA,
+                type: .text,
+                payloadJSON: "{\"text\":\"msg1\"}"
+            ),
+            PeerMessage(
+                workspaceId: workspace,
+                senderDeviceId: deviceB,
+                receiverDeviceId: deviceA,
+                type: .notification,
+                payloadJSON: "{\"text\":\"msg2\"}"
+            ),
+            // This one is for a different device — should be skipped
+            PeerMessage(
+                workspaceId: workspace,
+                senderDeviceId: deviceB,
+                receiverDeviceId: UUID(),
+                type: .text
+            ),
+        ]
+
+        await router.deliverQueued(messages: messages)
+        XCTAssertEqual(handler.handledMessages.count, 2)
+    }
+
+    func testDeliverQueuedSkipsNonQueued() async {
+        let handler = MockPeerMessageHandler()
+        router.registerHandler(handler, for: .text)
+
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .text,
+            status: .delivered // not queued
+        )
+        await router.deliverQueued(messages: [msg])
+        XCTAssertEqual(handler.handledMessages.count, 0)
+    }
+
+    // MARK: - Router: Query
+
+    func testRecentInbox() async {
+        let handler = MockPeerMessageHandler()
+        router.registerHandler(handler, for: .text)
+
+        for _ in 0..<5 {
+            let msg = PeerMessage(
+                workspaceId: workspace,
+                senderDeviceId: deviceB,
+                receiverDeviceId: deviceA,
+                type: .text
+            )
+            await router.receive(message: msg)
+        }
+
+        let recent = router.recentInbox(limit: 3)
+        XCTAssertEqual(recent.count, 3)
+    }
+
+    func testMarkSent() {
+        let msg = router.send(to: deviceB, type: .text)
+        XCTAssertEqual(router.outbox[msg.id]!.status, .queued)
+
+        router.markSent(messageId: msg.id)
+        XCTAssertEqual(router.outbox[msg.id]!.status, .delivered)
+        XCTAssertNotNil(router.outbox[msg.id]!.deliveredAt)
+    }
+
+    func testMarkSentNonExistent() {
+        router.markSent(messageId: UUID()) // should not crash
+    }
+
+    // MARK: - Router: Cleanup
+
+    func testCleanupExpired() {
+        // Send message with very short TTL (already expired)
+        let msg = router.send(to: deviceB, type: .text, ttl: -60)
+        XCTAssertEqual(router.outbox[msg.id]!.status, .queued)
+
+        router.cleanupExpired()
+        XCTAssertEqual(router.outbox[msg.id]!.status, .expired)
+    }
+
+    func testCleanupKeepsValidMessages() {
+        let msg = router.send(to: deviceB, type: .text, ttl: 3600)
+        router.cleanupExpired()
+        XCTAssertEqual(router.outbox[msg.id]!.status, .queued)
+    }
+
+    func testPurgeRemovesOldProcessed() async {
+        let handler = MockPeerMessageHandler()
+        router.registerHandler(handler, for: .text)
+
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .text,
+            createdAt: Date().addingTimeInterval(-200_000)
+        )
+        await router.receive(message: msg)
+
+        // Verify it's in inbox
+        XCTAssertNotNil(router.inbox[msg.id])
+
+        router.purge(olderThan: 86400)
+        XCTAssertNil(router.inbox[msg.id])
+    }
+
+    func testPurgeKeepsRecentMessages() async {
+        let handler = MockPeerMessageHandler()
+        router.registerHandler(handler, for: .text)
+
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .text
+        )
+        await router.receive(message: msg)
+
+        router.purge(olderThan: 86400)
+        XCTAssertNotNil(router.inbox[msg.id]) // recent, should stay
+    }
+
+    // MARK: - Router: Handler Registration
+
+    func testRegisterMultipleHandlers() async {
+        let textHandler = MockPeerMessageHandler()
+        let ttsHandler = MockPeerMessageHandler()
+        router.registerHandler(textHandler, for: .text)
+        router.registerHandler(ttsHandler, for: .ttsRequest)
+
+        let textMsg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .text
+        )
+        let ttsMsg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .ttsRequest
+        )
+
+        await router.receive(message: textMsg)
+        await router.receive(message: ttsMsg)
+
+        XCTAssertEqual(textHandler.handledMessages.count, 1)
+        XCTAssertEqual(ttsHandler.handledMessages.count, 1)
+    }
+
+    func testReplaceHandler() async {
+        let handler1 = MockPeerMessageHandler()
+        let handler2 = MockPeerMessageHandler()
+        router.registerHandler(handler1, for: .text)
+        router.registerHandler(handler2, for: .text) // replace
+
+        let msg = PeerMessage(
+            workspaceId: workspace,
+            senderDeviceId: deviceB,
+            receiverDeviceId: deviceA,
+            type: .text
+        )
+        await router.receive(message: msg)
+
+        XCTAssertEqual(handler1.handledMessages.count, 0)
+        XCTAssertEqual(handler2.handledMessages.count, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- `PeerMessage` 모델: 5가지 메시지 타입(text/tts_request/command/notification/task_result), 상태 추적(queued→delivered→processed), TTL 기반 만료
- `PeerMessageRouter`: 메시지 송수신, 핸들러 등록 패턴, 오프라인 큐 전달, 만료 정리
- `PeerMessageHandler` 프로토콜: 메시지 타입별 처리 위임 (TTS 재생, 명령 실행 등)
- Supabase CodingKeys로 snake_case DB 호환

Closes #16

## Test plan
- [x] PeerMessageType Codable + displayName
- [x] PeerMessage 모델 기본값, payload 파싱, 만료 판정, Codable roundtrip
- [x] Router 송신: outbox 추가, 복수 전송, 커스텀 TTL
- [x] Router 수신: 핸들러 성공/실패/미등록, 만료 메시지 스킵
- [x] 큐 전달: 자기 디바이스만 처리, 비-queued 상태 스킵
- [x] 정리: 만료 처리, 오래된 메시지 purge, 최근 메시지 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)