### PR TITLE
feat: iOS 컴패니언 앱 기본 구조 (DochiMobile)

### DIFF
--- a/DochiMobile/DochiMobileApp.swift
+++ b/DochiMobile/DochiMobileApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct DochiMobileApp: App {
+    @StateObject private var viewModel = MobileChatViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            MobileContentView()
+                .environmentObject(viewModel)
+        }
+    }
+}

--- a/DochiMobile/ViewModels/MobileChatViewModel.swift
+++ b/DochiMobile/ViewModels/MobileChatViewModel.swift
@@ -1,0 +1,123 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Chat Message Model
+
+struct MobileChatMessage: Identifiable, Sendable {
+    let id: UUID
+    let role: MobileChatRole
+    let content: String
+    let timestamp: Date
+
+    init(id: UUID = UUID(), role: MobileChatRole, content: String, timestamp: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+    }
+}
+
+enum MobileChatRole: String, Sendable {
+    case user
+    case assistant
+}
+
+// MARK: - Chat ViewModel
+
+@MainActor
+final class MobileChatViewModel: ObservableObject {
+    @Published var messages: [MobileChatMessage] = []
+    @Published var inputText = ""
+    @Published var isLoading = false
+
+    private var conversationHistory: [[String: String]] = []
+
+    func send() {
+        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !isLoading else { return }
+
+        let userMessage = MobileChatMessage(role: .user, content: text)
+        messages.append(userMessage)
+        conversationHistory.append(["role": "user", "content": text])
+        inputText = ""
+        isLoading = true
+
+        Task {
+            do {
+                let response = try await callAPI(messages: conversationHistory)
+                let assistantMessage = MobileChatMessage(role: .assistant, content: response)
+                messages.append(assistantMessage)
+                conversationHistory.append(["role": "assistant", "content": response])
+            } catch {
+                let errorMessage = MobileChatMessage(
+                    role: .assistant,
+                    content: "오류: \(error.localizedDescription)"
+                )
+                messages.append(errorMessage)
+            }
+            isLoading = false
+        }
+    }
+
+    func clearMessages() {
+        messages.removeAll()
+        conversationHistory.removeAll()
+    }
+
+    // MARK: - API
+
+    private func callAPI(messages: [[String: String]]) async throws -> String {
+        let apiKey = UserDefaults.standard.string(forKey: "mobile_api_key") ?? ""
+        let model = UserDefaults.standard.string(forKey: "mobile_model") ?? "claude-sonnet-4-5-20250929"
+
+        guard !apiKey.isEmpty else {
+            throw MobileAPIError.noAPIKey
+        }
+
+        let url = URL(string: "https://api.anthropic.com/v1/messages")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 4096,
+            "system": "당신은 도치라는 이름의 AI 어시스턴트입니다. 간결하고 친절하게 답변합니다.",
+            "messages": messages,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, _) = try await URLSession.shared.data(for: request)
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]],
+              let first = content.first,
+              let text = first["text"] as? String else {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let error = json["error"] as? [String: Any],
+               let msg = error["message"] as? String {
+                throw MobileAPIError.apiError(msg)
+            }
+            throw MobileAPIError.invalidResponse
+        }
+        return text
+    }
+}
+
+// MARK: - Errors
+
+enum MobileAPIError: LocalizedError {
+    case noAPIKey
+    case invalidResponse
+    case apiError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noAPIKey: "설정에서 API 키를 입력해주세요."
+        case .invalidResponse: "잘못된 응답입니다."
+        case .apiError(let msg): "API 오류: \(msg)"
+        }
+    }
+}

--- a/DochiMobile/Views/MobileContentView.swift
+++ b/DochiMobile/Views/MobileContentView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+struct MobileContentView: View {
+    @EnvironmentObject private var viewModel: MobileChatViewModel
+    @State private var showSettings = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Messages
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 12) {
+                            ForEach(viewModel.messages) { message in
+                                MobileChatBubble(message: message)
+                                    .id(message.id)
+                            }
+                        }
+                        .padding()
+                    }
+                    .onChange(of: viewModel.messages.count) {
+                        if let last = viewModel.messages.last {
+                            withAnimation {
+                                proxy.scrollTo(last.id, anchor: .bottom)
+                            }
+                        }
+                    }
+                }
+
+                Divider()
+
+                // Input
+                MobileChatInput(
+                    text: $viewModel.inputText,
+                    isLoading: viewModel.isLoading,
+                    onSend: { viewModel.send() }
+                )
+            }
+            .navigationTitle("도치")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showSettings = true
+                    } label: {
+                        Image(systemName: "gearshape")
+                    }
+                }
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        viewModel.clearMessages()
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .disabled(viewModel.messages.isEmpty)
+                }
+            }
+            .sheet(isPresented: $showSettings) {
+                MobileSettingsView()
+            }
+        }
+    }
+}
+
+// MARK: - Chat Bubble
+
+struct MobileChatBubble: View {
+    let message: MobileChatMessage
+
+    var body: some View {
+        HStack {
+            if message.role == .user { Spacer() }
+
+            VStack(alignment: message.role == .user ? .trailing : .leading, spacing: 4) {
+                Text(message.content)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(message.role == .user ? Color.blue : Color(.systemGray5))
+                    .foregroundStyle(message.role == .user ? .white : .primary)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+
+                Text(message.timestamp, style: .time)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: 280, alignment: message.role == .user ? .trailing : .leading)
+
+            if message.role == .assistant { Spacer() }
+        }
+    }
+}
+
+// MARK: - Chat Input
+
+struct MobileChatInput: View {
+    @Binding var text: String
+    let isLoading: Bool
+    let onSend: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            TextField("메시지를 입력하세요...", text: $text, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...5)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(Color(.systemGray6))
+                .clipShape(RoundedRectangle(cornerRadius: 20))
+                .disabled(isLoading)
+
+            Button(action: onSend) {
+                if isLoading {
+                    ProgressView()
+                        .frame(width: 36, height: 36)
+                } else {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                        .foregroundStyle(.blue)
+                        .frame(width: 36, height: 36)
+                }
+            }
+            .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isLoading)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+}

--- a/DochiMobile/Views/MobileSettingsView.swift
+++ b/DochiMobile/Views/MobileSettingsView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct MobileSettingsView: View {
+    @AppStorage("mobile_api_key") private var apiKey = ""
+    @AppStorage("mobile_model") private var model = "claude-sonnet-4-5-20250929"
+    @AppStorage("mobile_provider") private var provider = "anthropic"
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("API 설정") {
+                    SecureField("API 키", text: $apiKey)
+                        .textContentType(.password)
+                        .autocorrectionDisabled()
+
+                    Picker("프로바이더", selection: $provider) {
+                        Text("Anthropic").tag("anthropic")
+                        Text("OpenAI").tag("openai")
+                    }
+
+                    TextField("모델", text: $model)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                }
+
+                Section("정보") {
+                    HStack {
+                        Text("버전")
+                        Spacer()
+                        Text("1.0.0")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("설정")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("완료") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -71,6 +71,27 @@ targets:
         SWIFT_STRICT_CONCURRENCY: targeted
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
 
+  DochiMobile:
+    type: application
+    platform: iOS
+    sources:
+      - path: DochiMobile
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.hckim.dochi.mobile
+        PRODUCT_NAME: 도치
+        MARKETING_VERSION: "1.0.0"
+        CURRENT_PROJECT_VERSION: 1
+        SWIFT_VERSION: "6.0"
+        IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: XEF9KH7N43
+        SWIFT_STRICT_CONCURRENCY: targeted
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_CFBundleDisplayName: 도치
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+
   DochiCLI:
     type: tool
     platform: macOS


### PR DESCRIPTION
## Summary
- `DochiMobile` iOS 타겟 (iOS 17+, SwiftUI)
- 채팅 UI: 버블 메시지, 스크롤 뷰, 텍스트 입력, 로딩 상태
- `MobileChatViewModel`: 대화 히스토리 + Anthropic API 직접 호출
- 설정 뷰: API 키, 모델, 프로바이더 설정 (AppStorage)
- `project.yml`에 iOS 타겟 등록

참고: iOS SDK 미설치 환경이라 시뮬레이터 빌드 미검증. macOS 타겟 빌드/테스트 정상.

Closes #18

## Test plan
- [x] macOS Dochi 앱 빌드 성공 (iOS 타겟 추가 후에도)
- [x] DochiCLI 빌드 성공
- [x] project.yml 구조 검증 (xcodegen generate 성공)
- [ ] iOS 시뮬레이터 빌드 (iOS SDK 설치 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)