### PR TITLE
feat: 슬랙 봇 서비스 (Socket Mode + Web API)

### DIFF
--- a/Dochi/Services/Protocols/SlackServiceProtocol.swift
+++ b/Dochi/Services/Protocols/SlackServiceProtocol.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+// MARK: - Slack Models
+
+struct SlackUser: Codable, Sendable {
+    let id: String
+    let name: String
+    let isBot: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case isBot = "is_bot"
+    }
+}
+
+struct SlackMessage: Codable, Sendable {
+    let channelId: String
+    let userId: String?
+    let text: String
+    let threadTs: String?   // thread timestamp (nil for top-level)
+    let ts: String          // message timestamp (used as ID)
+    let isMention: Bool     // whether bot was @mentioned
+
+    enum CodingKeys: String, CodingKey {
+        case channelId = "channel_id"
+        case userId = "user_id"
+        case text
+        case threadTs = "thread_ts"
+        case ts
+        case isMention = "is_mention"
+    }
+}
+
+struct SlackChannel: Codable, Sendable {
+    let id: String
+    let name: String
+    let isDM: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case isDM = "is_dm"
+    }
+}
+
+// MARK: - Slack Chat Mapping
+
+struct SlackChatMapping: Codable, Sendable, Identifiable {
+    var id: String { channelId }
+    let channelId: String
+    var workspaceId: UUID?
+    var label: String
+    var enabled: Bool
+
+    init(channelId: String, workspaceId: UUID? = nil, label: String, enabled: Bool = true) {
+        self.channelId = channelId
+        self.workspaceId = workspaceId
+        self.label = label
+        self.enabled = enabled
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case channelId = "channel_id"
+        case workspaceId = "workspace_id"
+        case label, enabled
+    }
+}
+
+// MARK: - Protocol
+
+@MainActor
+protocol SlackServiceProtocol {
+    var isConnected: Bool { get }
+
+    /// Connect to Slack using Socket Mode or Events API.
+    func connect(botToken: String, appToken: String) async throws
+    func disconnect()
+
+    /// Send a message to a channel or DM. Returns the message timestamp.
+    func sendMessage(channelId: String, text: String, threadTs: String?) async throws -> String
+
+    /// Update an existing message.
+    func updateMessage(channelId: String, ts: String, text: String) async throws
+
+    /// Send a typing indicator.
+    func sendTyping(channelId: String) async throws
+
+    /// Get bot identity.
+    func authTest(botToken: String) async throws -> SlackUser
+
+    /// Incoming message handler.
+    var onMessage: (@MainActor @Sendable (SlackMessage) -> Void)? { get set }
+}

--- a/Dochi/Services/Slack/SlackService.swift
+++ b/Dochi/Services/Slack/SlackService.swift
@@ -1,0 +1,275 @@
+import Foundation
+import os
+
+/// Slack bot service using Web API + Socket Mode.
+@MainActor
+final class SlackService: SlackServiceProtocol {
+    private(set) var isConnected = false
+    var onMessage: (@MainActor @Sendable (SlackMessage) -> Void)?
+
+    private var botToken: String?
+    private var appToken: String?
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var pingTask: Task<Void, Never>?
+    private var botUserId: String?
+
+    init() {}
+
+    // MARK: - Connection
+
+    func connect(botToken: String, appToken: String) async throws {
+        self.botToken = botToken
+        self.appToken = appToken
+
+        // Get WebSocket URL via apps.connections.open
+        let wsURL = try await openConnection(appToken: appToken)
+
+        // Identify bot user
+        let botUser = try await authTest(botToken: botToken)
+        botUserId = botUser.id
+        Log.cloud.info("Slack bot connected: \(botUser.name) (\(botUser.id))")
+
+        // Connect WebSocket
+        let session = URLSession(configuration: .default)
+        webSocketTask = session.webSocketTask(with: wsURL)
+        webSocketTask?.resume()
+        isConnected = true
+
+        startReceiving()
+        startPing()
+    }
+
+    func disconnect() {
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        pingTask?.cancel()
+        pingTask = nil
+        isConnected = false
+        Log.cloud.info("Slack bot disconnected")
+    }
+
+    // MARK: - Messaging
+
+    func sendMessage(channelId: String, text: String, threadTs: String?) async throws -> String {
+        guard let botToken else { throw SlackError.notConnected }
+
+        var body: [String: Any] = [
+            "channel": channelId,
+            "text": text,
+        ]
+        if let threadTs {
+            body["thread_ts"] = threadTs
+        }
+
+        let result = try await apiCall("chat.postMessage", body: body, token: botToken)
+        guard let ts = result["ts"] as? String else {
+            throw SlackError.invalidResponse
+        }
+        return ts
+    }
+
+    func updateMessage(channelId: String, ts: String, text: String) async throws {
+        guard let botToken else { throw SlackError.notConnected }
+
+        let body: [String: Any] = [
+            "channel": channelId,
+            "ts": ts,
+            "text": text,
+        ]
+        _ = try await apiCall("chat.update", body: body, token: botToken)
+    }
+
+    func sendTyping(channelId: String) async throws {
+        // Slack doesn't have a direct typing indicator API for bots in the same way.
+        // We can use chat.postMessage with a "typing..." placeholder, but that's noisy.
+        // For Socket Mode, we skip this.
+        Log.cloud.debug("Slack typing indicator skipped (not supported for bots)")
+    }
+
+    func authTest(botToken: String) async throws -> SlackUser {
+        let result = try await apiCall("auth.test", body: [:], token: botToken)
+        guard let userId = result["user_id"] as? String,
+              let userName = result["user"] as? String else {
+            throw SlackError.invalidResponse
+        }
+        let isBot = result["bot_id"] != nil
+        return SlackUser(id: userId, name: userName, isBot: isBot)
+    }
+
+    // MARK: - Socket Mode
+
+    private func openConnection(appToken: String) async throws -> URL {
+        let result = try await apiCall("apps.connections.open", body: [:], token: appToken)
+        guard let urlStr = result["url"] as? String, let url = URL(string: urlStr) else {
+            throw SlackError.invalidResponse
+        }
+        return url
+    }
+
+    private func startReceiving() {
+        guard let ws = webSocketTask else { return }
+        ws.receive { [weak self] result in
+            Task { @MainActor in
+                switch result {
+                case .success(let message):
+                    self?.handleWebSocketMessage(message)
+                    self?.startReceiving() // continue listening
+                case .failure(let error):
+                    Log.cloud.error("Slack WebSocket error: \(error.localizedDescription)")
+                    self?.isConnected = false
+                }
+            }
+        }
+    }
+
+    private func handleWebSocketMessage(_ message: URLSessionWebSocketTask.Message) {
+        guard case .string(let text) = message,
+              let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return
+        }
+
+        let type = json["type"] as? String
+
+        // Acknowledge envelope
+        if let envelopeId = json["envelope_id"] as? String {
+            acknowledgeEnvelope(envelopeId)
+        }
+
+        // Handle events_api type
+        if type == "events_api",
+           let payload = json["payload"] as? [String: Any],
+           let event = payload["event"] as? [String: Any] {
+            handleEvent(event)
+        }
+    }
+
+    private func handleEvent(_ event: [String: Any]) {
+        guard let eventType = event["type"] as? String else { return }
+
+        switch eventType {
+        case "message":
+            // Skip bot's own messages
+            if let botId = event["bot_id"] as? String, !botId.isEmpty { return }
+            if let subtype = event["subtype"] as? String, subtype == "bot_message" { return }
+
+            guard let channelId = event["channel"] as? String,
+                  let text = event["text"] as? String,
+                  let ts = event["ts"] as? String else { return }
+
+            let userId = event["user"] as? String
+            let threadTs = event["thread_ts"] as? String
+            let isMention = botUserId.map { text.contains("<@\($0)>") } ?? false
+
+            let slackMessage = SlackMessage(
+                channelId: channelId,
+                userId: userId,
+                text: Self.cleanMentions(text),
+                threadTs: threadTs,
+                ts: ts,
+                isMention: isMention
+            )
+
+            Log.cloud.debug("Slack message from \(userId ?? "unknown") in \(channelId)")
+            onMessage?(slackMessage)
+
+        case "app_mention":
+            guard let channelId = event["channel"] as? String,
+                  let text = event["text"] as? String,
+                  let ts = event["ts"] as? String else { return }
+
+            let userId = event["user"] as? String
+            let threadTs = event["thread_ts"] as? String
+
+            let slackMessage = SlackMessage(
+                channelId: channelId,
+                userId: userId,
+                text: Self.cleanMentions(text),
+                threadTs: threadTs,
+                ts: ts,
+                isMention: true
+            )
+
+            Log.cloud.debug("Slack mention from \(userId ?? "unknown") in \(channelId)")
+            onMessage?(slackMessage)
+
+        default:
+            break
+        }
+    }
+
+    private func acknowledgeEnvelope(_ envelopeId: String) {
+        let ack: [String: Any] = ["envelope_id": envelopeId]
+        guard let data = try? JSONSerialization.data(withJSONObject: ack),
+              let str = String(data: data, encoding: .utf8) else { return }
+        webSocketTask?.send(.string(str)) { error in
+            if let error {
+                Log.cloud.warning("Slack ack failed: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func startPing() {
+        pingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                guard !Task.isCancelled else { break }
+                self?.webSocketTask?.sendPing { error in
+                    if let error {
+                        Log.cloud.warning("Slack ping failed: \(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Remove <@U...> mention markers from text.
+    nonisolated static func cleanMentions(_ text: String) -> String {
+        // Replace <@UXXXXXX> patterns with empty string
+        var result = text
+        while let range = result.range(of: "<@[A-Z0-9]+>", options: .regularExpression) {
+            result.removeSubrange(range)
+        }
+        return result.trimmingCharacters(in: .whitespaces)
+    }
+
+    private func apiCall(_ method: String, body: [String: Any], token: String) async throws -> [String: Any] {
+        let url = URL(string: "https://slack.com/api/\(method)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+
+        if !body.isEmpty {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        }
+
+        let (data, _) = try await URLSession.shared.data(for: request)
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw SlackError.invalidResponse
+        }
+        guard json["ok"] as? Bool == true else {
+            let errorStr = json["error"] as? String ?? "unknown"
+            throw SlackError.apiError(errorStr)
+        }
+        return json
+    }
+}
+
+// MARK: - Errors
+
+enum SlackError: LocalizedError {
+    case notConnected
+    case invalidResponse
+    case apiError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected: "슬랙에 연결되어 있지 않습니다."
+        case .invalidResponse: "잘못된 API 응답입니다."
+        case .apiError(let msg): "슬랙 API 오류: \(msg)"
+        }
+    }
+}

--- a/DochiTests/SlackServiceTests.swift
+++ b/DochiTests/SlackServiceTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class SlackServiceTests: XCTestCase {
+
+    // MARK: - SlackUser Model
+
+    func testSlackUserCodable() throws {
+        let user = SlackUser(id: "U12345", name: "dochi-bot", isBot: true)
+        let data = try JSONEncoder().encode(user)
+        let decoded = try JSONDecoder().decode(SlackUser.self, from: data)
+        XCTAssertEqual(decoded.id, "U12345")
+        XCTAssertEqual(decoded.name, "dochi-bot")
+        XCTAssertTrue(decoded.isBot)
+    }
+
+    func testSlackUserCodingKeys() throws {
+        let json = """
+        {"id":"U99","name":"bot","is_bot":false}
+        """.data(using: .utf8)!
+        let user = try JSONDecoder().decode(SlackUser.self, from: json)
+        XCTAssertEqual(user.id, "U99")
+        XCTAssertFalse(user.isBot)
+    }
+
+    // MARK: - SlackMessage Model
+
+    func testSlackMessageCodable() throws {
+        let msg = SlackMessage(
+            channelId: "C123",
+            userId: "U456",
+            text: "안녕하세요",
+            threadTs: "1234567890.123456",
+            ts: "1234567890.654321",
+            isMention: true
+        )
+        let data = try JSONEncoder().encode(msg)
+        let decoded = try JSONDecoder().decode(SlackMessage.self, from: data)
+        XCTAssertEqual(decoded.channelId, "C123")
+        XCTAssertEqual(decoded.userId, "U456")
+        XCTAssertEqual(decoded.text, "안녕하세요")
+        XCTAssertEqual(decoded.threadTs, "1234567890.123456")
+        XCTAssertTrue(decoded.isMention)
+    }
+
+    func testSlackMessageNilThread() throws {
+        let msg = SlackMessage(
+            channelId: "C123",
+            userId: nil,
+            text: "hello",
+            threadTs: nil,
+            ts: "123.456",
+            isMention: false
+        )
+        let data = try JSONEncoder().encode(msg)
+        let decoded = try JSONDecoder().decode(SlackMessage.self, from: data)
+        XCTAssertNil(decoded.userId)
+        XCTAssertNil(decoded.threadTs)
+        XCTAssertFalse(decoded.isMention)
+    }
+
+    // MARK: - SlackChannel Model
+
+    func testSlackChannelCodable() throws {
+        let ch = SlackChannel(id: "C100", name: "general", isDM: false)
+        let data = try JSONEncoder().encode(ch)
+        let decoded = try JSONDecoder().decode(SlackChannel.self, from: data)
+        XCTAssertEqual(decoded.id, "C100")
+        XCTAssertEqual(decoded.name, "general")
+        XCTAssertFalse(decoded.isDM)
+    }
+
+    func testSlackChannelDM() throws {
+        let ch = SlackChannel(id: "D200", name: "dm-user", isDM: true)
+        XCTAssertTrue(ch.isDM)
+    }
+
+    // MARK: - SlackChatMapping Model
+
+    func testChatMappingInit() {
+        let mapping = SlackChatMapping(channelId: "C123", label: "#general")
+        XCTAssertEqual(mapping.id, "C123")
+        XCTAssertEqual(mapping.channelId, "C123")
+        XCTAssertEqual(mapping.label, "#general")
+        XCTAssertTrue(mapping.enabled)
+        XCTAssertNil(mapping.workspaceId)
+    }
+
+    func testChatMappingCodable() throws {
+        let wsId = UUID()
+        let mapping = SlackChatMapping(
+            channelId: "C456",
+            workspaceId: wsId,
+            label: "@user",
+            enabled: false
+        )
+        let data = try JSONEncoder().encode(mapping)
+        let decoded = try JSONDecoder().decode(SlackChatMapping.self, from: data)
+        XCTAssertEqual(decoded.channelId, "C456")
+        XCTAssertEqual(decoded.workspaceId, wsId)
+        XCTAssertEqual(decoded.label, "@user")
+        XCTAssertFalse(decoded.enabled)
+    }
+
+    // MARK: - MockSlackService
+
+    func testMockConnect() async throws {
+        let slack = MockSlackService()
+        XCTAssertFalse(slack.isConnected)
+        try await slack.connect(botToken: "xoxb-test", appToken: "xapp-test")
+        XCTAssertTrue(slack.isConnected)
+        XCTAssertEqual(slack.connectCalls.count, 1)
+        XCTAssertEqual(slack.connectCalls[0].botToken, "xoxb-test")
+    }
+
+    func testMockDisconnect() async throws {
+        let slack = MockSlackService()
+        try await slack.connect(botToken: "xoxb", appToken: "xapp")
+        slack.disconnect()
+        XCTAssertFalse(slack.isConnected)
+    }
+
+    func testMockSendMessage() async throws {
+        let slack = MockSlackService()
+        let ts = try await slack.sendMessage(channelId: "C123", text: "hello", threadTs: nil)
+        XCTAssertEqual(ts, "1000")
+        XCTAssertEqual(slack.sentMessages.count, 1)
+        XCTAssertEqual(slack.sentMessages[0].text, "hello")
+        XCTAssertNil(slack.sentMessages[0].threadTs)
+    }
+
+    func testMockSendMessageIncrementsTs() async throws {
+        let slack = MockSlackService()
+        let ts1 = try await slack.sendMessage(channelId: "C1", text: "a", threadTs: nil)
+        let ts2 = try await slack.sendMessage(channelId: "C1", text: "b", threadTs: nil)
+        XCTAssertNotEqual(ts1, ts2)
+    }
+
+    func testMockSendMessageWithThread() async throws {
+        let slack = MockSlackService()
+        _ = try await slack.sendMessage(channelId: "C1", text: "reply", threadTs: "999.000")
+        XCTAssertEqual(slack.sentMessages[0].threadTs, "999.000")
+    }
+
+    func testMockUpdateMessage() async throws {
+        let slack = MockSlackService()
+        try await slack.updateMessage(channelId: "C1", ts: "100.000", text: "edited")
+        XCTAssertEqual(slack.updatedMessages.count, 1)
+        XCTAssertEqual(slack.updatedMessages[0].text, "edited")
+    }
+
+    func testMockAuthTest() async throws {
+        let slack = MockSlackService()
+        let user = try await slack.authTest(botToken: "xoxb-test")
+        XCTAssertTrue(user.isBot)
+        XCTAssertEqual(user.name, "test-bot")
+    }
+
+    func testMockConformsToProtocol() {
+        let slack: SlackServiceProtocol = MockSlackService()
+        XCTAssertFalse(slack.isConnected)
+    }
+
+    func testMockOnMessageCallback() async throws {
+        let slack = MockSlackService()
+        var received: SlackMessage?
+        slack.onMessage = { msg in
+            received = msg
+        }
+
+        let msg = SlackMessage(
+            channelId: "C1",
+            userId: "U1",
+            text: "test",
+            threadTs: nil,
+            ts: "123.456",
+            isMention: false
+        )
+        slack.onMessage?(msg)
+        XCTAssertEqual(received?.text, "test")
+    }
+
+    // MARK: - Clean Mentions
+
+    func testCleanMentionsRemovesBotMention() {
+        let cleaned = SlackService.cleanMentions("<@U123BOT> 안녕하세요")
+        XCTAssertEqual(cleaned, "안녕하세요")
+    }
+
+    func testCleanMentionsRemovesMultiple() {
+        let cleaned = SlackService.cleanMentions("<@U111> <@U222> 코드 리뷰 부탁")
+        XCTAssertEqual(cleaned, "코드 리뷰 부탁")
+    }
+
+    func testCleanMentionsNoMention() {
+        let cleaned = SlackService.cleanMentions("그냥 텍스트")
+        XCTAssertEqual(cleaned, "그냥 텍스트")
+    }
+
+    func testCleanMentionsEmpty() {
+        let cleaned = SlackService.cleanMentions("")
+        XCTAssertEqual(cleaned, "")
+    }
+
+    // MARK: - SlackError
+
+    func testSlackErrorDescriptions() {
+        XCTAssertNotNil(SlackError.notConnected.errorDescription)
+        XCTAssertNotNil(SlackError.invalidResponse.errorDescription)
+        XCTAssertTrue(SlackError.apiError("test").errorDescription!.contains("test"))
+    }
+}


### PR DESCRIPTION
## Summary
- `SlackServiceProtocol`: 연결/해제, 메시지 송수신, 스레드 지원, 타이핑 인디케이터
- `SlackService`: Socket Mode WebSocket 연결, events_api 이벤트 처리, @멘션 감지, 봇 메시지 필터링
- 모델: `SlackUser`, `SlackMessage`, `SlackChannel`, `SlackChatMapping` (Codable, snake_case 호환)
- `MockSlackService` + 22개 단위 테스트

Closes #12

## Test plan
- [x] SlackUser/SlackMessage/SlackChannel Codable roundtrip + CodingKeys
- [x] SlackChatMapping 기본값 + Codable
- [x] Mock: connect/disconnect 상태 추적
- [x] Mock: sendMessage 증분 ts + 스레드 지원
- [x] Mock: updateMessage 추적
- [x] Mock: authTest 봇 사용자 반환
- [x] Mock: onMessage 콜백 동작
- [x] Mock: 프로토콜 적합성
- [x] cleanMentions: 단일/다중 멘션 제거, 멘션 없는 텍스트, 빈 문자열
- [x] SlackError 설명 문자열

🤖 Generated with [Claude Code](https://claude.com/claude-code)