### PR TITLE
feat: 코딩 에이전트 세션 관리 시스템

### DIFF
--- a/Dochi/Models/CodingSession.swift
+++ b/Dochi/Models/CodingSession.swift
@@ -1,0 +1,241 @@
+import Foundation
+
+// MARK: - Coding Agent Types
+
+enum CodingAgentType: String, Codable, Sendable, CaseIterable {
+    case claudeCode = "claude_code"
+    case codex
+
+    var cliName: String {
+        switch self {
+        case .claudeCode: "claude"
+        case .codex: "codex"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .claudeCode: "Claude Code"
+        case .codex: "Codex"
+        }
+    }
+}
+
+enum CodingSessionStatus: String, Codable, Sendable {
+    case active
+    case paused
+    case completed
+    case failed
+}
+
+// MARK: - Session Step
+
+struct CodingSessionStep: Codable, Identifiable, Sendable {
+    let id: UUID
+    let instruction: String
+    var output: String?
+    var isSuccess: Bool?
+    let startedAt: Date
+    var completedAt: Date?
+
+    init(
+        id: UUID = UUID(),
+        instruction: String,
+        output: String? = nil,
+        isSuccess: Bool? = nil,
+        startedAt: Date = Date(),
+        completedAt: Date? = nil
+    ) {
+        self.id = id
+        self.instruction = instruction
+        self.output = output
+        self.isSuccess = isSuccess
+        self.startedAt = startedAt
+        self.completedAt = completedAt
+    }
+
+    var duration: TimeInterval? {
+        guard let completedAt else { return nil }
+        return completedAt.timeIntervalSince(startedAt)
+    }
+}
+
+// MARK: - Session Model
+
+struct CodingSession: Codable, Identifiable, Sendable {
+    let id: UUID
+    var agentType: CodingAgentType
+    var workingDirectory: String
+    var status: CodingSessionStatus
+    var steps: [CodingSessionStep]
+    let startedAt: Date
+    var lastActivityAt: Date
+    var summary: String?
+
+    init(
+        id: UUID = UUID(),
+        agentType: CodingAgentType,
+        workingDirectory: String,
+        status: CodingSessionStatus = .active,
+        steps: [CodingSessionStep] = [],
+        startedAt: Date = Date(),
+        lastActivityAt: Date = Date(),
+        summary: String? = nil
+    ) {
+        self.id = id
+        self.agentType = agentType
+        self.workingDirectory = workingDirectory
+        self.status = status
+        self.steps = steps
+        self.startedAt = startedAt
+        self.lastActivityAt = lastActivityAt
+        self.summary = summary
+    }
+
+    var totalDuration: TimeInterval {
+        lastActivityAt.timeIntervalSince(startedAt)
+    }
+
+    var stepCount: Int { steps.count }
+
+    var successfulSteps: Int {
+        steps.filter { $0.isSuccess == true }.count
+    }
+
+    var failedSteps: Int {
+        steps.filter { $0.isSuccess == false }.count
+    }
+
+    var lastOutput: String? {
+        steps.last?.output
+    }
+}
+
+// MARK: - Session Manager
+
+@MainActor
+final class CodingSessionManager {
+    var sessions: [UUID: CodingSession] = [:]
+
+    init() {}
+
+    // MARK: - Session CRUD
+
+    @discardableResult
+    func createSession(
+        agentType: CodingAgentType,
+        workingDirectory: String
+    ) -> CodingSession {
+        let session = CodingSession(
+            agentType: agentType,
+            workingDirectory: workingDirectory
+        )
+        sessions[session.id] = session
+        Log.tool.info("Coding session created: \(agentType.displayName) @ \(workingDirectory)")
+        return session
+    }
+
+    func session(id: UUID) -> CodingSession? {
+        sessions[id]
+    }
+
+    func activeSessions() -> [CodingSession] {
+        sessions.values
+            .filter { $0.status == .active }
+            .sorted { $0.lastActivityAt > $1.lastActivityAt }
+    }
+
+    func allSessions(limit: Int = 20) -> [CodingSession] {
+        Array(
+            sessions.values
+                .sorted { $0.startedAt > $1.startedAt }
+                .prefix(limit)
+        )
+    }
+
+    // MARK: - Step Tracking
+
+    @discardableResult
+    func addStep(sessionId: UUID, instruction: String) -> CodingSessionStep? {
+        guard var session = sessions[sessionId], session.status == .active else { return nil }
+        let step = CodingSessionStep(instruction: instruction)
+        session.steps.append(step)
+        session.lastActivityAt = Date()
+        sessions[sessionId] = session
+        Log.tool.debug("Step added to session [\(sessionId.uuidString.prefix(8))]: \(instruction.prefix(60))")
+        return step
+    }
+
+    func completeStep(sessionId: UUID, stepId: UUID, output: String, isSuccess: Bool) -> Bool {
+        guard var session = sessions[sessionId] else { return false }
+        guard let idx = session.steps.firstIndex(where: { $0.id == stepId }) else { return false }
+
+        session.steps[idx].output = output
+        session.steps[idx].isSuccess = isSuccess
+        session.steps[idx].completedAt = Date()
+        session.lastActivityAt = Date()
+        sessions[sessionId] = session
+        return true
+    }
+
+    // MARK: - Status Updates
+
+    func pauseSession(id: UUID) -> Bool {
+        guard var session = sessions[id], session.status == .active else { return false }
+        session.status = .paused
+        session.lastActivityAt = Date()
+        sessions[id] = session
+        Log.tool.info("Coding session paused: [\(id.uuidString.prefix(8))]")
+        return true
+    }
+
+    func resumeSession(id: UUID) -> Bool {
+        guard var session = sessions[id], session.status == .paused else { return false }
+        session.status = .active
+        session.lastActivityAt = Date()
+        sessions[id] = session
+        Log.tool.info("Coding session resumed: [\(id.uuidString.prefix(8))]")
+        return true
+    }
+
+    func completeSession(id: UUID, summary: String? = nil) -> Bool {
+        guard var session = sessions[id],
+              session.status == .active || session.status == .paused else { return false }
+        session.status = .completed
+        session.summary = summary
+        session.lastActivityAt = Date()
+        sessions[id] = session
+        Log.tool.info("Coding session completed: [\(id.uuidString.prefix(8))]")
+        return true
+    }
+
+    func failSession(id: UUID, summary: String? = nil) -> Bool {
+        guard var session = sessions[id],
+              session.status == .active || session.status == .paused else { return false }
+        session.status = .failed
+        session.summary = summary
+        session.lastActivityAt = Date()
+        sessions[id] = session
+        Log.tool.error("Coding session failed: [\(id.uuidString.prefix(8))]")
+        return true
+    }
+
+    // MARK: - Cleanup
+
+    func removeSession(id: UUID) -> Bool {
+        sessions.removeValue(forKey: id) != nil
+    }
+
+    func cleanupCompleted(olderThan interval: TimeInterval = 86400 * 7) {
+        let cutoff = Date().addingTimeInterval(-interval)
+        let toRemove = sessions.values.filter {
+            ($0.status == .completed || $0.status == .failed) && $0.lastActivityAt < cutoff
+        }
+        for session in toRemove {
+            sessions.removeValue(forKey: session.id)
+        }
+        if !toRemove.isEmpty {
+            Log.tool.debug("Cleaned up \(toRemove.count) old coding sessions")
+        }
+    }
+}

--- a/Dochi/Services/Tools/BuiltInToolService.swift
+++ b/Dochi/Services/Tools/BuiltInToolService.swift
@@ -214,6 +214,13 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
         registry.register(CodingRunTaskTool())
         registry.register(CodingReviewTool())
 
+        // Coding session management (conditional, safe/restricted)
+        let codingSessionManager = CodingSessionManager()
+        registry.register(CodingSessionListTool(sessionManager: codingSessionManager))
+        registry.register(CodingSessionStartTool(sessionManager: codingSessionManager))
+        registry.register(CodingSessionPauseTool(sessionManager: codingSessionManager))
+        registry.register(CodingSessionEndTool(sessionManager: codingSessionManager))
+
         // MCP settings (conditional, sensitive)
         registry.register(MCPAddServerTool(mcpService: mcpService))
         registry.register(MCPUpdateServerTool(mcpService: mcpService))

--- a/Dochi/Services/Tools/CodingSessionTool.swift
+++ b/Dochi/Services/Tools/CodingSessionTool.swift
@@ -1,0 +1,262 @@
+import Foundation
+
+// MARK: - Session List Tool
+
+@MainActor
+final class CodingSessionListTool: BuiltInToolProtocol {
+    let name = "coding.sessions"
+    let category: ToolCategory = .safe
+    let description = "현재 코딩 에이전트 세션 목록을 조회합니다."
+    let isBaseline = false
+
+    private let sessionManager: CodingSessionManager
+
+    init(sessionManager: CodingSessionManager) {
+        self.sessionManager = sessionManager
+    }
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "status": [
+                    "type": "string",
+                    "enum": ["active", "paused", "completed", "failed", "all"],
+                    "description": "필터할 상태 (기본: all)",
+                ],
+            ] as [String: Any],
+            "required": [] as [String],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        let filterStatus = arguments["status"] as? String ?? "all"
+
+        let sessions: [CodingSession]
+        if filterStatus == "all" {
+            sessions = sessionManager.allSessions()
+        } else if filterStatus == "active" {
+            sessions = sessionManager.activeSessions()
+        } else {
+            let status = CodingSessionStatus(rawValue: filterStatus)
+            sessions = sessionManager.allSessions().filter { $0.status == status }
+        }
+
+        guard !sessions.isEmpty else {
+            return ToolResult(toolCallId: "", content: "코딩 세션이 없습니다.")
+        }
+
+        let lines = sessions.map { s in
+            let statusIcon: String
+            switch s.status {
+            case .active: statusIcon = "▶️"
+            case .paused: statusIcon = "⏸️"
+            case .completed: statusIcon = "✅"
+            case .failed: statusIcon = "❌"
+            }
+            return "\(statusIcon) [\(s.id.uuidString.prefix(8))] \(s.agentType.displayName) — \(s.workingDirectory) (\(s.stepCount)단계)"
+        }
+
+        return ToolResult(toolCallId: "", content: "코딩 세션 목록 (\(sessions.count)개):\n" + lines.joined(separator: "\n"))
+    }
+}
+
+// MARK: - Session Start Tool
+
+@MainActor
+final class CodingSessionStartTool: BuiltInToolProtocol {
+    let name = "coding.session_start"
+    let category: ToolCategory = .restricted
+    let description = "새 코딩 에이전트 세션을 시작합니다."
+    let isBaseline = false
+
+    private let sessionManager: CodingSessionManager
+
+    init(sessionManager: CodingSessionManager) {
+        self.sessionManager = sessionManager
+    }
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "work_dir": ["type": "string", "description": "작업 디렉토리 경로"],
+                "agent": [
+                    "type": "string",
+                    "enum": ["claude_code", "codex"],
+                    "description": "코딩 에이전트 유형 (기본: claude_code)",
+                ],
+            ] as [String: Any],
+            "required": ["work_dir"],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        guard let workDir = arguments["work_dir"] as? String, !workDir.isEmpty else {
+            return ToolResult(toolCallId: "", content: "work_dir 파라미터가 필요합니다.", isError: true)
+        }
+
+        let expandedDir = NSString(string: workDir).expandingTildeInPath
+        guard FileManager.default.fileExists(atPath: expandedDir) else {
+            return ToolResult(toolCallId: "", content: "디렉토리를 찾을 수 없습니다: \(workDir)", isError: true)
+        }
+
+        let agentRaw = arguments["agent"] as? String ?? "claude_code"
+        let agentType = CodingAgentType(rawValue: agentRaw) ?? .claudeCode
+
+        let session = sessionManager.createSession(
+            agentType: agentType,
+            workingDirectory: expandedDir
+        )
+
+        return ToolResult(toolCallId: "", content: """
+            세션 시작됨:
+            - ID: \(session.id.uuidString.prefix(8))
+            - 에이전트: \(session.agentType.displayName)
+            - 디렉토리: \(session.workingDirectory)
+            """)
+    }
+}
+
+// MARK: - Session Pause/Resume Tool
+
+@MainActor
+final class CodingSessionPauseTool: BuiltInToolProtocol {
+    let name = "coding.session_pause"
+    let category: ToolCategory = .safe
+    let description = "코딩 세션을 일시정지하거나 재개합니다."
+    let isBaseline = false
+
+    private let sessionManager: CodingSessionManager
+
+    init(sessionManager: CodingSessionManager) {
+        self.sessionManager = sessionManager
+    }
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "session_id": ["type": "string", "description": "세션 UUID (앞 8자리 가능)"],
+                "action": [
+                    "type": "string",
+                    "enum": ["pause", "resume"],
+                    "description": "일시정지 또는 재개",
+                ],
+            ] as [String: Any],
+            "required": ["session_id", "action"],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        guard let sessionIdStr = arguments["session_id"] as? String else {
+            return ToolResult(toolCallId: "", content: "session_id가 필요합니다.", isError: true)
+        }
+        guard let action = arguments["action"] as? String else {
+            return ToolResult(toolCallId: "", content: "action이 필요합니다.", isError: true)
+        }
+
+        let sessionId = resolveSessionId(sessionIdStr)
+        guard let sessionId else {
+            return ToolResult(toolCallId: "", content: "세션을 찾을 수 없습니다: \(sessionIdStr)", isError: true)
+        }
+
+        let success: Bool
+        if action == "pause" {
+            success = sessionManager.pauseSession(id: sessionId)
+        } else {
+            success = sessionManager.resumeSession(id: sessionId)
+        }
+
+        guard success else {
+            return ToolResult(toolCallId: "", content: "세션 상태 변경 실패. 현재 상태를 확인해주세요.", isError: true)
+        }
+
+        return ToolResult(toolCallId: "", content: "세션 [\(sessionId.uuidString.prefix(8))] \(action == "pause" ? "일시정지" : "재개")됨")
+    }
+
+    private func resolveSessionId(_ input: String) -> UUID? {
+        if let uuid = UUID(uuidString: input) {
+            return sessionManager.session(id: uuid) != nil ? uuid : nil
+        }
+        // Partial match
+        let lowered = input.lowercased()
+        return sessionManager.allSessions()
+            .first { $0.id.uuidString.lowercased().hasPrefix(lowered) }?.id
+    }
+}
+
+// MARK: - Session End Tool
+
+@MainActor
+final class CodingSessionEndTool: BuiltInToolProtocol {
+    let name = "coding.session_end"
+    let category: ToolCategory = .safe
+    let description = "코딩 세션을 완료 또는 실패로 종료합니다."
+    let isBaseline = false
+
+    private let sessionManager: CodingSessionManager
+
+    init(sessionManager: CodingSessionManager) {
+        self.sessionManager = sessionManager
+    }
+
+    var inputSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "session_id": ["type": "string", "description": "세션 UUID (앞 8자리 가능)"],
+                "result": [
+                    "type": "string",
+                    "enum": ["completed", "failed"],
+                    "description": "종료 상태 (기본: completed)",
+                ],
+                "summary": ["type": "string", "description": "작업 요약"],
+            ] as [String: Any],
+            "required": ["session_id"],
+        ]
+    }
+
+    func execute(arguments: [String: Any]) async -> ToolResult {
+        guard let sessionIdStr = arguments["session_id"] as? String else {
+            return ToolResult(toolCallId: "", content: "session_id가 필요합니다.", isError: true)
+        }
+
+        let result = arguments["result"] as? String ?? "completed"
+        let summary = arguments["summary"] as? String
+
+        let sessionId = resolveSessionId(sessionIdStr)
+        guard let sessionId else {
+            return ToolResult(toolCallId: "", content: "세션을 찾을 수 없습니다: \(sessionIdStr)", isError: true)
+        }
+
+        let success: Bool
+        if result == "failed" {
+            success = sessionManager.failSession(id: sessionId, summary: summary)
+        } else {
+            success = sessionManager.completeSession(id: sessionId, summary: summary)
+        }
+
+        guard success else {
+            return ToolResult(toolCallId: "", content: "세션 종료 실패.", isError: true)
+        }
+
+        let session = sessionManager.session(id: sessionId)!
+        return ToolResult(toolCallId: "", content: """
+            세션 종료됨:
+            - ID: \(sessionId.uuidString.prefix(8))
+            - 상태: \(result == "failed" ? "실패" : "완료")
+            - 총 단계: \(session.stepCount) (성공: \(session.successfulSteps), 실패: \(session.failedSteps))
+            \(summary.map { "- 요약: \($0)" } ?? "")
+            """)
+    }
+
+    private func resolveSessionId(_ input: String) -> UUID? {
+        if let uuid = UUID(uuidString: input) {
+            return sessionManager.session(id: uuid) != nil ? uuid : nil
+        }
+        let lowered = input.lowercased()
+        return sessionManager.allSessions()
+            .first { $0.id.uuidString.lowercased().hasPrefix(lowered) }?.id
+    }
+}

--- a/DochiTests/CodingSessionTests.swift
+++ b/DochiTests/CodingSessionTests.swift
@@ -1,0 +1,415 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class CodingSessionTests: XCTestCase {
+
+    // MARK: - CodingAgentType
+
+    func testAgentTypeCliNames() {
+        XCTAssertEqual(CodingAgentType.claudeCode.cliName, "claude")
+        XCTAssertEqual(CodingAgentType.codex.cliName, "codex")
+    }
+
+    func testAgentTypeDisplayNames() {
+        XCTAssertEqual(CodingAgentType.claudeCode.displayName, "Claude Code")
+        XCTAssertEqual(CodingAgentType.codex.displayName, "Codex")
+    }
+
+    func testAgentTypeCodable() throws {
+        for type in CodingAgentType.allCases {
+            let data = try JSONEncoder().encode(type)
+            let decoded = try JSONDecoder().decode(CodingAgentType.self, from: data)
+            XCTAssertEqual(decoded, type)
+        }
+    }
+
+    func testAgentTypeRawValues() {
+        XCTAssertEqual(CodingAgentType.claudeCode.rawValue, "claude_code")
+        XCTAssertEqual(CodingAgentType.codex.rawValue, "codex")
+    }
+
+    // MARK: - CodingSessionStep
+
+    func testStepInitDefaults() {
+        let step = CodingSessionStep(instruction: "테스트 추가")
+        XCTAssertEqual(step.instruction, "테스트 추가")
+        XCTAssertNil(step.output)
+        XCTAssertNil(step.isSuccess)
+        XCTAssertNil(step.completedAt)
+        XCTAssertNil(step.duration)
+    }
+
+    func testStepDuration() {
+        let started = Date()
+        let completed = started.addingTimeInterval(30)
+        let step = CodingSessionStep(
+            instruction: "test",
+            output: "ok",
+            isSuccess: true,
+            startedAt: started,
+            completedAt: completed
+        )
+        XCTAssertEqual(step.duration!, 30, accuracy: 0.01)
+    }
+
+    func testStepCodable() throws {
+        let step = CodingSessionStep(
+            instruction: "fix bug",
+            output: "done",
+            isSuccess: true,
+            completedAt: Date()
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(step)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(CodingSessionStep.self, from: data)
+        XCTAssertEqual(decoded.id, step.id)
+        XCTAssertEqual(decoded.instruction, "fix bug")
+        XCTAssertEqual(decoded.isSuccess, true)
+    }
+
+    // MARK: - CodingSession Model
+
+    func testSessionInitDefaults() {
+        let session = CodingSession(
+            agentType: .claudeCode,
+            workingDirectory: "/tmp/project"
+        )
+        XCTAssertEqual(session.agentType, .claudeCode)
+        XCTAssertEqual(session.workingDirectory, "/tmp/project")
+        XCTAssertEqual(session.status, .active)
+        XCTAssertTrue(session.steps.isEmpty)
+        XCTAssertEqual(session.stepCount, 0)
+        XCTAssertEqual(session.successfulSteps, 0)
+        XCTAssertEqual(session.failedSteps, 0)
+        XCTAssertNil(session.summary)
+        XCTAssertNil(session.lastOutput)
+    }
+
+    func testSessionStepCounts() {
+        var session = CodingSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        session.steps = [
+            CodingSessionStep(instruction: "a", isSuccess: true),
+            CodingSessionStep(instruction: "b", isSuccess: false),
+            CodingSessionStep(instruction: "c", isSuccess: true),
+            CodingSessionStep(instruction: "d"), // in progress
+        ]
+        XCTAssertEqual(session.stepCount, 4)
+        XCTAssertEqual(session.successfulSteps, 2)
+        XCTAssertEqual(session.failedSteps, 1)
+    }
+
+    func testSessionLastOutput() {
+        var session = CodingSession(agentType: .codex, workingDirectory: "/tmp")
+        session.steps = [
+            CodingSessionStep(instruction: "a", output: "first"),
+            CodingSessionStep(instruction: "b", output: "second"),
+        ]
+        XCTAssertEqual(session.lastOutput, "second")
+    }
+
+    func testSessionCodable() throws {
+        let session = CodingSession(
+            agentType: .codex,
+            workingDirectory: "/home/project",
+            summary: "테스트 완료"
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(session)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(CodingSession.self, from: data)
+        XCTAssertEqual(decoded.id, session.id)
+        XCTAssertEqual(decoded.agentType, .codex)
+        XCTAssertEqual(decoded.summary, "테스트 완료")
+    }
+
+    // MARK: - Session Manager: Create
+
+    func testCreateSession() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp/test")
+        XCTAssertEqual(session.status, .active)
+        XCTAssertEqual(session.agentType, .claudeCode)
+        XCTAssertNotNil(manager.session(id: session.id))
+    }
+
+    func testCreateMultipleSessions() {
+        let manager = CodingSessionManager()
+        manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp/a")
+        manager.createSession(agentType: .codex, workingDirectory: "/tmp/b")
+        XCTAssertEqual(manager.allSessions().count, 2)
+    }
+
+    // MARK: - Session Manager: Active Sessions
+
+    func testActiveSessions() {
+        let manager = CodingSessionManager()
+        let s1 = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp/a")
+        manager.createSession(agentType: .codex, workingDirectory: "/tmp/b")
+
+        XCTAssertEqual(manager.activeSessions().count, 2)
+
+        _ = manager.pauseSession(id: s1.id)
+        XCTAssertEqual(manager.activeSessions().count, 1)
+    }
+
+    // MARK: - Session Manager: Steps
+
+    func testAddStep() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        let step = manager.addStep(sessionId: session.id, instruction: "테스트 작성")
+        XCTAssertNotNil(step)
+        XCTAssertEqual(manager.session(id: session.id)!.stepCount, 1)
+    }
+
+    func testAddStepToNonActiveSession() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        _ = manager.completeSession(id: session.id)
+        let step = manager.addStep(sessionId: session.id, instruction: "more work")
+        XCTAssertNil(step) // can't add to completed session
+    }
+
+    func testCompleteStep() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        let step = manager.addStep(sessionId: session.id, instruction: "fix bug")!
+        let result = manager.completeStep(sessionId: session.id, stepId: step.id, output: "fixed!", isSuccess: true)
+        XCTAssertTrue(result)
+
+        let updated = manager.session(id: session.id)!
+        XCTAssertEqual(updated.steps[0].output, "fixed!")
+        XCTAssertEqual(updated.steps[0].isSuccess, true)
+        XCTAssertNotNil(updated.steps[0].completedAt)
+    }
+
+    func testCompleteStepNonExistent() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        let result = manager.completeStep(sessionId: session.id, stepId: UUID(), output: "ok", isSuccess: true)
+        XCTAssertFalse(result)
+    }
+
+    // MARK: - Session Manager: Status Updates
+
+    func testPauseAndResume() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+
+        XCTAssertTrue(manager.pauseSession(id: session.id))
+        XCTAssertEqual(manager.session(id: session.id)!.status, .paused)
+
+        XCTAssertTrue(manager.resumeSession(id: session.id))
+        XCTAssertEqual(manager.session(id: session.id)!.status, .active)
+    }
+
+    func testPauseNonActive() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        _ = manager.completeSession(id: session.id)
+        XCTAssertFalse(manager.pauseSession(id: session.id)) // can't pause completed
+    }
+
+    func testResumeNonPaused() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        XCTAssertFalse(manager.resumeSession(id: session.id)) // active, not paused
+    }
+
+    func testCompleteSession() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        XCTAssertTrue(manager.completeSession(id: session.id, summary: "All done"))
+        let updated = manager.session(id: session.id)!
+        XCTAssertEqual(updated.status, .completed)
+        XCTAssertEqual(updated.summary, "All done")
+    }
+
+    func testCompleteFromPaused() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        _ = manager.pauseSession(id: session.id)
+        XCTAssertTrue(manager.completeSession(id: session.id))
+    }
+
+    func testCompleteAlreadyCompleted() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        _ = manager.completeSession(id: session.id)
+        XCTAssertFalse(manager.completeSession(id: session.id)) // already completed
+    }
+
+    func testFailSession() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        XCTAssertTrue(manager.failSession(id: session.id, summary: "Build error"))
+        let updated = manager.session(id: session.id)!
+        XCTAssertEqual(updated.status, .failed)
+        XCTAssertEqual(updated.summary, "Build error")
+    }
+
+    // MARK: - Session Manager: Cleanup
+
+    func testRemoveSession() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        XCTAssertTrue(manager.removeSession(id: session.id))
+        XCTAssertNil(manager.session(id: session.id))
+    }
+
+    func testRemoveNonExistent() {
+        let manager = CodingSessionManager()
+        XCTAssertFalse(manager.removeSession(id: UUID()))
+    }
+
+    func testCleanupCompleted() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        _ = manager.completeSession(id: session.id)
+
+        // Move lastActivityAt to distant past
+        manager.sessions[session.id]!.lastActivityAt = Date().addingTimeInterval(-1_000_000)
+
+        manager.cleanupCompleted(olderThan: 86400 * 7)
+        XCTAssertNil(manager.session(id: session.id))
+    }
+
+    func testCleanupKeepsRecent() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        _ = manager.completeSession(id: session.id)
+
+        manager.cleanupCompleted(olderThan: 86400 * 7)
+        XCTAssertNotNil(manager.session(id: session.id)) // recent
+    }
+
+    func testCleanupKeepsActive() {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        manager.sessions[session.id]!.lastActivityAt = Date().addingTimeInterval(-1_000_000)
+
+        manager.cleanupCompleted(olderThan: 86400 * 7)
+        XCTAssertNotNil(manager.session(id: session.id)) // active, not cleaned
+    }
+
+    // MARK: - Session Tools
+
+    func testSessionListToolEmpty() async {
+        let manager = CodingSessionManager()
+        let tool = CodingSessionListTool(sessionManager: manager)
+        XCTAssertEqual(tool.name, "coding.sessions")
+        XCTAssertEqual(tool.category, .safe)
+        XCTAssertFalse(tool.isBaseline)
+
+        let result = await tool.execute(arguments: [:])
+        XCTAssertTrue(result.content.contains("없습니다"))
+    }
+
+    func testSessionListToolWithSessions() async {
+        let manager = CodingSessionManager()
+        manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp/a")
+        manager.createSession(agentType: .codex, workingDirectory: "/tmp/b")
+
+        let tool = CodingSessionListTool(sessionManager: manager)
+        let result = await tool.execute(arguments: [:])
+        XCTAssertTrue(result.content.contains("2개"))
+    }
+
+    func testSessionListToolFilterActive() async {
+        let manager = CodingSessionManager()
+        let s1 = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp/a")
+        manager.createSession(agentType: .codex, workingDirectory: "/tmp/b")
+        _ = manager.pauseSession(id: s1.id)
+
+        let tool = CodingSessionListTool(sessionManager: manager)
+        let result = await tool.execute(arguments: ["status": "active"])
+        XCTAssertTrue(result.content.contains("1개"))
+    }
+
+    func testSessionStartTool() async {
+        let manager = CodingSessionManager()
+        let tool = CodingSessionStartTool(sessionManager: manager)
+        XCTAssertEqual(tool.name, "coding.session_start")
+        XCTAssertEqual(tool.category, .restricted)
+
+        let result = await tool.execute(arguments: ["work_dir": "/tmp"])
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("세션 시작"))
+        XCTAssertEqual(manager.allSessions().count, 1)
+    }
+
+    func testSessionStartToolMissingDir() async {
+        let manager = CodingSessionManager()
+        let tool = CodingSessionStartTool(sessionManager: manager)
+        let result = await tool.execute(arguments: [:])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testSessionStartToolNonExistentDir() async {
+        let manager = CodingSessionManager()
+        let tool = CodingSessionStartTool(sessionManager: manager)
+        let result = await tool.execute(arguments: ["work_dir": "/nonexistent/path/xyz"])
+        XCTAssertTrue(result.isError)
+    }
+
+    func testSessionPauseTool() async {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        let tool = CodingSessionPauseTool(sessionManager: manager)
+
+        let result = await tool.execute(arguments: [
+            "session_id": session.id.uuidString,
+            "action": "pause",
+        ])
+        XCTAssertFalse(result.isError)
+        XCTAssertEqual(manager.session(id: session.id)!.status, .paused)
+    }
+
+    func testSessionPauseToolPartialId() async {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        let shortId = String(session.id.uuidString.prefix(8))
+        let tool = CodingSessionPauseTool(sessionManager: manager)
+
+        let result = await tool.execute(arguments: [
+            "session_id": shortId,
+            "action": "pause",
+        ])
+        XCTAssertFalse(result.isError)
+    }
+
+    func testSessionEndTool() async {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        _ = manager.addStep(sessionId: session.id, instruction: "test")
+
+        let tool = CodingSessionEndTool(sessionManager: manager)
+        let result = await tool.execute(arguments: [
+            "session_id": session.id.uuidString,
+            "summary": "작업 완료",
+        ])
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("완료"))
+        XCTAssertEqual(manager.session(id: session.id)!.status, .completed)
+    }
+
+    func testSessionEndToolFailed() async {
+        let manager = CodingSessionManager()
+        let session = manager.createSession(agentType: .claudeCode, workingDirectory: "/tmp")
+        let tool = CodingSessionEndTool(sessionManager: manager)
+
+        let result = await tool.execute(arguments: [
+            "session_id": session.id.uuidString,
+            "result": "failed",
+            "summary": "빌드 에러",
+        ])
+        XCTAssertFalse(result.isError)
+        XCTAssertEqual(manager.session(id: session.id)!.status, .failed)
+    }
+}


### PR DESCRIPTION
## Summary
- `CodingSession` 모델: 에이전트 타입(Claude Code/Codex), 작업 디렉토리, 상태(active/paused/completed/failed), 단계별 작업 기록
- `CodingSessionManager`: 다중 세션 CRUD, 단계 추적, 상태 전이, 완료/실패 세션 정리
- 4개 LLM 도구: `coding.sessions`(목록), `coding.session_start`(시작), `coding.session_pause`(일시정지/재개), `coding.session_end`(종료)
- 기존 `CodingRunTaskTool`/`CodingReviewTool`과 함께 동작

Closes #54

## Test plan
- [x] CodingAgentType Codable/rawValue/cliName/displayName
- [x] CodingSessionStep 기본값, 소요시간, Codable
- [x] CodingSession 모델 기본값, 단계 카운트, lastOutput, Codable
- [x] Manager: 세션 생성, 다중 세션, 활성 필터
- [x] Manager: 단계 추가/완료, 비활성 세션 단계 추가 차단
- [x] Manager: pause/resume/complete/fail 상태 전이 + 잘못된 전이 차단
- [x] Manager: 세션 삭제, 오래된 완료 세션 정리
- [x] Tools: 목록 조회(빈/필터), 시작(성공/실패), 일시정지(전체/부분ID), 종료(완료/실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)