### PR TITLE
[UX-8] 컨텍스트/메모리 관리 UX 개선

### DIFF
--- a/Dochi/Models/CommandPaletteItem.swift
+++ b/Dochi/Models/CommandPaletteItem.swift
@@ -26,6 +26,7 @@ struct CommandPaletteItem: Identifiable, Sendable {
         case switchAgent(name: String)
         case openSettings
         case openContextInspector
+        case openMemoryPanel
         case openCapabilityCatalog
         case openSystemStatus
         case openShortcutHelp
@@ -117,10 +118,18 @@ enum CommandPaletteRegistry {
             action: .openSettings
         ),
         CommandPaletteItem(
+            id: "memory-panel",
+            icon: "brain",
+            title: "메모리 인스펙터",
+            subtitle: "⌘I",
+            category: .navigation,
+            action: .openMemoryPanel
+        ),
+        CommandPaletteItem(
             id: "context-inspector",
             icon: "doc.text.magnifyingglass",
             title: "컨텍스트 인스펙터",
-            subtitle: "⌘I",
+            subtitle: "⌘⌥I",
             category: .navigation,
             action: .openContextInspector
         ),

--- a/Dochi/Models/MemoryContextInfo.swift
+++ b/Dochi/Models/MemoryContextInfo.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// UX-8: 어시스턴트 메시지에 첨부되는 메모리 참조 정보
+struct MemoryContextInfo: Codable, Sendable, Equatable {
+    let systemPromptLength: Int
+    let agentPersonaLength: Int
+    let workspaceMemoryLength: Int
+    let agentMemoryLength: Int
+    let personalMemoryLength: Int
+
+    var totalLength: Int {
+        systemPromptLength + agentPersonaLength + workspaceMemoryLength + agentMemoryLength + personalMemoryLength
+    }
+
+    /// 대략적인 토큰 수 추정 (한국어 기준 ~2자/토큰)
+    var estimatedTokens: Int {
+        totalLength / 2
+    }
+
+    var hasAnyMemory: Bool {
+        totalLength > 0
+    }
+
+    /// 사용된 계층 수
+    var activeLayerCount: Int {
+        [systemPromptLength, agentPersonaLength, workspaceMemoryLength, agentMemoryLength, personalMemoryLength]
+            .filter { $0 > 0 }
+            .count
+    }
+
+    struct LayerInfo: Identifiable {
+        let id: String
+        let name: String
+        let icon: String
+        let charCount: Int
+
+        var isActive: Bool { charCount > 0 }
+    }
+
+    var layers: [LayerInfo] {
+        [
+            LayerInfo(id: "system", name: "시스템 프롬프트", icon: "doc.text", charCount: systemPromptLength),
+            LayerInfo(id: "persona", name: "에이전트 페르소나", icon: "person.text.rectangle", charCount: agentPersonaLength),
+            LayerInfo(id: "workspace", name: "워크스페이스 메모리", icon: "square.grid.2x2", charCount: workspaceMemoryLength),
+            LayerInfo(id: "agent", name: "에이전트 메모리", icon: "brain", charCount: agentMemoryLength),
+            LayerInfo(id: "personal", name: "개인 메모리", icon: "person", charCount: personalMemoryLength),
+        ]
+    }
+}

--- a/Dochi/Models/MemoryToastEvent.swift
+++ b/Dochi/Models/MemoryToastEvent.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// UX-8: 메모리 저장/업데이트 시 표시할 토스트 이벤트
+struct MemoryToastEvent: Identifiable, Sendable {
+    let id: UUID
+    let scope: Scope
+    let action: Action
+    let contentPreview: String
+    let timestamp: Date
+
+    enum Scope: String, Sendable {
+        case workspace = "워크스페이스"
+        case personal = "개인"
+        case agent = "에이전트"
+    }
+
+    enum Action: String, Sendable {
+        case saved = "저장됨"
+        case updated = "업데이트됨"
+    }
+
+    init(id: UUID = UUID(), scope: Scope, action: Action, contentPreview: String, timestamp: Date = Date()) {
+        self.id = id
+        self.scope = scope
+        self.action = action
+        self.contentPreview = String(contentPreview.prefix(80))
+        self.timestamp = timestamp
+    }
+
+    var displayMessage: String {
+        "\(scope.rawValue) 메모리에 \(action.rawValue)"
+    }
+}

--- a/Dochi/Models/Message.swift
+++ b/Dochi/Models/Message.swift
@@ -44,8 +44,9 @@ struct Message: Codable, Identifiable, Sendable {
     var imageURLs: [URL]?
     var metadata: MessageMetadata?
     var toolExecutionRecords: [ToolExecutionRecord]?
+    var memoryContextInfo: MemoryContextInfo?
 
-    init(id: UUID = UUID(), role: MessageRole, content: String, timestamp: Date = Date(), toolCalls: [CodableToolCall]? = nil, toolCallId: String? = nil, imageURLs: [URL]? = nil, metadata: MessageMetadata? = nil, toolExecutionRecords: [ToolExecutionRecord]? = nil) {
+    init(id: UUID = UUID(), role: MessageRole, content: String, timestamp: Date = Date(), toolCalls: [CodableToolCall]? = nil, toolCallId: String? = nil, imageURLs: [URL]? = nil, metadata: MessageMetadata? = nil, toolExecutionRecords: [ToolExecutionRecord]? = nil, memoryContextInfo: MemoryContextInfo? = nil) {
         self.id = id
         self.role = role
         self.content = content
@@ -55,6 +56,7 @@ struct Message: Codable, Identifiable, Sendable {
         self.imageURLs = imageURLs
         self.metadata = metadata
         self.toolExecutionRecords = toolExecutionRecords
+        self.memoryContextInfo = memoryContextInfo
     }
 
     init(from decoder: Decoder) throws {
@@ -68,5 +70,6 @@ struct Message: Codable, Identifiable, Sendable {
         imageURLs = try container.decodeIfPresent([URL].self, forKey: .imageURLs)
         metadata = try container.decodeIfPresent(MessageMetadata.self, forKey: .metadata)
         toolExecutionRecords = try container.decodeIfPresent([ToolExecutionRecord].self, forKey: .toolExecutionRecords)
+        memoryContextInfo = try container.decodeIfPresent(MemoryContextInfo.self, forKey: .memoryContextInfo)
     }
 }

--- a/Dochi/Views/KeyboardShortcutHelpView.swift
+++ b/Dochi/Views/KeyboardShortcutHelpView.swift
@@ -40,7 +40,8 @@ struct KeyboardShortcutHelpView: View {
             title: "패널",
             icon: "sidebar.squares.leading",
             entries: [
-                ShortcutEntry(keys: "⌘I", description: "컨텍스트 인스펙터"),
+                ShortcutEntry(keys: "⌘I", description: "메모리 인스펙터 패널"),
+                ShortcutEntry(keys: "⌘⌥I", description: "컨텍스트 인스펙터 (시트)"),
                 ShortcutEntry(keys: "⌘⇧S", description: "시스템 상태"),
                 ShortcutEntry(keys: "⌘⇧F", description: "기능 카탈로그"),
                 ShortcutEntry(keys: "⌘,", description: "설정"),

--- a/Dochi/Views/MemoryPanelView.swift
+++ b/Dochi/Views/MemoryPanelView.swift
@@ -1,0 +1,394 @@
+import SwiftUI
+
+/// UX-8: 우측 인스펙터 패널 — 메모리 계층 트리 시각화
+struct MemoryPanelView: View {
+    let contextService: ContextServiceProtocol
+    let settings: AppSettings
+    let sessionContext: SessionContext
+
+    // Node content states
+    @State private var systemPromptText: String = ""
+    @State private var agentPersonaText: String = ""
+    @State private var workspaceMemoryText: String = ""
+    @State private var agentMemoryText: String = ""
+    @State private var personalMemoryText: String = ""
+
+    // Expand states
+    @State private var expandedNodes: Set<String> = []
+
+    // Save feedback
+    @State private var savedNodes: Set<String> = []
+
+    var body: some View {
+        VStack(spacing: 0) {
+            panelHeader
+            Divider()
+            nodeList
+            Divider()
+            panelFooter
+        }
+        .frame(minWidth: 260, idealWidth: 300, maxWidth: 360)
+        .onAppear { loadAll() }
+    }
+
+    // MARK: - Header
+
+    private var panelHeader: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("메모리 인스펙터")
+                .font(.system(size: 14, weight: .semibold))
+
+            HStack(spacing: 6) {
+                // Agent badge
+                HStack(spacing: 3) {
+                    Image(systemName: "person.fill")
+                        .font(.system(size: 9))
+                    Text(settings.activeAgentName)
+                        .font(.system(size: 10))
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.blue.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                // Workspace badge
+                HStack(spacing: 3) {
+                    Image(systemName: "square.grid.2x2")
+                        .font(.system(size: 9))
+                    Text(workspaceDisplayName)
+                        .font(.system(size: 10))
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.purple.opacity(0.1))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+            }
+            .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    // MARK: - Node List
+
+    private var nodeList: some View {
+        ScrollView {
+            VStack(spacing: 2) {
+                MemoryNodeView(
+                    nodeId: "system",
+                    icon: "doc.text",
+                    title: "시스템 프롬프트",
+                    subtitle: "system_prompt.md",
+                    emptyHint: "LLM에게 전달할 기본 지시사항을 입력하세요.",
+                    text: $systemPromptText,
+                    isExpanded: binding(for: "system"),
+                    isSaved: savedNodes.contains("system"),
+                    onSave: {
+                        contextService.saveBaseSystemPrompt(systemPromptText)
+                        markSaved("system")
+                        Log.storage.info("System prompt saved from memory panel")
+                    }
+                )
+
+                MemoryNodeView(
+                    nodeId: "persona",
+                    icon: "person.text.rectangle",
+                    title: "에이전트 페르소나",
+                    subtitle: "persona.md",
+                    emptyHint: "에이전트의 성격과 역할을 정의하세요.",
+                    text: $agentPersonaText,
+                    isExpanded: binding(for: "persona"),
+                    isSaved: savedNodes.contains("persona"),
+                    onSave: {
+                        contextService.saveAgentPersona(
+                            workspaceId: sessionContext.workspaceId,
+                            agentName: settings.activeAgentName,
+                            content: agentPersonaText
+                        )
+                        markSaved("persona")
+                        Log.storage.info("Agent persona saved from memory panel")
+                    }
+                )
+
+                MemoryNodeView(
+                    nodeId: "workspace",
+                    icon: "square.grid.2x2",
+                    title: "워크스페이스 메모리",
+                    subtitle: "memory.md",
+                    emptyHint: "이 워크스페이스 공통 메모리입니다. LLM이 자동으로 기록합니다.",
+                    text: $workspaceMemoryText,
+                    isExpanded: binding(for: "workspace"),
+                    isSaved: savedNodes.contains("workspace"),
+                    onSave: {
+                        contextService.saveWorkspaceMemory(
+                            workspaceId: sessionContext.workspaceId,
+                            content: workspaceMemoryText
+                        )
+                        markSaved("workspace")
+                        Log.storage.info("Workspace memory saved from memory panel")
+                    }
+                )
+
+                MemoryNodeView(
+                    nodeId: "agent",
+                    icon: "brain",
+                    title: "에이전트 메모리",
+                    subtitle: "memory.md",
+                    emptyHint: "에이전트가 학습한 내용이 여기에 저장됩니다.",
+                    text: $agentMemoryText,
+                    isExpanded: binding(for: "agent"),
+                    isSaved: savedNodes.contains("agent"),
+                    onSave: {
+                        contextService.saveAgentMemory(
+                            workspaceId: sessionContext.workspaceId,
+                            agentName: settings.activeAgentName,
+                            content: agentMemoryText
+                        )
+                        markSaved("agent")
+                        Log.storage.info("Agent memory saved from memory panel")
+                    }
+                )
+
+                if sessionContext.currentUserId != nil {
+                    MemoryNodeView(
+                        nodeId: "personal",
+                        icon: "person",
+                        title: "개인 메모리",
+                        subtitle: "user memory",
+                        emptyHint: "사용자에 대해 기억할 내용이 여기에 저장됩니다.",
+                        text: $personalMemoryText,
+                        isExpanded: binding(for: "personal"),
+                        isSaved: savedNodes.contains("personal"),
+                        onSave: {
+                            guard let userId = sessionContext.currentUserId else { return }
+                            contextService.saveUserMemory(userId: userId, content: personalMemoryText)
+                            markSaved("personal")
+                            Log.storage.info("User memory saved from memory panel")
+                        }
+                    )
+                } else {
+                    HStack(spacing: 6) {
+                        Image(systemName: "person.slash")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                        Text("사용자가 설정되지 않아 개인 메모리를 표시할 수 없습니다.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    // MARK: - Footer
+
+    private var panelFooter: some View {
+        VStack(spacing: 4) {
+            HStack {
+                Text("총 \(totalChars)자 / ~\(estimatedTokens)토큰")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    // MARK: - Helpers
+
+    private var totalChars: Int {
+        systemPromptText.count + agentPersonaText.count + workspaceMemoryText.count + agentMemoryText.count + personalMemoryText.count
+    }
+
+    private var estimatedTokens: Int {
+        max(1, totalChars / 2)
+    }
+
+    private var workspaceDisplayName: String {
+        let id = sessionContext.workspaceId
+        if id == UUID(uuidString: "00000000-0000-0000-0000-000000000000") {
+            return "기본"
+        }
+        return String(id.uuidString.prefix(8))
+    }
+
+    private func binding(for nodeId: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedNodes.contains(nodeId) },
+            set: { isExpanded in
+                if isExpanded {
+                    expandedNodes.insert(nodeId)
+                } else {
+                    expandedNodes.remove(nodeId)
+                }
+            }
+        )
+    }
+
+    private func markSaved(_ nodeId: String) {
+        savedNodes.insert(nodeId)
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            savedNodes.remove(nodeId)
+        }
+    }
+
+    private func loadAll() {
+        systemPromptText = contextService.loadBaseSystemPrompt() ?? ""
+
+        let wsId = sessionContext.workspaceId
+        let agentName = settings.activeAgentName
+        agentPersonaText = contextService.loadAgentPersona(workspaceId: wsId, agentName: agentName) ?? ""
+        workspaceMemoryText = contextService.loadWorkspaceMemory(workspaceId: wsId) ?? ""
+        agentMemoryText = contextService.loadAgentMemory(workspaceId: wsId, agentName: agentName) ?? ""
+
+        if let userId = sessionContext.currentUserId {
+            personalMemoryText = contextService.loadUserMemory(userId: userId) ?? ""
+        }
+
+        Log.app.debug("Memory panel loaded all content")
+    }
+}
+
+// MARK: - MemoryNodeView
+
+/// 개별 메모리 노드 카드 (접기/펼치기 패턴)
+struct MemoryNodeView: View {
+    let nodeId: String
+    let icon: String
+    let title: String
+    let subtitle: String
+    let emptyHint: String
+    @Binding var text: String
+    @Binding var isExpanded: Bool
+    let isSaved: Bool
+    let onSave: () -> Void
+
+    @State private var isDirty = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header (always visible)
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 10)
+
+                    Image(systemName: icon)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+
+                    Text(title)
+                        .font(.system(size: 12, weight: .medium))
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    if isSaved {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.green)
+                    }
+
+                    Text("\(text.count)자")
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if !isExpanded && !text.isEmpty {
+                // Preview (collapsed, non-empty)
+                Text(text.prefix(80).replacingOccurrences(of: "\n", with: " "))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(2)
+                    .padding(.horizontal, 28)
+                    .padding(.bottom, 6)
+            }
+
+            // Expanded content
+            if isExpanded {
+                if text.isEmpty {
+                    // Empty state
+                    VStack(spacing: 6) {
+                        Text(emptyHint)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                            .multilineTextAlignment(.center)
+
+                        Button {
+                            text = ""
+                            isDirty = true
+                        } label: {
+                            Text("작성하기")
+                                .font(.system(size: 11, weight: .medium))
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                } else {
+                    // Editor
+                    editorView
+                }
+            }
+        }
+        .background(isExpanded ? Color.secondary.opacity(0.04) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .padding(.horizontal, 4)
+    }
+
+    private var editorView: some View {
+        VStack(spacing: 4) {
+            TextEditor(text: $text)
+                .font(.system(size: 11, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .padding(4)
+                .background(Color(nsColor: .textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                )
+                .frame(minHeight: 80, maxHeight: 200)
+                .onChange(of: text) { _, _ in
+                    isDirty = true
+                }
+
+            HStack {
+                Text(subtitle)
+                    .font(.system(size: 9))
+                    .foregroundStyle(.quaternary)
+
+                Spacer()
+
+                if isDirty {
+                    Button("저장") {
+                        onSave()
+                        isDirty = false
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.mini)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 8)
+    }
+}

--- a/Dochi/Views/MemoryReferenceBadgeView.swift
+++ b/Dochi/Views/MemoryReferenceBadgeView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// UX-8: 어시스턴트 메시지 하단에 표시되는 메모리 참조 배지
+struct MemoryReferenceBadgeView: View {
+    let info: MemoryContextInfo
+    @State private var showPopover = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "doc.plaintext")
+                .font(.system(size: 9))
+                .foregroundStyle(.purple)
+
+            Text("메모리 \(info.activeLayerCount)계층")
+                .font(.system(size: 10))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(.purple.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .onHover { hovering in
+            showPopover = hovering
+        }
+        .popover(isPresented: $showPopover, arrowEdge: .bottom) {
+            popoverContent
+        }
+    }
+
+    private var popoverContent: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("메모리 참조")
+                .font(.system(size: 12, weight: .semibold))
+
+            Divider()
+
+            ForEach(info.layers) { layer in
+                HStack(spacing: 6) {
+                    Image(systemName: layer.icon)
+                        .font(.system(size: 10))
+                        .foregroundStyle(layer.isActive ? .primary : .tertiary)
+                        .frame(width: 14)
+
+                    Text(layer.name)
+                        .font(.system(size: 11))
+                        .foregroundStyle(layer.isActive ? .primary : .tertiary)
+
+                    Spacer()
+
+                    if layer.isActive {
+                        Text("\(layer.charCount)자")
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("--")
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(.quaternary)
+                    }
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Text("합계")
+                    .font(.system(size: 11, weight: .medium))
+                Spacer()
+                Text("\(info.totalLength)자 (~\(info.estimatedTokens)토큰)")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(10)
+        .frame(minWidth: 200)
+    }
+}

--- a/Dochi/Views/MemoryToastView.swift
+++ b/Dochi/Views/MemoryToastView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// UX-8: 메모리 저장 시 우측 하단에 표시되는 토스트
+struct MemoryToastView: View {
+    let event: MemoryToastEvent
+    let onViewMemory: () -> Void
+    let onDismiss: () -> Void
+
+    @State private var isVisible = false
+    @State private var dismissed = false
+
+    var body: some View {
+        if !dismissed {
+            toastContent
+                .opacity(isVisible ? 1 : 0)
+                .offset(y: isVisible ? 0 : 20)
+                .onAppear {
+                    withAnimation(.easeOut(duration: 0.3)) {
+                        isVisible = true
+                    }
+                    // Auto-dismiss after 5 seconds
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .seconds(5))
+                        dismiss()
+                    }
+                }
+        }
+    }
+
+    private var toastContent: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "externaldrive.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(.blue)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(event.displayMessage)
+                    .font(.system(size: 11, weight: .medium))
+
+                if !event.contentPreview.isEmpty {
+                    Text(event.contentPreview)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            Button("보기") {
+                onViewMemory()
+                dismiss()
+            }
+            .font(.system(size: 10, weight: .medium))
+            .buttonStyle(.bordered)
+            .controlSize(.mini)
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.tertiary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.secondary.opacity(0.15), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.1), radius: 8, y: 4)
+        .frame(maxWidth: 320)
+    }
+
+    private func dismiss() {
+        withAnimation(.easeIn(duration: 0.2)) {
+            isVisible = false
+        }
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(200))
+            dismissed = true
+            onDismiss()
+        }
+    }
+}
+
+/// 토스트 컨테이너 (여러 토스트를 우측 하단에 스택)
+struct MemoryToastContainerView: View {
+    let events: [MemoryToastEvent]
+    let onViewMemory: () -> Void
+    let onDismiss: (UUID) -> Void
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            Spacer()
+            ForEach(events) { event in
+                MemoryToastView(
+                    event: event,
+                    onViewMemory: onViewMemory,
+                    onDismiss: { onDismiss(event.id) }
+                )
+            }
+        }
+        .padding(.trailing, 16)
+        .padding(.bottom, 16)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .allowsHitTesting(!events.isEmpty)
+    }
+}

--- a/Dochi/Views/MessageBubbleView.swift
+++ b/Dochi/Views/MessageBubbleView.swift
@@ -84,9 +84,18 @@ struct MessageBubbleView: View {
                     }
                 }
 
-                // Metadata badge (assistant messages only)
-                if message.role == .assistant, let metadata = message.metadata {
-                    MessageMetadataBadgeView(metadata: metadata)
+                // Metadata badges (assistant messages only)
+                if message.role == .assistant {
+                    HStack(spacing: 4) {
+                        if let metadata = message.metadata {
+                            MessageMetadataBadgeView(metadata: metadata)
+                        }
+
+                        // UX-8: Memory reference badge
+                        if let memoryInfo = message.memoryContextInfo {
+                            MemoryReferenceBadgeView(info: memoryInfo)
+                        }
+                    }
                 }
 
                 // Timestamp

--- a/Dochi/Views/SystemPromptBannerView.swift
+++ b/Dochi/Views/SystemPromptBannerView.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+
+/// UX-8: 대화 상단 접을 수 있는 시스템 프롬프트 배너
+struct SystemPromptBannerView: View {
+    let contextService: ContextServiceProtocol
+    @State private var text: String = ""
+    @State private var isExpanded: Bool = UserDefaults.standard.bool(forKey: "systemPromptBannerExpanded")
+    @State private var isDirty: Bool = false
+    @State private var showSavedFeedback: Bool = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if text.isEmpty && !isExpanded {
+                emptyBanner
+            } else if isExpanded {
+                expandedBanner
+            } else {
+                collapsedBanner
+            }
+        }
+        .onAppear {
+            text = contextService.loadBaseSystemPrompt() ?? ""
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyBanner: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded = true
+                persistExpanded(true)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                Text("시스템 프롬프트가 설정되지 않았습니다")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                Spacer()
+                Text("작성하기")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.blue)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(.secondary.opacity(0.04))
+    }
+
+    // MARK: - Collapsed State
+
+    private var collapsedBanner: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isExpanded = true
+                persistExpanded(true)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                Text("시스템 프롬프트:")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Text(text.prefix(60).replacingOccurrences(of: "\n", with: " "))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .frame(height: 28)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(.secondary.opacity(0.04))
+    }
+
+    // MARK: - Expanded State
+
+    private var expandedBanner: some View {
+        VStack(spacing: 4) {
+            // Header
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                Text("시스템 프롬프트")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                if showSavedFeedback {
+                    Text("저장됨")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.green)
+                        .transition(.opacity)
+                }
+
+                Text("\(text.count)자")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isExpanded = false
+                        persistExpanded(false)
+                    }
+                } label: {
+                    Image(systemName: "chevron.up")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 6)
+
+            // Editor
+            TextEditor(text: $text)
+                .font(.system(size: 11, design: .monospaced))
+                .scrollContentBackground(.hidden)
+                .padding(4)
+                .background(Color(nsColor: .textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color(nsColor: .separatorColor), lineWidth: 0.5)
+                )
+                .frame(minHeight: 80, maxHeight: 200)
+                .padding(.horizontal, 12)
+                .onChange(of: text) { _, _ in
+                    isDirty = true
+                }
+
+            // Save button
+            if isDirty {
+                HStack {
+                    Spacer()
+                    Button("저장") {
+                        contextService.saveBaseSystemPrompt(text)
+                        isDirty = false
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            showSavedFeedback = true
+                        }
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .seconds(2))
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                showSavedFeedback = false
+                            }
+                        }
+                        Log.storage.info("System prompt saved from banner")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.mini)
+                }
+                .padding(.horizontal, 12)
+            }
+
+            Spacer()
+                .frame(height: 4)
+        }
+        .background(.secondary.opacity(0.04))
+    }
+
+    // MARK: - Helpers
+
+    private func persistExpanded(_ value: Bool) {
+        UserDefaults.standard.set(value, forKey: "systemPromptBannerExpanded")
+    }
+}

--- a/DochiTests/MemoryPanelTests.swift
+++ b/DochiTests/MemoryPanelTests.swift
@@ -1,0 +1,277 @@
+import XCTest
+@testable import Dochi
+
+/// UX-8: 메모리 패널/토스트/참조 배지 모델 테스트
+final class MemoryPanelTests: XCTestCase {
+
+    // MARK: - MemoryContextInfo Tests
+
+    func testMemoryContextInfoTotalLength() {
+        let info = MemoryContextInfo(
+            systemPromptLength: 100,
+            agentPersonaLength: 50,
+            workspaceMemoryLength: 200,
+            agentMemoryLength: 30,
+            personalMemoryLength: 80
+        )
+        XCTAssertEqual(info.totalLength, 460)
+    }
+
+    func testMemoryContextInfoEstimatedTokens() {
+        let info = MemoryContextInfo(
+            systemPromptLength: 100,
+            agentPersonaLength: 0,
+            workspaceMemoryLength: 0,
+            agentMemoryLength: 0,
+            personalMemoryLength: 0
+        )
+        XCTAssertEqual(info.estimatedTokens, 50)
+    }
+
+    func testMemoryContextInfoHasAnyMemory() {
+        let emptyInfo = MemoryContextInfo(
+            systemPromptLength: 0,
+            agentPersonaLength: 0,
+            workspaceMemoryLength: 0,
+            agentMemoryLength: 0,
+            personalMemoryLength: 0
+        )
+        XCTAssertFalse(emptyInfo.hasAnyMemory)
+
+        let nonEmptyInfo = MemoryContextInfo(
+            systemPromptLength: 10,
+            agentPersonaLength: 0,
+            workspaceMemoryLength: 0,
+            agentMemoryLength: 0,
+            personalMemoryLength: 0
+        )
+        XCTAssertTrue(nonEmptyInfo.hasAnyMemory)
+    }
+
+    func testMemoryContextInfoActiveLayerCount() {
+        let info = MemoryContextInfo(
+            systemPromptLength: 100,
+            agentPersonaLength: 0,
+            workspaceMemoryLength: 50,
+            agentMemoryLength: 0,
+            personalMemoryLength: 30
+        )
+        XCTAssertEqual(info.activeLayerCount, 3)
+    }
+
+    func testMemoryContextInfoLayers() {
+        let info = MemoryContextInfo(
+            systemPromptLength: 100,
+            agentPersonaLength: 50,
+            workspaceMemoryLength: 0,
+            agentMemoryLength: 0,
+            personalMemoryLength: 0
+        )
+        let layers = info.layers
+        XCTAssertEqual(layers.count, 5)
+        XCTAssertTrue(layers[0].isActive)
+        XCTAssertTrue(layers[1].isActive)
+        XCTAssertFalse(layers[2].isActive)
+        XCTAssertFalse(layers[3].isActive)
+        XCTAssertFalse(layers[4].isActive)
+    }
+
+    func testMemoryContextInfoCodableRoundTrip() throws {
+        let original = MemoryContextInfo(
+            systemPromptLength: 100,
+            agentPersonaLength: 50,
+            workspaceMemoryLength: 200,
+            agentMemoryLength: 30,
+            personalMemoryLength: 80
+        )
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(MemoryContextInfo.self, from: data)
+        XCTAssertEqual(original, decoded)
+    }
+
+    // MARK: - MemoryToastEvent Tests
+
+    func testMemoryToastEventDisplayMessage() {
+        let event = MemoryToastEvent(
+            scope: .personal,
+            action: .saved,
+            contentPreview: "좋아하는 음식: 피자"
+        )
+        XCTAssertEqual(event.displayMessage, "개인 메모리에 저장됨")
+    }
+
+    func testMemoryToastEventWorkspaceScope() {
+        let event = MemoryToastEvent(
+            scope: .workspace,
+            action: .updated,
+            contentPreview: "프로젝트 마일스톤 변경"
+        )
+        XCTAssertEqual(event.displayMessage, "워크스페이스 메모리에 업데이트됨")
+    }
+
+    func testMemoryToastEventContentPreviewTruncation() {
+        let longContent = String(repeating: "가", count: 200)
+        let event = MemoryToastEvent(scope: .personal, action: .saved, contentPreview: longContent)
+        XCTAssertEqual(event.contentPreview.count, 80)
+    }
+
+    func testMemoryToastEventAgentScope() {
+        let event = MemoryToastEvent(
+            scope: .agent,
+            action: .saved,
+            contentPreview: "새로운 학습 내용"
+        )
+        XCTAssertEqual(event.displayMessage, "에이전트 메모리에 저장됨")
+    }
+
+    // MARK: - Message with MemoryContextInfo Tests
+
+    func testMessageWithMemoryContextInfo() throws {
+        let info = MemoryContextInfo(
+            systemPromptLength: 100,
+            agentPersonaLength: 50,
+            workspaceMemoryLength: 0,
+            agentMemoryLength: 0,
+            personalMemoryLength: 0
+        )
+        let message = Message(
+            role: .assistant,
+            content: "안녕하세요!",
+            memoryContextInfo: info
+        )
+        XCTAssertNotNil(message.memoryContextInfo)
+        XCTAssertEqual(message.memoryContextInfo?.totalLength, 150)
+    }
+
+    func testMessageWithoutMemoryContextInfo() {
+        let message = Message(role: .assistant, content: "테스트")
+        XCTAssertNil(message.memoryContextInfo)
+    }
+
+    func testMessageMemoryContextInfoCodableRoundTrip() throws {
+        let info = MemoryContextInfo(
+            systemPromptLength: 100,
+            agentPersonaLength: 50,
+            workspaceMemoryLength: 200,
+            agentMemoryLength: 30,
+            personalMemoryLength: 80
+        )
+        let message = Message(
+            role: .assistant,
+            content: "테스트 응답",
+            memoryContextInfo: info
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(message)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(Message.self, from: data)
+
+        XCTAssertEqual(decoded.memoryContextInfo?.totalLength, 460)
+        XCTAssertEqual(decoded.memoryContextInfo?.activeLayerCount, 5)
+    }
+
+    func testMessageWithoutMemoryContextInfoBackwardsCompatible() throws {
+        // Simulate old JSON without memoryContextInfo field
+        let json = """
+        {
+            "id": "12345678-1234-1234-1234-123456789012",
+            "role": "assistant",
+            "content": "Hello",
+            "timestamp": "2026-01-01T00:00:00Z"
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let message = try decoder.decode(Message.self, from: data)
+
+        XCTAssertNil(message.memoryContextInfo)
+        XCTAssertEqual(message.content, "Hello")
+    }
+
+    // MARK: - ViewModel Memory Toast Tests
+
+    @MainActor
+    func testViewModelShowMemoryToast() {
+        let contextService = MockContextService()
+        let viewModel = makeViewModel(contextService: contextService)
+
+        viewModel.showMemoryToast(scope: .personal, action: .saved, contentPreview: "좋아하는 음식: 피자")
+        XCTAssertEqual(viewModel.memoryToastEvents.count, 1)
+        XCTAssertEqual(viewModel.memoryToastEvents[0].scope, .personal)
+    }
+
+    @MainActor
+    func testViewModelDismissMemoryToast() {
+        let contextService = MockContextService()
+        let viewModel = makeViewModel(contextService: contextService)
+
+        viewModel.showMemoryToast(scope: .workspace, action: .saved, contentPreview: "테스트")
+        let eventId = viewModel.memoryToastEvents[0].id
+        viewModel.dismissMemoryToast(id: eventId)
+        XCTAssertTrue(viewModel.memoryToastEvents.isEmpty)
+    }
+
+    @MainActor
+    func testViewModelBuildMemoryContextInfo() {
+        let contextService = MockContextService()
+        contextService.baseSystemPrompt = "You are a helpful assistant."
+        let wsId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+        contextService.workspaceMemory[wsId] = "프로젝트 관련 메모"
+
+        let settings = AppSettings()
+        let sessionContext = SessionContext(workspaceId: wsId, currentUserId: "user1")
+        contextService.userMemory["user1"] = "좋아하는 음식: 피자"
+
+        let viewModel = makeViewModel(
+            contextService: contextService,
+            settings: settings,
+            sessionContext: sessionContext
+        )
+        let info = viewModel.buildMemoryContextInfo()
+
+        XCTAssertTrue(info.hasAnyMemory)
+        XCTAssertEqual(info.systemPromptLength, "You are a helpful assistant.".count)
+        XCTAssertEqual(info.workspaceMemoryLength, "프로젝트 관련 메모".count)
+        XCTAssertEqual(info.personalMemoryLength, "좋아하는 음식: 피자".count)
+    }
+
+    @MainActor
+    func testViewModelBuildMemoryContextInfoEmpty() {
+        let contextService = MockContextService()
+        let viewModel = makeViewModel(contextService: contextService)
+        let info = viewModel.buildMemoryContextInfo()
+        XCTAssertFalse(info.hasAnyMemory)
+        XCTAssertEqual(info.totalLength, 0)
+    }
+
+    // MARK: - Helper
+
+    @MainActor
+    private func makeViewModel(
+        contextService: MockContextService = MockContextService(),
+        settings: AppSettings = AppSettings(),
+        sessionContext: SessionContext? = nil
+    ) -> DochiViewModel {
+        let wsId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+        let ctx = sessionContext ?? SessionContext(workspaceId: wsId)
+        return DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: contextService,
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: ctx
+        )
+    }
+}

--- a/spec/ui-inventory.md
+++ b/spec/ui-inventory.md
@@ -25,12 +25,14 @@ DochiApp (entry point)
     │   │   ├── SystemHealthBarView — 시스템 상태 바 (모델/동기화/하트비트/토큰) [항상 표시]
     │   │   ├── StatusBarView — 상태/토큰 (처리 중에만 표시)
     │   │   ├── ToolConfirmationBannerView — 민감 도구 승인 (카운트다운 타이머, Enter/Escape 단축키)
+    │   │   ├── SystemPromptBannerView — 시스템 프롬프트 접기/펼치기 배너 (UX-8)
     │   │   ├── ErrorBannerView — 에러 표시
     │   │   ├── AvatarView — 3D 아바타 (macOS 15+, 선택적)
     │   │   ├── EmptyConversationView — 빈 대화 시작 (카테고리 제안 + 카탈로그 링크 + 단축키 힌트 + 에이전트 힌트 카드)
     │   │   │   또는 ConversationView — 메시지 목록
     │   │   │       ├── MessageBubbleView — 개별 메시지 버블 (호버 시 복사 버튼)
     │   │   │       │   ├── MessageMetadataBadgeView — 모델/응답시간 배지 (assistant만, 호버 팝오버)
+    │   │   │       │   ├── MemoryReferenceBadgeView — 메모리 참조 배지 (assistant만, 호버 팝오버) (UX-8)
     │   │   │       │   └── ToolExecutionRecordCardView — 과거 도구 실행 기록 카드 (접을 수 있음)
     │   │   │       ├── ToolExecutionCardView — 실시간 도구 실행 카드 (상태별 스타일, 접을 수 있음)
     │   │   │       └── ToolChainProgressView — 도구 체인 진행 표시 (2개 이상 도구 실행 시)
@@ -40,7 +42,10 @@ DochiApp (entry point)
     │   └── [칸반 탭]
     │       └── KanbanWorkspaceView
     │           └── KanbanBoardView → KanbanColumnView → KanbanCardView
-    └── [Overlay] CommandPaletteView — ⌘K 커맨드 팔레트 (ZStack 오버레이)
+    ├── [Inspector] MemoryPanelView — 메모리 인스펙터 패널 (⌘I 토글) (UX-8)
+    │   └── MemoryNodeView — 계층별 메모리 노드 (접기/펼치기 + 인라인 편집)
+    ├── [Overlay] CommandPaletteView — ⌘K 커맨드 팔레트 (ZStack 오버레이)
+    └── [Overlay] MemoryToastContainerView — 메모리 저장 토스트 (우측 하단) (UX-8)
 ```
 
 ---
@@ -70,6 +75,12 @@ DochiApp (entry point)
 | ToolExecutionRecordCardView | `Views/ToolExecutionCardView.swift` | 과거 assistant 메시지 자동 | 아카이브된 도구 실행 기록 카드 (접힌 상태 기본) |
 | ToolChainProgressView | `Views/ToolChainProgressView.swift` | 도구 2개 이상 실행 시 자동 | 단계별 원형 인디케이터 + 연결선 + 전체 소요 시간 |
 | AvatarView | `Views/AvatarView.swift` | 설정 활성화 시 | VRM 3D 아바타 (RealityKit, macOS 15+) |
+| MemoryPanelView | `Views/MemoryPanelView.swift` | 툴바 "메모리" 버튼 (⌘I) | 우측 인스펙터: 메모리 계층 트리 (5단계), 인라인 편집, 글자수/토큰 표시 |
+| MemoryNodeView | `Views/MemoryPanelView.swift` | MemoryPanelView 내 자동 | 접기/펼치기 카드: 아이콘+제목+글자수+미리보기 / TextEditor+저장 |
+| SystemPromptBannerView | `Views/SystemPromptBannerView.swift` | 대화 상단 항상 표시 | 접힌: 미리보기+편집 / 펼침: TextEditor+저장, UserDefaults 상태 기억 |
+| MemoryToastView | `Views/MemoryToastView.swift` | save_memory/update_memory 도구 실행 시 자동 | 우측 하단 토스트: scope+action+미리보기+"보기" 버튼, 5초 자동 fade |
+| MemoryToastContainerView | `Views/MemoryToastView.swift` | 자동 | 여러 토스트 스택 관리 |
+| MemoryReferenceBadgeView | `Views/MemoryReferenceBadgeView.swift` | assistant 메시지 자동 | "메모리 N계층" 배지, 호버 시 계층별 글자수 팝오버 |
 
 ### 칸반
 
@@ -84,7 +95,7 @@ DochiApp (entry point)
 |------|------|-----------|------|
 | SystemStatusSheetView | `Views/SystemStatusSheetView.swift` | 툴바 "상태" 버튼 (⌘⇧S) 또는 SystemHealthBar 클릭 | 3탭 상세: LLM 교환 이력, 하트비트 틱 기록, 클라우드 동기화 |
 | CapabilityCatalogView | `Views/CapabilityCatalogView.swift` | 툴바 "기능" 버튼 (⌘⇧F) | 전체 도구 그룹별 카탈로그 |
-| ContextInspectorView | `Views/ContextInspectorView.swift` | 툴바 "컨텍스트" 버튼 (⌘I) | 시스템 프롬프트 / 에이전트 / 메모리 탭 |
+| ContextInspectorView | `Views/ContextInspectorView.swift` | ⌘⌥I 또는 커맨드 팔레트 | 시스템 프롬프트 / 에이전트 / 메모리 탭 (시트) |
 | KeyboardShortcutHelpView | `Views/KeyboardShortcutHelpView.swift` | ⌘/ 또는 커맨드 팔레트 | 4섹션 키보드 단축키 도움말 (480x520) |
 | CommandPaletteView | `Views/CommandPaletteView.swift` | ⌘K | VS Code 스타일 커맨드 팔레트 오버레이 (퍼지 검색, 그룹 섹션) |
 | QuickSwitcherView | `Views/QuickSwitcherView.swift` | ⌘⇧A / ⌘⇧W / ⌘⇧U | 에이전트/워크스페이스/사용자 빠른 전환 시트 |
@@ -137,6 +148,7 @@ DochiApp (entry point)
 | `metricsCollector` | `MetricsCollector` | LLM 교환 메트릭 수집 | SystemHealthBarView, SystemStatusSheetView |
 | `toolExecutions` | `[ToolExecution]` | 현재 턴 도구 실행 목록 | ConversationView (ToolExecutionCardView, ToolChainProgressView) |
 | `allToolCardsCollapsed` | `Bool` | 도구 카드 일괄 접기/펼치기 상태 | ⌘⇧T 토글 |
+| `memoryToastEvents` | `[MemoryToastEvent]` | 메모리 저장 토스트 이벤트 큐 | MemoryToastContainerView |
 
 ### 대화 정리 상태 (UX-4 추가)
 
@@ -181,6 +193,31 @@ ToolExecutionRecord 필드:
 | `isError` | `Bool` | 오류 여부 |
 | `durationSeconds` | `TimeInterval?` | 소요 시간 |
 | `resultSummary` | `String?` | 결과 요약 |
+
+### Message.memoryContextInfo (UX-8 추가)
+
+| 프로퍼티 | 타입 | 설명 |
+|----------|------|------|
+| `memoryContextInfo` | `MemoryContextInfo?` | 이 응답 생성 시 사용된 메모리 계층 정보 (하위호환: decodeIfPresent) |
+
+MemoryContextInfo 필드:
+| 프로퍼티 | 타입 | 설명 |
+|----------|------|------|
+| `systemPromptLength` | `Int` | 시스템 프롬프트 글자수 |
+| `agentPersonaLength` | `Int` | 에이전트 페르소나 글자수 |
+| `workspaceMemoryLength` | `Int` | 워크스페이스 메모리 글자수 |
+| `agentMemoryLength` | `Int` | 에이전트 메모리 글자수 |
+| `personalMemoryLength` | `Int` | 개인 메모리 글자수 |
+
+### MemoryToastEvent (UX-8 추가)
+
+| 프로퍼티 | 타입 | 설명 |
+|----------|------|------|
+| `id` | `UUID` | 이벤트 ID |
+| `scope` | `Scope` | workspace/personal/agent |
+| `action` | `Action` | saved/updated |
+| `contentPreview` | `String` | 저장 내용 미리보기 (80자 이내) |
+| `timestamp` | `Date` | 발생 시각 |
 
 ### 누락된 상태 (현재 UI에 노출 안 됨)
 
@@ -266,6 +303,24 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 민감 도구 확인: ToolConfirmationBannerView + 30초 카운트다운 타이머 + Enter(허용)/Escape(거부) 단축키
 ```
 
+### 컨텍스트/메모리 관리 (UX-8 추가)
+```
+메모리 인스펙터: ⌘I -> showMemoryPanel 토글 -> .inspector modifier -> MemoryPanelView
+  -> 계층 트리: 시스템프롬프트 / 에이전트페르소나 / 워크스페이스메모리 / 에이전트메모리 / 개인메모리
+  -> 각 MemoryNodeView: 접기(미리보기) / 펼치기(TextEditor + 저장 버튼)
+  -> 푸터: 총 N자 / ~M토큰
+시스템프롬프트 배너: 대화 상단 SystemPromptBannerView
+  -> 접힌: "시스템 프롬프트: 미리보기... [편집]" / 펼침: TextEditor + 저장
+  -> UserDefaults로 접힌/펼친 상태 기억
+메모리 토스트: save_memory/update_memory 도구 실행 -> MemoryToastEvent 생성
+  -> viewModel.memoryToastEvents 배열에 추가
+  -> MemoryToastContainerView (우측 하단): 5초 자동 fade + "보기" -> 메모리 패널 열기
+메모리 참조 배지: appendAssistantMessage() -> buildMemoryContextInfo() -> Message.memoryContextInfo
+  -> MessageBubbleView -> MemoryReferenceBadgeView: "메모리 N계층" 배지
+  -> 호버 팝오버: 계층별 사용 여부 + 글자수
+기존 컨텍스트 인스펙터: ⌘⌥I -> showContextInspector -> ContextInspectorView (시트)
+```
+
 ### 내보내기/공유 (UX-5 추가)
 ```
 빠른 내보내기: ⌘E -> viewModel.exportConversation(format: .markdown) -> NSSavePanel
@@ -290,7 +345,8 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 | ⌘1~9 | N번째 대화 선택 | ContentView (onKeyPress) |
 | ⌘E | 현재 대화 빠른 내보내기 (Markdown) | ContentView (hidden button) |
 | ⌘⇧E | 내보내기 옵션 시트 | ContentView 툴바 |
-| ⌘I | 컨텍스트 인스펙터 | ContentView 툴바 |
+| ⌘I | 메모리 인스펙터 패널 토글 | ContentView 툴바 (UX-8 변경) |
+| ⌘⌥I | 컨텍스트 인스펙터 (시트) | ContentView hidden button (UX-8 신규) |
 | ⌘, | 설정 | macOS 자동 (Settings scene) |
 | ⌘⇧S | 시스템 상태 시트 | ContentView 툴바 |
 | ⌘⇧F | 기능 카탈로그 | ContentView 툴바 |
@@ -323,6 +379,10 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 | FlowLayout (커스텀 Layout) | ConversationFilterView 태그 칩 | 줄바꿈 가능한 가로 배치 |
 | 접을 수 있는 카드 (VStack + Button + chevron) | ToolExecutionCardView, ToolExecutionRecordCardView | 상태별 색상, 클릭 접기/펼치기 |
 | 진행 체인 (HStack + Circle + Rectangle) | ToolChainProgressView | 단계별 아이콘 + 연결선 |
+| 인스펙터 (.inspector modifier) | MemoryPanelView | 우측 사이드 패널 (260~360pt) |
+| 접기/펼치기 배너 (VStack + Button) | SystemPromptBannerView | 접힌: 미리보기, 펼침: TextEditor |
+| 토스트 (HStack + material + shadow) | MemoryToastView | 우측 하단 알림 (5초 자동 fade) |
+| 메모리 노드 카드 (VStack + chevron) | MemoryNodeView | 접기/펼치기 + 인라인 편집 + 저장 |
 
 ---
 
@@ -336,6 +396,9 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 | 필터 결과 0개 | "조건에 맞는 대화가 없습니다" + 필터 초기화 | ConversationListView |
 | 에이전트 0개 | "에이전트가 없습니다" + 생성 버튼 | AgentCardGridView |
 | 에이전트 0개 (대화) | 에이전트 생성 힌트 카드 | EmptyConversationView |
+| 시스템 프롬프트 없음 | "시스템 프롬프트가 설정되지 않았습니다 [작성하기]" | SystemPromptBannerView |
+| 메모리 노드 비어 있음 | 노드별 안내 문구 + "작성하기" 버튼 | MemoryNodeView |
+| 개인 메모리 없음 (사용자 미설정) | "사용자가 설정되지 않아 표시할 수 없습니다" | MemoryPanelView |
 
 ---
 
@@ -377,4 +440,25 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 
 ---
 
-*최종 업데이트: 2026-02-15 (UX-7 머지 후)*
+### MemoryContextInfo (UX-8 추가)
+
+| 프로퍼티 | 타입 | 설명 |
+|----------|------|------|
+| `systemPromptLength` | `Int` | 시스템 프롬프트 글자수 |
+| `agentPersonaLength` | `Int` | 에이전트 페르소나 글자수 |
+| `workspaceMemoryLength` | `Int` | 워크스페이스 메모리 글자수 |
+| `agentMemoryLength` | `Int` | 에이전트 메모리 글자수 |
+| `personalMemoryLength` | `Int` | 개인 메모리 글자수 |
+
+### MemoryToastEvent (UX-8 추가)
+
+| 프로퍼티 | 타입 | 설명 |
+|----------|------|------|
+| `id` | `UUID` | 이벤트 ID |
+| `scope` | `Scope` | workspace/personal/agent |
+| `action` | `Action` | saved/updated |
+| `contentPreview` | `String` | 저장 내용 미리보기 (80자) |
+
+---
+
+*최종 업데이트: 2026-02-15 (UX-8 머지 후)*


### PR DESCRIPTION
## Summary

- **MemoryPanelView**: 우측 `.inspector` 패널 (`Cmd+I`로 토글), 5계층 메모리 트리 시각화 (시스템프롬프트 / 에이전트 페르소나 / 워크스페이스 메모리 / 에이전트 메모리 / 개인 메모리)
- **SystemPromptBannerView**: 대화 상단 접기/펼치기 시스템 프롬프트 배너, UserDefaults로 상태 기억
- **MemoryToastView**: `save_memory`/`update_memory` 도구 실행 시 우측 하단 토스트 알림 (5초 자동 fade, "보기" 버튼으로 패널 열기)
- **MemoryReferenceBadgeView**: assistant 메시지에 "메모리 N계층" 배지, 호버 시 계층별 글자수 팝오버
- **키보드 단축키 변경**: `Cmd+I` -> 메모리 인스펙터 패널, `Cmd+Opt+I` -> 기존 ContextInspectorView (시트)
- 커맨드 팔레트에 "메모리 인스펙터" 항목 추가
- 18개 단위 테스트 (모델 Codable, ViewModel 통합, 하위호환)

## Test plan

- [x] `xcodebuild build` 성공
- [x] `xcodebuild test` 통과 (18개 신규 테스트 전부 통과, 기존 테스트 1개 pre-existing failure)
- [ ] `Cmd+I`로 메모리 인스펙터 패널 열림/닫힘 확인
- [ ] 각 메모리 노드 접기/펼치기, 편집, 저장 확인
- [ ] `Cmd+Opt+I`로 기존 ContextInspectorView 시트 열림 확인
- [ ] 시스템 프롬프트 배너 접힌/펼친 상태 앱 재시작 후 유지 확인
- [ ] save_memory 도구 실행 시 토스트 표시, "보기" 클릭 시 패널 열림 확인
- [ ] assistant 메시지에 메모리 참조 배지 표시, 호버 팝오버 확인

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)