### PR TITLE
feat: 온보딩 2.0 — 기능 투어 & 단계별 가이드 (UX-9)

### DIFF
--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -231,4 +231,46 @@ final class AppSettings {
     var currentTTSProvider: TTSProvider {
         TTSProvider(rawValue: ttsProvider) ?? .system
     }
+
+    // MARK: - Guide (UX-9)
+
+    /// 인앱 힌트 표시 여부 (hintsGloballyDisabled의 반전)
+    var hintsEnabled: Bool {
+        get { !UserDefaults.standard.bool(forKey: "hintsGloballyDisabled") }
+        set { UserDefaults.standard.set(!newValue, forKey: "hintsGloballyDisabled") }
+    }
+
+    /// 기능 투어 완료 여부
+    var featureTourCompleted: Bool {
+        get { UserDefaults.standard.bool(forKey: "featureTourCompleted") }
+        set { UserDefaults.standard.set(newValue, forKey: "featureTourCompleted") }
+    }
+
+    /// 기능 투어 건너뛰기 여부
+    var featureTourSkipped: Bool {
+        get { UserDefaults.standard.bool(forKey: "featureTourSkipped") }
+        set { UserDefaults.standard.set(newValue, forKey: "featureTourSkipped") }
+    }
+
+    /// 기능 투어 재안내 배너 닫음 여부
+    var featureTourBannerDismissed: Bool {
+        get { UserDefaults.standard.bool(forKey: "featureTourBannerDismissed") }
+        set { UserDefaults.standard.set(newValue, forKey: "featureTourBannerDismissed") }
+    }
+
+    /// 모든 힌트 표시 상태를 초기화
+    func resetAllHints() {
+        let allKeys = UserDefaults.standard.dictionaryRepresentation().keys
+        for key in allKeys where key.hasPrefix("hint_seen_") {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        UserDefaults.standard.set(false, forKey: "hintsGloballyDisabled")
+    }
+
+    /// 기능 투어 상태를 초기화
+    func resetFeatureTour() {
+        UserDefaults.standard.set(false, forKey: "featureTourCompleted")
+        UserDefaults.standard.set(false, forKey: "featureTourSkipped")
+        UserDefaults.standard.set(false, forKey: "featureTourBannerDismissed")
+    }
 }

--- a/Dochi/Models/CommandPaletteItem.swift
+++ b/Dochi/Models/CommandPaletteItem.swift
@@ -36,6 +36,8 @@ struct CommandPaletteItem: Identifiable, Sendable {
         case openTagManagement
         case toggleMultiSelect
         case createAgent
+        case openFeatureTour
+        case resetHints
         case custom(id: String)
     }
 }
@@ -204,6 +206,22 @@ enum CommandPaletteRegistry {
             subtitle: "",
             category: .agent,
             action: .createAgent
+        ),
+        CommandPaletteItem(
+            id: "feature-tour",
+            icon: "questionmark.circle",
+            title: "기능 투어",
+            subtitle: "",
+            category: .navigation,
+            action: .openFeatureTour
+        ),
+        CommandPaletteItem(
+            id: "reset-hints",
+            icon: "arrow.counterclockwise",
+            title: "인앱 힌트 초기화",
+            subtitle: "",
+            category: .settings,
+            action: .resetHints
         ),
     ]
 

--- a/Dochi/Views/Guide/FeatureTourViews.swift
+++ b/Dochi/Views/Guide/FeatureTourViews.swift
@@ -1,0 +1,406 @@
+import SwiftUI
+
+// MARK: - Tour Step Enum
+
+/// 기능 투어 단계 (4단계)
+enum TourStep: Int, CaseIterable {
+    case overview = 0        // T1: 도구 카테고리 소개
+    case conversation = 1   // T2: 대화의 기본
+    case agentWorkspace = 2 // T3: 에이전트 & 워크스페이스
+    case shortcuts = 3      // T4: 빠른 조작법
+}
+
+// MARK: - FeatureTourView (Container)
+
+/// 기능 투어 컨테이너 뷰. 4단계를 네비게이션과 함께 관리한다.
+struct FeatureTourView: View {
+    let onComplete: () -> Void
+    let onSkip: () -> Void
+
+    @State private var currentStep: TourStep = .overview
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // 단계 인디케이터
+            HStack(spacing: 6) {
+                ForEach(TourStep.allCases, id: \.rawValue) { step in
+                    Circle()
+                        .fill(step.rawValue <= currentStep.rawValue ? Color.accentColor : Color.secondary.opacity(0.3))
+                        .frame(width: 8, height: 8)
+                }
+            }
+            .padding(.top, 16)
+
+            Spacer()
+
+            // 단계별 콘텐츠
+            Group {
+                switch currentStep {
+                case .overview:
+                    TourOverviewView()
+                case .conversation:
+                    TourConversationView()
+                case .agentWorkspace:
+                    TourAgentWorkspaceView()
+                case .shortcuts:
+                    TourShortcutsView()
+                }
+            }
+            .frame(maxWidth: 480)
+            .padding(.horizontal, 32)
+
+            Spacer()
+
+            // 네비게이션 바
+            HStack {
+                if currentStep == .overview {
+                    Button("건너뛰기") {
+                        onSkip()
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                } else {
+                    Button("이전") {
+                        withAnimation {
+                            currentStep = TourStep(rawValue: currentStep.rawValue - 1) ?? .overview
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                // 단계 인디케이터 (중앙 레이블)
+                Text("\(currentStep.rawValue + 1) / \(TourStep.allCases.count)")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.tertiary)
+
+                Spacer()
+
+                if currentStep == .shortcuts {
+                    Button("시작하기") {
+                        onComplete()
+                    }
+                    .buttonStyle(.borderedProminent)
+                } else {
+                    Button("다음") {
+                        withAnimation {
+                            currentStep = TourStep(rawValue: currentStep.rawValue + 1) ?? .shortcuts
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding(24)
+        }
+        .frame(width: 560, height: 480)
+    }
+}
+
+// MARK: - T1: 도구 카테고리 소개
+
+struct TourOverviewView: View {
+    private let categories: [(icon: String, name: String, description: String, color: Color)] = [
+        ("calendar", "일정 & 미리알림", "캘린더 조회/추가, 미리알림 관리, 타이머", .red),
+        ("rectangle.3.group", "칸반 보드", "프로젝트를 칸반으로 시각화하고 관리", .orange),
+        ("magnifyingglass", "웹 검색", "실시간 웹 검색과 정보 수집", .blue),
+        ("doc.text", "파일 & 클립보드", "파일 탐색, 읽기/쓰기, 클립보드", .green),
+        ("terminal", "개발 도구", "Git, GitHub, 셸 명령 실행", .purple),
+        ("music.note", "미디어", "음악 제어, 이미지 생성, 스크린샷", .pink),
+        ("brain", "메모리", "대화 내용 기억, 개인 정보 관리", .indigo),
+        ("puzzlepiece", "확장 (MCP)", "외부 도구 서버 연결", .teal),
+    ]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "square.grid.2x2.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(Color.accentColor)
+
+            Text("도치가 할 수 있는 것")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text("8가지 카테고리의 35개 도구를 대화로 활용할 수 있습니다.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            // 2열 4행 그리드
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 10),
+                GridItem(.flexible(), spacing: 10),
+            ], spacing: 8) {
+                ForEach(categories, id: \.name) { cat in
+                    HStack(spacing: 8) {
+                        Image(systemName: cat.icon)
+                            .font(.system(size: 14))
+                            .foregroundStyle(cat.color)
+                            .frame(width: 28, height: 28)
+                            .background(cat.color.opacity(0.1))
+                            .clipShape(Circle())
+
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(cat.name)
+                                .font(.system(size: 12, weight: .semibold))
+                                .lineLimit(1)
+                            Text(cat.description)
+                                .font(.system(size: 10))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+
+                        Spacer(minLength: 0)
+                    }
+                    .padding(6)
+                    .background(Color.secondary.opacity(0.05))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - T2: 대화의 기본
+
+struct TourConversationView: View {
+    private let sections: [(icon: String, title: String, description: String)] = [
+        ("text.bubble", "텍스트 입력",
+         "하단 입력창에 메시지를 입력하면 AI가 답변합니다. Shift+Enter로 줄바꿈."),
+        ("slash.circle", "슬래시 명령",
+         "/ 를 입력하면 명령 목록이 나타납니다. 빠르게 기능을 실행할 수 있습니다."),
+        ("mic", "음성 대화",
+         "마이크 버튼을 누르거나 웨이크워드를 말하면 음성으로 대화합니다."),
+    ]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "bubble.left.and.bubble.right.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(Color.accentColor)
+
+            Text("대화의 기본")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text("세 가지 방식으로 도치와 소통할 수 있습니다.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 0) {
+                ForEach(Array(sections.enumerated()), id: \.offset) { index, section in
+                    HStack(alignment: .top, spacing: 12) {
+                        Image(systemName: section.icon)
+                            .font(.system(size: 18))
+                            .foregroundStyle(Color.accentColor)
+                            .frame(width: 24, height: 24)
+
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(section.title)
+                                .font(.system(size: 13, weight: .semibold))
+                            Text(section.description)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 10)
+
+                    if index < sections.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+            .padding(12)
+            .background(Color.secondary.opacity(0.05))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            Text("도치는 필요한 도구를 자동으로 선택합니다. 별도로 도구를 지정할 필요 없어요.")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+        }
+    }
+}
+
+// MARK: - T3: 에이전트 & 워크스페이스
+
+struct TourAgentWorkspaceView: View {
+    private let templateIcons = [
+        ("chevron.left.slash.chevron.right", "코딩"),
+        ("magnifyingglass", "리서치"),
+        ("calendar", "일정"),
+        ("pencil.line", "작문"),
+        ("rectangle.3.group", "칸반"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("에이전트 & 워크스페이스")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            HStack(alignment: .top, spacing: 16) {
+                // 좌측: 에이전트
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "person.crop.rectangle.stack")
+                            .font(.system(size: 24))
+                            .foregroundStyle(.blue)
+                        Text("에이전트")
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+
+                    Text("목적에 맞는 AI 비서를 만들 수 있습니다. 코딩, 리서치, 일정 관리 등 템플릿으로 빠르게 시작하세요.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    // 템플릿 아이콘
+                    HStack(spacing: 8) {
+                        ForEach(templateIcons, id: \.1) { icon, label in
+                            VStack(spacing: 2) {
+                                Image(systemName: icon)
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.blue)
+                                    .frame(width: 28, height: 28)
+                                    .background(Color.blue.opacity(0.1))
+                                    .clipShape(Circle())
+                                Text(label)
+                                    .font(.system(size: 9))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+                .padding(12)
+                .background(Color.blue.opacity(0.04))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                // 우측: 워크스페이스
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "square.stack.3d.up")
+                            .font(.system(size: 24))
+                            .foregroundStyle(.purple)
+                        Text("워크스페이스")
+                            .font(.system(size: 14, weight: .semibold))
+                    }
+
+                    Text("프로젝트별로 독립된 공간을 만들 수 있습니다. 각 워크스페이스에 별도 메모리와 에이전트를 설정합니다.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    // 워크스페이스 전환 모의
+                    HStack(spacing: 6) {
+                        ForEach(["기본", "프로젝트 A"], id: \.self) { name in
+                            Text(name)
+                                .font(.system(size: 10, weight: .medium))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(name == "기본" ? Color.purple.opacity(0.15) : Color.secondary.opacity(0.08))
+                                .clipShape(RoundedRectangle(cornerRadius: 5))
+                        }
+                        Image(systemName: "plus.circle")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.purple.opacity(0.6))
+                    }
+
+                    keycapHint(keys: ["\u{2318}", "\u{21E7}", "W"], label: "로 빠르게 전환")
+                }
+                .padding(12)
+                .background(Color.purple.opacity(0.04))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+            }
+        }
+    }
+
+    private func keycapHint(keys: [String], label: String) -> some View {
+        HStack(spacing: 3) {
+            ForEach(keys, id: \.self) { key in
+                Text(key)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.15))
+                    .clipShape(RoundedRectangle(cornerRadius: 3))
+            }
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - T4: 빠른 조작법
+
+struct TourShortcutsView: View {
+    private let shortcuts: [(keys: String, action: String, description: String)] = [
+        ("\u{2318}K", "커맨드 팔레트", "무엇이든 빠르게 찾고 실행"),
+        ("\u{2318}N", "새 대화", "새 대화 시작"),
+        ("\u{2318}I", "메모리 패널", "AI가 기억하는 정보 확인/편집"),
+        ("\u{2318}\u{21E7}A", "에이전트 전환", "다른 에이전트로 빠르게 전환"),
+        ("\u{2318}/", "단축키 도움말", "전체 단축키 목록 보기"),
+    ]
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "keyboard.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(Color.accentColor)
+
+            Text("빠른 조작법")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text("자주 쓰는 기능을 단축키로 빠르게 실행할 수 있습니다.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            VStack(spacing: 0) {
+                ForEach(Array(shortcuts.enumerated()), id: \.offset) { index, shortcut in
+                    HStack(spacing: 12) {
+                        // 키캡
+                        Text(shortcut.keys)
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.secondary.opacity(0.12))
+                            .clipShape(RoundedRectangle(cornerRadius: 5))
+                            .frame(width: 60)
+
+                        // 동작명
+                        Text(shortcut.action)
+                            .font(.system(size: 13, weight: .medium))
+                            .frame(width: 100, alignment: .leading)
+
+                        // 설명
+                        Text(shortcut.description)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 8)
+
+                    if index < shortcuts.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+            .padding(12)
+            .background(Color.secondary.opacity(0.05))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            Text("전체 단축키는 \u{2318}/ 로 언제든 볼 수 있습니다.")
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+        }
+    }
+}

--- a/Dochi/Views/Guide/HintBubbleModifier.swift
+++ b/Dochi/Views/Guide/HintBubbleModifier.swift
@@ -1,0 +1,241 @@
+import SwiftUI
+import os
+
+// MARK: - HintManager
+
+/// 인앱 힌트 표시 상태를 관리하는 싱글턴.
+/// UserDefaults 기반으로 각 힌트의 표시 여부와 전역 비활성화 상태를 추적한다.
+@MainActor
+@Observable
+final class HintManager {
+    static let shared = HintManager()
+
+    /// 현재 표시 중인 힌트 ID (동시 최대 1개)
+    var activeHintId: String?
+
+    private init() {}
+
+    // MARK: - 개별 힌트
+
+    /// 특정 힌트가 이미 표시되었는지 확인
+    func hasSeenHint(_ id: String) -> Bool {
+        UserDefaults.standard.bool(forKey: "hint_seen_\(id)")
+    }
+
+    /// 특정 힌트를 표시 완료로 기록
+    func markHintSeen(_ id: String) {
+        UserDefaults.standard.set(true, forKey: "hint_seen_\(id)")
+        if activeHintId == id {
+            activeHintId = nil
+        }
+        Log.app.info("Hint marked seen: \(id)")
+    }
+
+    /// 힌트를 표시할 수 있는지 확인 (미표시 + 전역 활성 + 다른 힌트 미표시)
+    func canShowHint(_ id: String) -> Bool {
+        !isGloballyDisabled && !hasSeenHint(id) && (activeHintId == nil || activeHintId == id)
+    }
+
+    /// 힌트를 활성 상태로 설정
+    func activateHint(_ id: String) {
+        guard canShowHint(id) else { return }
+        activeHintId = id
+    }
+
+    /// 활성 힌트 해제 (닫기)
+    func dismissHint(_ id: String) {
+        markHintSeen(id)
+    }
+
+    // MARK: - 전역 비활성화
+
+    /// 모든 힌트가 전역적으로 비활성화되었는지
+    var isGloballyDisabled: Bool {
+        UserDefaults.standard.bool(forKey: "hintsGloballyDisabled")
+    }
+
+    /// 모든 힌트 전역 비활성화
+    func disableAllHints() {
+        UserDefaults.standard.set(true, forKey: "hintsGloballyDisabled")
+        activeHintId = nil
+        Log.app.info("All hints globally disabled")
+    }
+
+    // MARK: - 리셋
+
+    /// 모든 hint_seen_ 키 삭제 + 전역 비활성화 해제
+    func resetAllHints() {
+        let allKeys = UserDefaults.standard.dictionaryRepresentation().keys
+        for key in allKeys where key.hasPrefix("hint_seen_") {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        UserDefaults.standard.set(false, forKey: "hintsGloballyDisabled")
+        activeHintId = nil
+        Log.app.info("All hints reset")
+    }
+}
+
+// MARK: - HintBubbleModifier
+
+/// 말풍선 형태의 일회성 힌트를 표시하는 ViewModifier.
+/// 대상 뷰 진입 후 1.5초 후 fadeIn으로 나타나며, "확인" 또는 "X"로 닫을 수 있다.
+struct HintBubbleModifier: ViewModifier {
+    let id: String
+    let title: String
+    let message: String
+    let edge: Edge
+    let condition: Bool
+
+    @State private var isVisible = false
+    @State private var appearTask: Task<Void, Never>?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: overlayAlignment) {
+                if isVisible {
+                    hintBubble
+                        .transition(reduceMotion ? .identity : .opacity.combined(with: .scale(scale: 0.95)))
+                        .zIndex(999)
+                }
+            }
+            .onAppear {
+                scheduleAppearance()
+            }
+            .onDisappear {
+                appearTask?.cancel()
+                appearTask = nil
+            }
+            .onChange(of: condition) { _, newValue in
+                if newValue {
+                    scheduleAppearance()
+                } else {
+                    withAnimation { isVisible = false }
+                }
+            }
+    }
+
+    private var overlayAlignment: Alignment {
+        switch edge {
+        case .top: return .top
+        case .bottom: return .bottom
+        case .leading: return .leading
+        case .trailing: return .trailing
+        }
+    }
+
+    private func scheduleAppearance() {
+        guard condition, HintManager.shared.canShowHint(id) else { return }
+        appearTask?.cancel()
+        appearTask = Task { @MainActor in
+            if reduceMotion {
+                HintManager.shared.activateHint(id)
+                isVisible = true
+            } else {
+                try? await Task.sleep(for: .seconds(1.5))
+                guard !Task.isCancelled else { return }
+                guard HintManager.shared.canShowHint(id) else { return }
+                HintManager.shared.activateHint(id)
+                withAnimation(.easeOut(duration: 0.3)) {
+                    isVisible = true
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var hintBubble: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // 헤더: 아이콘 + 제목 + 닫기
+            HStack(spacing: 6) {
+                Image(systemName: "info.circle.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.blue)
+
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+
+                Spacer()
+
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("닫기")
+            }
+
+            // 설명
+            Text(message)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // 하단 버튼
+            HStack {
+                Spacer()
+
+                Button("다시 보지 않기") {
+                    HintManager.shared.disableAllHints()
+                    withAnimation { isVisible = false }
+                }
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+                .buttonStyle(.plain)
+
+                Button("확인") {
+                    dismiss()
+                }
+                .font(.system(size: 12))
+                .foregroundStyle(Color.accentColor)
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: 320)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .shadow(color: .black.opacity(0.1), radius: 8, y: 4)
+        .padding(8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(title). \(message)")
+        .accessibilityHint("확인 버튼으로 닫을 수 있습니다")
+    }
+
+    private func dismiss() {
+        HintManager.shared.dismissHint(id)
+        withAnimation(.easeIn(duration: 0.2)) {
+            isVisible = false
+        }
+    }
+}
+
+// MARK: - View Extension
+
+extension View {
+    /// 일회성 힌트 버블을 표시하는 modifier.
+    /// - Parameters:
+    ///   - id: 힌트 고유 ID (UserDefaults 키에 사용)
+    ///   - title: 힌트 제목
+    ///   - message: 힌트 설명
+    ///   - edge: 화살표 방향 (힌트 표시 위치)
+    ///   - condition: 표시 조건 (true일 때만 표시 시도)
+    func hintBubble(
+        id: String,
+        title: String,
+        message: String,
+        edge: Edge = .top,
+        condition: Bool = true
+    ) -> some View {
+        modifier(HintBubbleModifier(
+            id: id,
+            title: title,
+            message: message,
+            edge: edge,
+            condition: condition
+        ))
+    }
+}

--- a/Dochi/Views/Guide/SettingsHelpButton.swift
+++ b/Dochi/Views/Guide/SettingsHelpButton.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+// MARK: - SettingsHelpButton
+
+/// 설정 섹션 헤더에 사용하는 "?" 도움말 팝오버 버튼.
+/// 클릭 시 해당 섹션에 대한 설명을 팝오버로 표시한다.
+struct SettingsHelpButton: View {
+    let title: String
+    let content: String
+
+    @State private var isHovering = false
+    @State private var showPopover = false
+
+    init(title: String = "", content: String) {
+        self.title = title
+        self.content = content
+    }
+
+    var body: some View {
+        Button {
+            showPopover.toggle()
+        } label: {
+            Image(systemName: "questionmark.circle")
+                .font(.system(size: 12))
+                .foregroundStyle(isHovering ? Color.accentColor : .secondary)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .popover(isPresented: $showPopover, arrowEdge: .trailing) {
+            VStack(alignment: .leading, spacing: 6) {
+                if !title.isEmpty {
+                    Text(title)
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                Text(content)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(12)
+            .frame(maxWidth: 280)
+        }
+        .accessibilityLabel("\(title.isEmpty ? "도움말" : title) 도움말")
+        .accessibilityHint("클릭하면 도움말을 표시합니다")
+    }
+}
+
+// MARK: - Section Header with Help
+
+/// 도움말 버튼이 포함된 설정 섹션 헤더를 편리하게 생성하는 뷰.
+struct SettingsSectionHeader: View {
+    let title: String
+    let helpContent: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+            Spacer()
+            SettingsHelpButton(title: title, content: helpContent)
+        }
+    }
+}

--- a/Dochi/Views/Settings/AccountSettingsView.swift
+++ b/Dochi/Views/Settings/AccountSettingsView.swift
@@ -15,7 +15,7 @@ struct AccountSettingsView: View {
 
     var body: some View {
         Form {
-            Section("Supabase 연결") {
+            Section {
                 DisclosureGroup("서버 설정") {
                     TextField("URL", text: $supabaseURL)
                         .textFieldStyle(.roundedBorder)
@@ -46,6 +46,11 @@ struct AccountSettingsView: View {
                         }
                     }
                 }
+            } header: {
+                SettingsSectionHeader(
+                    title: "Supabase 연결",
+                    helpContent: "클라우드 동기화를 위한 Supabase 서버를 연결합니다. 대화, 메모리, 설정을 여러 기기에서 동기화할 수 있습니다. 자체 Supabase 프로젝트를 만들어 사용합니다."
+                )
             }
 
             Section("인증") {

--- a/Dochi/Views/Settings/AgentSettingsView.swift
+++ b/Dochi/Views/Settings/AgentSettingsView.swift
@@ -9,14 +9,29 @@ struct AgentSettingsView: View {
     var onAgentDeleted: (() -> Void)?
 
     var body: some View {
-        AgentCardGridView(
-            contextService: contextService,
-            settings: settings,
-            sessionContext: sessionContext,
-            viewModel: viewModel,
-            onAgentDeleted: onAgentDeleted
-        )
-        .padding()
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("에이전트 관리")
+                    .font(.headline)
+                SettingsHelpButton(
+                    title: "에이전트",
+                    content: "에이전트는 특정 목적에 맞게 설정된 AI 비서입니다. 각 에이전트는 고유한 페르소나, 모델, 도구 권한을 가집니다. 템플릿으로 빠르게 만들거나, 기존 에이전트를 복제/편집할 수 있습니다."
+                )
+                Spacer()
+            }
+            .padding(.horizontal)
+            .padding(.top, 12)
+            .padding(.bottom, 4)
+
+            AgentCardGridView(
+                contextService: contextService,
+                settings: settings,
+                sessionContext: sessionContext,
+                viewModel: viewModel,
+                onAgentDeleted: onAgentDeleted
+            )
+            .padding()
+        }
     }
 }
 

--- a/Dochi/Views/Settings/FamilySettingsView.swift
+++ b/Dochi/Views/Settings/FamilySettingsView.swift
@@ -13,7 +13,7 @@ struct FamilySettingsView: View {
 
     var body: some View {
         Form {
-            Section("구성원 목록") {
+            Section {
                 if profiles.isEmpty {
                     Text("등록된 구성원이 없습니다")
                         .foregroundStyle(.secondary)
@@ -81,6 +81,11 @@ struct FamilySettingsView: View {
                         }
                     }
                 }
+            } header: {
+                SettingsSectionHeader(
+                    title: "구성원 목록",
+                    helpContent: "여러 사용자가 하나의 도치를 공유할 수 있습니다. 각 사용자는 별도의 메모리와 대화 기록을 가집니다. 사이드바 상단이나 \u{2318}\u{21E7}U로 사용자를 전환할 수 있습니다."
+                )
             }
 
             Section("구성원 추가") {

--- a/Dochi/Views/Settings/IntegrationsSettingsView.swift
+++ b/Dochi/Views/Settings/IntegrationsSettingsView.swift
@@ -48,7 +48,7 @@ struct IntegrationsSettingsView: View {
 
     @ViewBuilder
     private var telegramSection: some View {
-        Section("텔레그램") {
+        Section {
             Toggle("봇 활성화", isOn: Binding(
                 get: { settings.telegramEnabled },
                 set: { newValue in
@@ -130,6 +130,10 @@ struct IntegrationsSettingsView: View {
                 set: { settings.telegramStreamReplies = $0 }
             ))
 
+            Text("응답을 점진적으로 전송합니다 (API 호출 증가)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
             Picker("연결 모드", selection: Binding(
                 get: { TelegramConnectionMode(rawValue: settings.telegramConnectionMode) ?? .polling },
                 set: { settings.telegramConnectionMode = $0.rawValue }
@@ -171,6 +175,11 @@ struct IntegrationsSettingsView: View {
                     }
                 }
             }
+        } header: {
+            SettingsSectionHeader(
+                title: "텔레그램",
+                helpContent: "텔레그램 봇을 연결하면 텔레그램 DM으로도 도치와 대화할 수 있습니다. @BotFather에서 봇을 만들고 토큰을 입력하세요."
+            )
         }
     }
 
@@ -284,7 +293,7 @@ struct IntegrationsSettingsView: View {
 
     @ViewBuilder
     private var mcpSection: some View {
-        Section("MCP 서버") {
+        Section {
             let servers = mcpService?.listServers() ?? []
 
             if servers.isEmpty {
@@ -303,6 +312,11 @@ struct IntegrationsSettingsView: View {
             } label: {
                 Label("MCP 서버 추가", systemImage: "plus")
             }
+        } header: {
+            SettingsSectionHeader(
+                title: "MCP 서버",
+                helpContent: "Model Context Protocol 서버를 추가하면 외부 도구를 도치에 연결할 수 있습니다. 데이터베이스, 사내 API 등을 AI가 직접 사용합니다."
+            )
         }
         .confirmationDialog(
             "이 MCP 서버를 삭제하시겠습니까?",

--- a/Dochi/Views/Settings/ToolsSettingsView.swift
+++ b/Dochi/Views/Settings/ToolsSettingsView.swift
@@ -49,6 +49,11 @@ struct ToolsSettingsView: View {
         VStack(spacing: 0) {
             // Header
             HStack {
+                SettingsHelpButton(
+                    title: "도구",
+                    content: "도치가 사용할 수 있는 35개 내장 도구 목록입니다. \"기본 제공\" 도구는 항상 사용 가능하고, \"조건부\" 도구는 AI가 필요할 때 자동으로 활성화합니다. 권한 등급(safe/sensitive/restricted)에 따라 승인이 필요할 수 있습니다."
+                )
+
                 HStack {
                     Image(systemName: "magnifyingglass")
                         .foregroundStyle(.secondary)

--- a/Dochi/Views/Settings/VoiceSettingsView.swift
+++ b/Dochi/Views/Settings/VoiceSettingsView.swift
@@ -11,7 +11,7 @@ struct VoiceSettingsView: View {
 
     var body: some View {
         Form {
-            Section("TTS 프로바이더") {
+            Section {
                 Picker("프로바이더", selection: Binding(
                     get: { settings.ttsProvider },
                     set: { settings.ttsProvider = $0 }
@@ -21,6 +21,11 @@ struct VoiceSettingsView: View {
                     }
                 }
                 .pickerStyle(.radioGroup)
+            } header: {
+                SettingsSectionHeader(
+                    title: "TTS 프로바이더",
+                    helpContent: "텍스트를 음성으로 변환하는 엔진을 선택합니다. \"시스템 TTS\"는 추가 설정 없이 사용 가능하며, Google Cloud TTS와 Supertonic은 더 자연스러운 음성을 제공합니다."
+                )
             }
 
             if settings.currentTTSProvider == .googleCloud {

--- a/DochiTests/OnboardingGuideTests.swift
+++ b/DochiTests/OnboardingGuideTests.swift
@@ -1,0 +1,261 @@
+import XCTest
+@testable import Dochi
+
+// MARK: - HintManager Tests
+
+final class HintManagerTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // 테스트 전 모든 hint 관련 UserDefaults 초기화
+        let allKeys = UserDefaults.standard.dictionaryRepresentation().keys
+        for key in allKeys where key.hasPrefix("hint_seen_") {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        UserDefaults.standard.removeObject(forKey: "hintsGloballyDisabled")
+    }
+
+    @MainActor
+    func testHasSeenHint_defaultFalse() {
+        let manager = HintManager.shared
+        XCTAssertFalse(manager.hasSeenHint("testHint"))
+    }
+
+    @MainActor
+    func testMarkHintSeen() {
+        let manager = HintManager.shared
+        manager.markHintSeen("testHint")
+        XCTAssertTrue(manager.hasSeenHint("testHint"))
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "hint_seen_testHint"))
+    }
+
+    @MainActor
+    func testCanShowHint_notSeenAndNotDisabled() {
+        let manager = HintManager.shared
+        manager.activeHintId = nil
+        XCTAssertTrue(manager.canShowHint("newHint"))
+    }
+
+    @MainActor
+    func testCanShowHint_alreadySeen() {
+        let manager = HintManager.shared
+        manager.markHintSeen("seenHint")
+        XCTAssertFalse(manager.canShowHint("seenHint"))
+    }
+
+    @MainActor
+    func testCanShowHint_globallyDisabled() {
+        let manager = HintManager.shared
+        manager.disableAllHints()
+        XCTAssertFalse(manager.canShowHint("anyHint"))
+    }
+
+    @MainActor
+    func testCanShowHint_anotherHintActive() {
+        let manager = HintManager.shared
+        manager.activeHintId = "otherHint"
+        XCTAssertFalse(manager.canShowHint("newHint"))
+    }
+
+    @MainActor
+    func testCanShowHint_sameHintActive() {
+        let manager = HintManager.shared
+        manager.activeHintId = "myHint"
+        XCTAssertTrue(manager.canShowHint("myHint"))
+    }
+
+    @MainActor
+    func testDisableAllHints() {
+        let manager = HintManager.shared
+        manager.activeHintId = nil
+        manager.activateHint("someHint")
+        manager.disableAllHints()
+
+        XCTAssertTrue(manager.isGloballyDisabled)
+        XCTAssertNil(manager.activeHintId)
+        XCTAssertFalse(manager.canShowHint("someHint"))
+    }
+
+    @MainActor
+    func testResetAllHints() {
+        let manager = HintManager.shared
+        manager.markHintSeen("hint1")
+        manager.markHintSeen("hint2")
+        manager.disableAllHints()
+
+        manager.resetAllHints()
+
+        XCTAssertFalse(manager.isGloballyDisabled)
+        XCTAssertFalse(manager.hasSeenHint("hint1"))
+        XCTAssertFalse(manager.hasSeenHint("hint2"))
+        XCTAssertNil(manager.activeHintId)
+    }
+
+    @MainActor
+    func testActivateHint() {
+        let manager = HintManager.shared
+        manager.activeHintId = nil
+        manager.activateHint("firstHint")
+        XCTAssertEqual(manager.activeHintId, "firstHint")
+    }
+
+    @MainActor
+    func testDismissHint() {
+        let manager = HintManager.shared
+        manager.activeHintId = nil
+        manager.activateHint("toClose")
+        manager.dismissHint("toClose")
+
+        XCTAssertNil(manager.activeHintId)
+        XCTAssertTrue(manager.hasSeenHint("toClose"))
+    }
+}
+
+// MARK: - AppSettings Guide Tests
+
+final class AppSettingsGuideTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "hintsGloballyDisabled")
+        UserDefaults.standard.removeObject(forKey: "featureTourCompleted")
+        UserDefaults.standard.removeObject(forKey: "featureTourSkipped")
+        UserDefaults.standard.removeObject(forKey: "featureTourBannerDismissed")
+        let allKeys = UserDefaults.standard.dictionaryRepresentation().keys
+        for key in allKeys where key.hasPrefix("hint_seen_") {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
+    @MainActor
+    func testHintsEnabled_defaultTrue() {
+        let settings = AppSettings()
+        XCTAssertTrue(settings.hintsEnabled)
+    }
+
+    @MainActor
+    func testHintsEnabled_setFalse() {
+        let settings = AppSettings()
+        settings.hintsEnabled = false
+        XCTAssertFalse(settings.hintsEnabled)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "hintsGloballyDisabled"))
+    }
+
+    @MainActor
+    func testHintsEnabled_setTrue() {
+        let settings = AppSettings()
+        settings.hintsEnabled = false
+        settings.hintsEnabled = true
+        XCTAssertTrue(settings.hintsEnabled)
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "hintsGloballyDisabled"))
+    }
+
+    @MainActor
+    func testFeatureTourCompleted() {
+        let settings = AppSettings()
+        XCTAssertFalse(settings.featureTourCompleted)
+        settings.featureTourCompleted = true
+        XCTAssertTrue(settings.featureTourCompleted)
+    }
+
+    @MainActor
+    func testFeatureTourSkipped() {
+        let settings = AppSettings()
+        XCTAssertFalse(settings.featureTourSkipped)
+        settings.featureTourSkipped = true
+        XCTAssertTrue(settings.featureTourSkipped)
+    }
+
+    @MainActor
+    func testResetAllHints() {
+        let settings = AppSettings()
+        // Setup: mark some hints as seen and disable
+        UserDefaults.standard.set(true, forKey: "hint_seen_firstConversation")
+        UserDefaults.standard.set(true, forKey: "hint_seen_firstKanban")
+        UserDefaults.standard.set(true, forKey: "hintsGloballyDisabled")
+
+        settings.resetAllHints()
+
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "hint_seen_firstConversation"))
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "hint_seen_firstKanban"))
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "hintsGloballyDisabled"))
+        XCTAssertTrue(settings.hintsEnabled)
+    }
+
+    @MainActor
+    func testResetFeatureTour() {
+        let settings = AppSettings()
+        settings.featureTourCompleted = true
+        settings.featureTourSkipped = true
+        settings.featureTourBannerDismissed = true
+
+        settings.resetFeatureTour()
+
+        XCTAssertFalse(settings.featureTourCompleted)
+        XCTAssertFalse(settings.featureTourSkipped)
+        XCTAssertFalse(settings.featureTourBannerDismissed)
+    }
+}
+
+// MARK: - Tour Step Tests
+
+final class TourStepTests: XCTestCase {
+
+    func testTourStepAllCases() {
+        let allCases = TourStep.allCases
+        XCTAssertEqual(allCases.count, 4)
+        XCTAssertEqual(allCases[0], .overview)
+        XCTAssertEqual(allCases[1], .conversation)
+        XCTAssertEqual(allCases[2], .agentWorkspace)
+        XCTAssertEqual(allCases[3], .shortcuts)
+    }
+
+    func testTourStepRawValues() {
+        XCTAssertEqual(TourStep.overview.rawValue, 0)
+        XCTAssertEqual(TourStep.conversation.rawValue, 1)
+        XCTAssertEqual(TourStep.agentWorkspace.rawValue, 2)
+        XCTAssertEqual(TourStep.shortcuts.rawValue, 3)
+    }
+
+    func testTourStepFromRawValue() {
+        XCTAssertEqual(TourStep(rawValue: 0), .overview)
+        XCTAssertEqual(TourStep(rawValue: 3), .shortcuts)
+        XCTAssertNil(TourStep(rawValue: 4))
+        XCTAssertNil(TourStep(rawValue: -1))
+    }
+}
+
+// MARK: - CommandPalette Guide Items Tests
+
+final class CommandPaletteGuideItemTests: XCTestCase {
+
+    func testStaticItemsContainFeatureTour() {
+        let tourItem = CommandPaletteRegistry.staticItems.first { $0.id == "feature-tour" }
+        XCTAssertNotNil(tourItem, "Static items should contain feature tour item")
+        XCTAssertEqual(tourItem?.title, "기능 투어")
+    }
+
+    func testStaticItemsContainResetHints() {
+        let resetItem = CommandPaletteRegistry.staticItems.first { $0.id == "reset-hints" }
+        XCTAssertNotNil(resetItem, "Static items should contain reset hints item")
+        XCTAssertEqual(resetItem?.title, "인앱 힌트 초기화")
+    }
+
+    func testFeatureTourAction() {
+        let tourItem = CommandPaletteRegistry.staticItems.first { $0.id == "feature-tour" }
+        if case .openFeatureTour = tourItem?.action {
+            // Expected
+        } else {
+            XCTFail("Feature tour item should have openFeatureTour action")
+        }
+    }
+
+    func testResetHintsAction() {
+        let resetItem = CommandPaletteRegistry.staticItems.first { $0.id == "reset-hints" }
+        if case .resetHints = resetItem?.action {
+            // Expected
+        } else {
+            XCTFail("Reset hints item should have resetHints action")
+        }
+    }
+}

--- a/spec/ui-inventory.md
+++ b/spec/ui-inventory.md
@@ -28,7 +28,7 @@ DochiApp (entry point)
     │   │   ├── SystemPromptBannerView — 시스템 프롬프트 접기/펼치기 배너 (UX-8)
     │   │   ├── ErrorBannerView — 에러 표시
     │   │   ├── AvatarView — 3D 아바타 (macOS 15+, 선택적)
-    │   │   ├── EmptyConversationView — 빈 대화 시작 (카테고리 제안 + 카탈로그 링크 + 단축키 힌트 + 에이전트 힌트 카드)
+    │   │   ├── EmptyConversationView — 빈 대화 시작 (카테고리 제안 + 카탈로그 링크 + 단축키 힌트 + 에이전트 힌트 카드 + 투어 리마인더 + 첫 대화 힌트)
     │   │   │   또는 ConversationView — 메시지 목록
     │   │   │       ├── MessageBubbleView — 개별 메시지 버블 (호버 시 복사 버튼)
     │   │   │       │   ├── MessageMetadataBadgeView — 모델/응답시간 배지 (assistant만, 호버 팝오버)
@@ -66,7 +66,7 @@ DochiApp (entry point)
 | BulkActionToolbarView | `Views/Sidebar/ConversationListView.swift` | 일괄선택 모드 활성 시 | N개 선택 + 폴더/태그/내보내기/즐겨찾기/삭제 |
 | ConversationView | `Views/ConversationView.swift` | 대화 선택 시 | 메시지 스크롤 뷰 |
 | MessageBubbleView | `Views/MessageBubbleView.swift` | 자동 | 개별 메시지 렌더링 (역할별 스타일), 호버 시 복사 버튼 오버레이 |
-| EmptyConversationView | `Views/ContentView.swift` | 빈 대화 | 카테고리별 제안 프롬프트, "모든 기능 보기" 링크, 단축키 힌트, 에이전트 0개 시 생성 힌트 카드 |
+| EmptyConversationView | `Views/ContentView.swift` | 빈 대화 | 카테고리별 제안 프롬프트, "모든 기능 보기" 링크, 단축키 힌트, 에이전트 0개 시 생성 힌트 카드, 투어 리마인더 배너, 첫 대화 힌트 버블 |
 | InputBarView | `Views/ContentView.swift` | 항상 표시 | 텍스트 입력, 마이크, 전송/취소 버튼, 슬래시 명령 |
 | SystemHealthBarView | `Views/SystemHealthBarView.swift` | 항상 표시 | 현재 모델, 동기화 상태, 하트비트, 세션 토큰 (클릭 → 상세 시트) |
 | MessageMetadataBadgeView | `Views/MessageBubbleView.swift` | assistant 메시지 자동 | 모델명·응답시간 배지, 호버 시 상세 팝오버 (토큰/프로바이더/폴백) |
@@ -100,7 +100,8 @@ DochiApp (entry point)
 | CommandPaletteView | `Views/CommandPaletteView.swift` | ⌘K | VS Code 스타일 커맨드 팔레트 오버레이 (퍼지 검색, 그룹 섹션) |
 | QuickSwitcherView | `Views/QuickSwitcherView.swift` | ⌘⇧A / ⌘⇧W / ⌘⇧U | 에이전트/워크스페이스/사용자 빠른 전환 시트 |
 | TagManagementView | `Views/Sidebar/TagManagementView.swift` | 사이드바 "태그" 버튼 또는 컨텍스트 메뉴 "태그 관리" | 태그 CRUD 시트 (360x400pt), 9색 팔레트, 사용 수 |
-| OnboardingView | `Views/OnboardingView.swift` | 최초 실행 시 자동 | 6단계 초기 설정 위저드 |
+| OnboardingView | `Views/OnboardingView.swift` | 최초 실행 시 자동 | 6단계 초기 설정 위저드 + 기능 투어 연결 |
+| FeatureTourView | `Views/Guide/FeatureTourViews.swift` | 온보딩 완료 후 / 설정 > 일반 > 가이드 / 커맨드 팔레트 | 4단계 기능 투어 (개요/대화/에이전트·워크스페이스/단축키) |
 | WorkspaceManagementView | `Views/Sidebar/WorkspaceManagementView.swift` | SidebarHeader 메뉴 | 워크스페이스 생성/삭제 |
 | AgentCreationView | `Views/Sidebar/AgentCreationView.swift` | (레거시 — AgentWizardView로 대체) | 에이전트 생성 폼 |
 | AgentWizardView | `Views/Agent/AgentWizardView.swift` | SidebarHeader [+], 커맨드 팔레트, EmptyConversationView 힌트 카드 | 5단계 에이전트 생성 위저드 (560x520pt), 템플릿 선택 → 기본 정보 → 페르소나 → 모델/권한 → 요약 |
@@ -113,7 +114,7 @@ DochiApp (entry point)
 
 | 탭 | 파일 | 내용 |
 |----|------|------|
-| 일반 | `Views/SettingsView.swift` 내 | 폰트, 인터랙션 모드, 웨이크워드, 아바타, Heartbeat |
+| 일반 | `Views/SettingsView.swift` 내 | 폰트, 인터랙션 모드, 웨이크워드, 아바타, Heartbeat, 가이드 (투어/힌트 관리) |
 | AI 모델 | `Views/SettingsView.swift` 내 | 프로바이더/모델 선택, Ollama, 태스크 라우팅, 폴백 |
 | API 키 | `Views/SettingsView.swift` 내 | OpenAI/Anthropic/Z.AI/Tavily/Fal.ai 키 관리 |
 | 음성 | `Views/Settings/VoiceSettingsView.swift` | TTS 프로바이더, 음성, 속도/피치 |
@@ -237,6 +238,7 @@ MemoryContextInfo 필드:
 | 통합 | `telegramEnabled`, `telegramStreamReplies`, `ollamaBaseURL` |
 | Heartbeat | `heartbeatEnabled`, `heartbeatIntervalMinutes`, `heartbeatCheckCalendar/Kanban/Reminders` |
 | 아바타 | `avatarEnabled` |
+| 가이드 | `hintsEnabled`, `featureTourCompleted`, `featureTourSkipped`, `featureTourBannerDismissed` |
 | 기타 | `chatFontSize`, `currentWorkspaceId`, `defaultUserId`, `activeAgentName` |
 
 ---
@@ -321,6 +323,23 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 기존 컨텍스트 인스펙터: ⌘⌥I -> showContextInspector -> ContextInspectorView (시트)
 ```
 
+### 가이드/온보딩 (UX-9 추가)
+```
+기능 투어: 온보딩 완료 → "기능 둘러보기" 버튼 → FeatureTourView (4단계)
+  → 완료/건너뛰기 → UserDefaults(featureTourCompleted/Skipped) 기록
+투어 리마인더: EmptyConversationView → 투어 건너뛴 사용자에게 배너 표시
+  → "둘러보기" → FeatureTourView / "X" → featureTourBannerDismissed
+인앱 힌트: 뷰 진입 → HintBubbleModifier → HintManager.canShowHint() 확인
+  → 1.5초 후 fadeIn → "확인"/닫기 → markHintSeen() → UserDefaults 기록
+  → "다시 보지 않기" → disableAllHints() → 모든 힌트 전역 비활성화
+설정 도움말: SettingsSectionHeader → SettingsHelpButton → 클릭 → 팝오버
+가이드 관리: 설정 > 일반 > 가이드 섹션
+  → "기능 투어 다시 보기" → FeatureTourView 시트
+  → "인앱 힌트 초기화" → resetAllHints()
+  → "인앱 힌트 표시" 토글 → hintsEnabled get/set
+커맨드 팔레트: "기능 투어" → FeatureTourView 시트 / "인앱 힌트 초기화" → resetHints
+```
+
 ### 내보내기/공유 (UX-5 추가)
 ```
 빠른 내보내기: ⌘E -> viewModel.exportConversation(format: .markdown) -> NSSavePanel
@@ -383,6 +402,9 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 | 접기/펼치기 배너 (VStack + Button) | SystemPromptBannerView | 접힌: 미리보기, 펼침: TextEditor |
 | 토스트 (HStack + material + shadow) | MemoryToastView | 우측 하단 알림 (5초 자동 fade) |
 | 메모리 노드 카드 (VStack + chevron) | MemoryNodeView | 접기/펼치기 + 인라인 편집 + 저장 |
+| 힌트 버블 (ViewModifier + material) | HintBubbleModifier | 일회성 맥락 힌트 (1.5초 후 fadeIn, 최대 1개, "다시 보지 않기") |
+| 설정 도움말 버튼 (? + popover) | SettingsHelpButton | 섹션 헤더 "?" 아이콘, 클릭 시 설명 팝오버 (280pt) |
+| 투어 단계 (step indicator + 콘텐츠) | FeatureTourView | 4단계 워크스루 (이전/다음/건너뛰기/시작) |
 
 ---
 
@@ -399,6 +421,8 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 | 시스템 프롬프트 없음 | "시스템 프롬프트가 설정되지 않았습니다 [작성하기]" | SystemPromptBannerView |
 | 메모리 노드 비어 있음 | 노드별 안내 문구 + "작성하기" 버튼 | MemoryNodeView |
 | 개인 메모리 없음 (사용자 미설정) | "사용자가 설정되지 않아 표시할 수 없습니다" | MemoryPanelView |
+| 투어 미완료 (건너뜀) | "도치의 주요 기능을 알아보세요" 배너 + "둘러보기" | EmptyConversationView |
+| 첫 대화 힌트 | "첫 대화를 시작해보세요!" 힌트 버블 | EmptyConversationView |
 
 ---
 
@@ -461,4 +485,4 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 
 ---
 
-*최종 업데이트: 2026-02-15 (UX-8 머지 후)*
+*최종 업데이트: 2026-02-15 (UX-9 머지 후)*


### PR DESCRIPTION
## Summary

Closes #137

UX-9 온보딩 2.0 구현: 3계층 가이드 시스템으로 사용자 발견성을 높인다.

### A. 온보딩 기능 투어 (FeatureTourView)
- 온보딩 완료 후 선택적 4단계 기능 투어 제공
- T1: 도구 카테고리 개요 (2x4 그리드)
- T2: 대화 방식 (텍스트/슬래시/음성)
- T3: 에이전트 & 워크스페이스 소개
- T4: 키보드 단축키 안내
- 건너뛰기 시 EmptyConversationView에 리마인더 배너 표시
- 설정 > 일반 > 가이드에서 다시 볼 수 있음

### B. 인앱 힌트 버블 (HintBubbleModifier)
- HintManager 싱글턴: activeHintId 기반 동시 최대 1개 표시
- UserDefaults 기반 일회성 표시 추적 (hint_seen_{id})
- 뷰 진입 1.5초 후 fadeIn, "확인"/"X"로 닫기, "다시 보지 않기" 전역 비활성화
- 접근성: reduceMotion 지원, VoiceOver 레이블
- EmptyConversationView에 firstConversation 힌트 적용

### C. 설정 도움말 (SettingsHelpButton + SettingsSectionHeader)
- "?" 아이콘 + 클릭 시 설명 팝오버 (280pt)
- 전체 9개 설정 탭에 섹션별 도움말 적용:
  - 일반 (글꼴/인터랙션/웨이크워드/아바타/하트비트), AI 모델, API 키, 음성, 가족, 에이전트, 도구, 통합, 계정
- `.help()` modifier를 인라인 캡션으로 변환 (발견성 개선)

### D. 가이드 관리 (AppSettings)
- `hintsEnabled`, `featureTourCompleted/Skipped/BannerDismissed` 프로퍼티
- `resetAllHints()`, `resetFeatureTour()` 메서드
- 설정 > 일반 > "가이드" 섹션 (투어 다시 보기/힌트 초기화/힌트 토글)
- 커맨드 팔레트에 "기능 투어"/"인앱 힌트 초기화" 항목 추가

## Changed Files (16)

**New files (3):**
- `Dochi/Views/Guide/HintBubbleModifier.swift` — HintManager + HintBubbleModifier + View extension
- `Dochi/Views/Guide/SettingsHelpButton.swift` — SettingsHelpButton + SettingsSectionHeader
- `Dochi/Views/Guide/FeatureTourViews.swift` — TourStep + FeatureTourView + 4 step views

**Modified files (12):**
- `Dochi/Models/AppSettings.swift` — 가이드 프로퍼티/메서드 추가
- `Dochi/Models/CommandPaletteItem.swift` — openFeatureTour/resetHints 액션 + 정적 아이템
- `Dochi/Views/ContentView.swift` — 투어 시트, 팔레트 액션 핸들링, EmptyConversationView 확장
- `Dochi/Views/OnboardingView.swift` — 기능 투어 연결 (완료 화면 버튼 추가)
- `Dochi/Views/SettingsView.swift` — GeneralSettingsView 가이드 섹션, ModelSettingsView/APIKeySettingsView 도움말
- `Dochi/Views/Settings/*.swift` (5개) — SettingsSectionHeader 적용

**Test file (1):**
- `DochiTests/OnboardingGuideTests.swift` — 25개 테스트 (HintManager 11, AppSettings 7, TourStep 3, CommandPalette 4)

**Spec (1):**
- `spec/ui-inventory.md` — UX-9 화면/컴포넌트/데이터흐름/빈상태 추가

## Test plan

- [x] `xcodebuild build` 통과
- [x] `xcodebuild test` 통과 (812개 중 1개 기존 실패 — TaskQueueTests.testCheckDeadlinesExpired, 무관)
- [x] 25개 신규 테스트 전부 통과
- [ ] 스모크 테스트: 앱 실행 후 온보딩 → 기능 투어 4단계 탐색 → 건너뛰기/완료 확인
- [ ] 설정 > 일반 > 가이드에서 투어 다시 보기, 힌트 초기화, 힌트 토글 동작 확인
- [ ] EmptyConversationView에서 투어 리마인더 배너 표시 확인
- [ ] 커맨드 팔레트에서 "기능 투어"/"인앱 힌트 초기화" 항목 동작 확인
- [ ] 각 설정 탭 "?" 버튼 팝오버 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)