### PR TITLE
[UX-10] 설정 UX 리디자인 — NavigationSplitView + QuickModelPopover

### DIFF
--- a/Dochi/Models/CommandPaletteItem.swift
+++ b/Dochi/Models/CommandPaletteItem.swift
@@ -38,6 +38,8 @@ struct CommandPaletteItem: Identifiable, Sendable {
         case createAgent
         case openFeatureTour
         case resetHints
+        case openQuickModelPopover
+        case openSettingsSection(section: String)
         case custom(id: String)
     }
 }
@@ -195,7 +197,7 @@ enum CommandPaletteRegistry {
             id: "toggle-multi-select",
             icon: "checklist",
             title: "일괄 선택 모드",
-            subtitle: "⌘⇧M",
+            subtitle: "",
             category: .navigation,
             action: .toggleMultiSelect
         ),
@@ -222,6 +224,63 @@ enum CommandPaletteRegistry {
             subtitle: "",
             category: .settings,
             action: .resetHints
+        ),
+        // UX-10: 설정 관련 팔레트 명령
+        CommandPaletteItem(
+            id: "settings.model",
+            icon: "cpu",
+            title: "모델 빠르게 변경",
+            subtitle: "\u{2318}\u{21E7}M",
+            category: .settings,
+            action: .openQuickModelPopover
+        ),
+        CommandPaletteItem(
+            id: "settings.open.ai",
+            icon: "brain",
+            title: "AI 모델 설정",
+            subtitle: "",
+            category: .settings,
+            action: .openSettingsSection(section: "ai-model")
+        ),
+        CommandPaletteItem(
+            id: "settings.open.apikey",
+            icon: "key",
+            title: "API 키 설정",
+            subtitle: "",
+            category: .settings,
+            action: .openSettingsSection(section: "api-key")
+        ),
+        CommandPaletteItem(
+            id: "settings.open.voice",
+            icon: "speaker.wave.2",
+            title: "음성 설정",
+            subtitle: "",
+            category: .settings,
+            action: .openSettingsSection(section: "voice")
+        ),
+        CommandPaletteItem(
+            id: "settings.open.agent",
+            icon: "person.crop.rectangle.stack",
+            title: "에이전트 설정",
+            subtitle: "",
+            category: .settings,
+            action: .openSettingsSection(section: "agent")
+        ),
+        CommandPaletteItem(
+            id: "settings.open.integration",
+            icon: "puzzlepiece",
+            title: "통합 서비스 설정",
+            subtitle: "",
+            category: .settings,
+            action: .openSettingsSection(section: "integrations")
+        ),
+        CommandPaletteItem(
+            id: "settings.open.account",
+            icon: "person.circle",
+            title: "계정/동기화 설정",
+            subtitle: "",
+            category: .settings,
+            action: .openSettingsSection(section: "account")
         ),
     ]
 

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -45,7 +45,7 @@ final class DochiViewModel {
     var allToolInfos: [ToolInfo] { toolService.allToolInfos }
     let contextService: ContextServiceProtocol
     private let conversationService: ConversationServiceProtocol
-    private let keychainService: KeychainServiceProtocol
+    private(set) var keychainService: KeychainServiceProtocol
     private let speechService: SpeechServiceProtocol
     private var ttsService: TTSServiceProtocol
     private let soundService: SoundServiceProtocol

--- a/Dochi/Views/QuickModelPopoverView.swift
+++ b/Dochi/Views/QuickModelPopoverView.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+
+/// Quick model switching popover, triggered from SystemHealthBarView model indicator or Cmd+Shift+M.
+struct QuickModelPopoverView: View {
+    var settings: AppSettings
+    var keychainService: KeychainServiceProtocol?
+
+    @State private var selectedProviderRaw: String = ""
+    @State private var selectedModel: String = ""
+    @State private var ollamaModels: [String] = []
+
+    private var selectedProvider: LLMProvider {
+        LLMProvider(rawValue: selectedProviderRaw) ?? .openai
+    }
+
+    private var availableModels: [String] {
+        if selectedProvider == .ollama {
+            return ollamaModels
+        }
+        return selectedProvider.models
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            Text("빠른 모델 변경")
+                .font(.system(size: 13, weight: .semibold))
+                .padding(.bottom, 2)
+
+            Divider()
+
+            // Provider selection
+            VStack(alignment: .leading, spacing: 6) {
+                Text("프로바이더")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+
+                ForEach(LLMProvider.allCases, id: \.self) { provider in
+                    providerRow(provider)
+                }
+            }
+
+            Divider()
+
+            // Model list
+            VStack(alignment: .leading, spacing: 6) {
+                Text("모델")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+
+                if availableModels.isEmpty {
+                    Text("사용 가능한 모델이 없습니다")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                        .padding(.vertical, 4)
+                } else {
+                    ForEach(availableModels, id: \.self) { model in
+                        modelRow(model)
+                    }
+                }
+            }
+
+            Divider()
+
+            // Auto model selection toggle
+            Toggle("자동 모델 선택 (라우팅)", isOn: Binding(
+                get: { settings.taskRoutingEnabled },
+                set: {
+                    settings.taskRoutingEnabled = $0
+                    Log.app.info("설정 변경: taskRoutingEnabled = \($0)")
+                }
+            ))
+            .font(.system(size: 11))
+
+            Divider()
+
+            // Footer: link to full settings
+            HStack {
+                Button {
+                    NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "gearshape")
+                            .font(.system(size: 10))
+                        Text("설정에서 상세 설정 열기")
+                            .font(.system(size: 11))
+                    }
+                    .foregroundStyle(Color.accentColor)
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+            }
+        }
+        .padding(14)
+        .frame(width: 320)
+        .onAppear {
+            selectedProviderRaw = settings.llmProvider
+            selectedModel = settings.llmModel
+            if selectedProvider == .ollama {
+                fetchOllamaModels()
+            }
+        }
+    }
+
+    // MARK: - Provider Row
+
+    @ViewBuilder
+    private func providerRow(_ provider: LLMProvider) -> some View {
+        let isSelected = selectedProvider == provider
+        let hasKey = !provider.requiresAPIKey || hasAPIKey(for: provider)
+
+        Button {
+            guard hasKey else { return }
+            selectedProviderRaw = provider.rawValue
+            settings.llmProvider = provider.rawValue
+            Log.app.info("설정 변경: llmProvider = \(provider.rawValue)")
+
+            if provider == .ollama {
+                fetchOllamaModels()
+            } else if !provider.models.contains(selectedModel) {
+                let newModel = provider.models.first ?? ""
+                selectedModel = newModel
+                settings.llmModel = newModel
+                Log.app.info("설정 변경: llmModel = \(newModel)")
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isSelected ? "circle.inset.filled" : "circle")
+                    .font(.system(size: 11))
+                    .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+
+                Text(provider.displayName)
+                    .font(.system(size: 12))
+                    .foregroundStyle(hasKey ? .primary : .secondary)
+
+                if !hasKey {
+                    Text("(키 없음)")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+
+                Spacer()
+            }
+            .padding(.vertical, 2)
+        }
+        .buttonStyle(.plain)
+        .disabled(!hasKey)
+    }
+
+    // MARK: - Model Row
+
+    @ViewBuilder
+    private func modelRow(_ model: String) -> some View {
+        let isSelected = selectedModel == model
+
+        Button {
+            selectedModel = model
+            settings.llmModel = model
+            Log.app.info("설정 변경: llmModel = \(model)")
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isSelected ? "circle.inset.filled" : "circle")
+                    .font(.system(size: 11))
+                    .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+
+                Text(model)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+
+                Spacer()
+
+                // Context window tokens
+                let tokens = selectedProvider.contextWindowTokens(for: model)
+                Text("\(tokens / 1000)K")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Helpers
+
+    private func hasAPIKey(for provider: LLMProvider) -> Bool {
+        guard let keychainService else { return true }
+        guard provider.requiresAPIKey else { return true }
+        let key = keychainService.load(account: provider.keychainAccount)
+        return key != nil && !key!.isEmpty
+    }
+
+    private func fetchOllamaModels() {
+        Task {
+            let baseURL = URL(string: settings.ollamaBaseURL) ?? URL(string: "http://localhost:11434")!
+            let models = await OllamaModelFetcher.fetchModels(baseURL: baseURL)
+            ollamaModels = models
+            if !models.contains(selectedModel) {
+                let newModel = models.first ?? ""
+                selectedModel = newModel
+                settings.llmModel = newModel
+            }
+        }
+    }
+}

--- a/Dochi/Views/Settings/SettingsSidebarView.swift
+++ b/Dochi/Views/Settings/SettingsSidebarView.swift
@@ -1,0 +1,301 @@
+import SwiftUI
+
+// MARK: - SettingsSection
+
+enum SettingsSection: String, CaseIterable, Identifiable {
+    case aiModel = "ai-model"
+    case apiKey = "api-key"
+    case voice = "voice"
+    case interface = "interface"
+    case wakeWord = "wake-word"
+    case heartbeat = "heartbeat"
+    case family = "family"
+    case agent = "agent"
+    case tools = "tools"
+    case integrations = "integrations"
+    case account = "account"
+    case guide = "guide"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .aiModel: return "AI 모델"
+        case .apiKey: return "API 키"
+        case .voice: return "음성 합성"
+        case .interface: return "인터페이스"
+        case .wakeWord: return "웨이크워드"
+        case .heartbeat: return "하트비트"
+        case .family: return "가족 구성원"
+        case .agent: return "에이전트"
+        case .tools: return "도구"
+        case .integrations: return "통합 서비스"
+        case .account: return "계정/동기화"
+        case .guide: return "가이드"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .aiModel: return "brain"
+        case .apiKey: return "key"
+        case .voice: return "speaker.wave.2"
+        case .interface: return "textformat.size"
+        case .wakeWord: return "mic"
+        case .heartbeat: return "heart"
+        case .family: return "person.2"
+        case .agent: return "person.crop.rectangle.stack"
+        case .tools: return "wrench.and.screwdriver"
+        case .integrations: return "puzzlepiece"
+        case .account: return "person.circle"
+        case .guide: return "play.rectangle"
+        }
+    }
+
+    var group: SettingsSectionGroup {
+        switch self {
+        case .aiModel, .apiKey: return .ai
+        case .voice: return .voice
+        case .interface, .wakeWord, .heartbeat: return .general
+        case .family, .agent: return .people
+        case .tools, .integrations, .account: return .connection
+        case .guide: return .help
+        }
+    }
+
+    var searchKeywords: [String] {
+        switch self {
+        case .aiModel:
+            return ["모델", "프로바이더", "OpenAI", "Anthropic", "Z.AI", "Ollama", "라우팅", "폴백"]
+        case .apiKey:
+            return ["API", "키", "key", "OpenAI", "Anthropic", "Tavily", "Fal", "티어"]
+        case .voice:
+            return ["음성", "TTS", "속도", "피치", "Google Cloud", "프로바이더"]
+        case .interface:
+            return ["글꼴", "폰트", "크기", "모드", "아바타", "VRM"]
+        case .wakeWord:
+            return ["웨이크워드", "마이크", "침묵", "음성 입력"]
+        case .heartbeat:
+            return ["하트비트", "주기", "캘린더", "칸반", "미리알림", "조용한 시간"]
+        case .family:
+            return ["가족", "구성원", "프로필", "사용자"]
+        case .agent:
+            return ["에이전트", "페르소나", "템플릿"]
+        case .tools:
+            return ["도구", "tool", "권한", "safe", "sensitive", "restricted"]
+        case .integrations:
+            return ["텔레그램", "MCP", "봇", "웹훅"]
+        case .account:
+            return ["Supabase", "동기화", "로그인", "인증"]
+        case .guide:
+            return ["투어", "힌트", "온보딩"]
+        }
+    }
+
+    /// Check if this section matches a search query
+    func matches(query: String) -> Bool {
+        let q = query.lowercased()
+        if title.lowercased().contains(q) { return true }
+        return searchKeywords.contains { $0.lowercased().contains(q) }
+    }
+}
+
+// MARK: - SettingsSectionGroup
+
+enum SettingsSectionGroup: String, CaseIterable {
+    case ai = "AI"
+    case voice = "음성"
+    case general = "일반"
+    case people = "사람"
+    case connection = "연결"
+    case help = "도움말"
+
+    var sections: [SettingsSection] {
+        SettingsSection.allCases.filter { $0.group == self }
+    }
+}
+
+// MARK: - SettingsSidebarView
+
+struct SettingsSidebarView: View {
+    @Binding var selectedSection: SettingsSection
+    @Binding var searchText: String
+
+    @FocusState private var isSearchFocused: Bool
+
+    private var filteredGroups: [(group: SettingsSectionGroup, sections: [SettingsSection])] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        var result: [(group: SettingsSectionGroup, sections: [SettingsSection])] = []
+
+        for group in SettingsSectionGroup.allCases {
+            let sections: [SettingsSection]
+            if query.isEmpty {
+                sections = group.sections
+            } else {
+                sections = group.sections.filter { $0.matches(query: query) }
+            }
+            if !sections.isEmpty {
+                result.append((group, sections))
+            }
+        }
+
+        return result
+    }
+
+    private var flatSections: [SettingsSection] {
+        filteredGroups.flatMap(\.sections)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Search field
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                TextField("검색...", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+                    .focused($isSearchFocused)
+
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(.quaternary.opacity(0.5))
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .padding(.horizontal, 10)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+
+            Divider()
+
+            if flatSections.isEmpty {
+                VStack(spacing: 8) {
+                    Spacer()
+                    Text("일치하는 설정이 없습니다")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(filteredGroups, id: \.group) { group in
+                            // Group header
+                            Text(group.group.rawValue)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .textCase(.uppercase)
+                                .padding(.horizontal, 14)
+                                .padding(.top, 12)
+                                .padding(.bottom, 4)
+
+                            ForEach(group.sections) { section in
+                                SettingsSidebarRow(
+                                    section: section,
+                                    isSelected: selectedSection == section,
+                                    onSelect: {
+                                        selectedSection = section
+                                    }
+                                )
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            // Version footer
+            Divider()
+            Text(versionString)
+                .font(.system(size: 10))
+                .foregroundStyle(.quaternary)
+                .padding(.vertical, 6)
+                .frame(maxWidth: .infinity)
+        }
+        .frame(width: 180)
+        .onKeyPress(.upArrow) {
+            moveSelection(by: -1)
+            return .handled
+        }
+        .onKeyPress(.downArrow) {
+            moveSelection(by: 1)
+            return .handled
+        }
+    }
+
+    private func moveSelection(by delta: Int) {
+        let flat = flatSections
+        guard !flat.isEmpty else { return }
+        if let currentIndex = flat.firstIndex(of: selectedSection) {
+            let newIndex = max(0, min(flat.count - 1, currentIndex + delta))
+            selectedSection = flat[newIndex]
+        } else {
+            selectedSection = flat.first ?? .aiModel
+        }
+    }
+
+    private var versionString: String {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        return "v\(version) (\(build))"
+    }
+}
+
+// MARK: - SettingsSidebarRow
+
+struct SettingsSidebarRow: View {
+    let section: SettingsSection
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button {
+            onSelect()
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: section.icon)
+                    .font(.system(size: 13))
+                    .foregroundStyle(isSelected ? Color.accentColor : .secondary)
+                    .frame(width: 18)
+
+                Text(section.title)
+                    .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
+                    .foregroundStyle(isSelected ? .primary : .primary)
+                    .lineLimit(1)
+
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(
+                        isSelected
+                            ? Color.accentColor.opacity(0.12)
+                            : isHovering ? Color.secondary.opacity(0.06) : Color.clear
+                    )
+            )
+            .padding(.horizontal, 6)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .accessibilityLabel(section.title)
+    }
+}

--- a/DochiTests/SettingsRedesignTests.swift
+++ b/DochiTests/SettingsRedesignTests.swift
@@ -1,0 +1,245 @@
+import XCTest
+@testable import Dochi
+
+// MARK: - SettingsSection Tests
+
+final class SettingsSectionTests: XCTestCase {
+
+    func testAllCasesCount() {
+        XCTAssertEqual(SettingsSection.allCases.count, 12, "There should be 12 settings sections")
+    }
+
+    func testTitleNotEmpty() {
+        for section in SettingsSection.allCases {
+            XCTAssertFalse(section.title.isEmpty, "Section \(section.rawValue) should have a title")
+        }
+    }
+
+    func testIconNotEmpty() {
+        for section in SettingsSection.allCases {
+            XCTAssertFalse(section.icon.isEmpty, "Section \(section.rawValue) should have an icon")
+        }
+    }
+
+    func testSearchKeywordsNotEmpty() {
+        for section in SettingsSection.allCases {
+            XCTAssertFalse(section.searchKeywords.isEmpty, "Section \(section.rawValue) should have search keywords")
+        }
+    }
+
+    func testUniqueRawValues() {
+        let rawValues = SettingsSection.allCases.map(\.rawValue)
+        XCTAssertEqual(Set(rawValues).count, rawValues.count, "Section raw values should be unique")
+    }
+
+    func testUniqueIds() {
+        let ids = SettingsSection.allCases.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Section IDs should be unique")
+    }
+
+    // MARK: - Group mapping
+
+    func testGroupMapping() {
+        XCTAssertEqual(SettingsSection.aiModel.group, .ai)
+        XCTAssertEqual(SettingsSection.apiKey.group, .ai)
+        XCTAssertEqual(SettingsSection.voice.group, .voice)
+        XCTAssertEqual(SettingsSection.interface.group, .general)
+        XCTAssertEqual(SettingsSection.wakeWord.group, .general)
+        XCTAssertEqual(SettingsSection.heartbeat.group, .general)
+        XCTAssertEqual(SettingsSection.family.group, .people)
+        XCTAssertEqual(SettingsSection.agent.group, .people)
+        XCTAssertEqual(SettingsSection.tools.group, .connection)
+        XCTAssertEqual(SettingsSection.integrations.group, .connection)
+        XCTAssertEqual(SettingsSection.account.group, .connection)
+        XCTAssertEqual(SettingsSection.guide.group, .help)
+    }
+
+    func testAllSectionsHaveGroup() {
+        for section in SettingsSection.allCases {
+            // Just verify group is accessible (no crash)
+            _ = section.group
+        }
+    }
+
+    func testAllGroupsHaveSections() {
+        for group in SettingsSectionGroup.allCases {
+            XCTAssertFalse(group.sections.isEmpty, "Group \(group.rawValue) should have at least one section")
+        }
+    }
+
+    func testGroupSectionsAreComplete() {
+        // All sections should be covered by groups
+        let allGroupedSections = SettingsSectionGroup.allCases.flatMap(\.sections)
+        XCTAssertEqual(
+            Set(allGroupedSections),
+            Set(SettingsSection.allCases),
+            "All sections should be covered by groups"
+        )
+    }
+
+    // MARK: - Specific titles and icons
+
+    func testAIModelSection() {
+        let section = SettingsSection.aiModel
+        XCTAssertEqual(section.title, "AI 모델")
+        XCTAssertEqual(section.icon, "brain")
+        XCTAssertEqual(section.rawValue, "ai-model")
+    }
+
+    func testAPIKeySection() {
+        let section = SettingsSection.apiKey
+        XCTAssertEqual(section.title, "API 키")
+        XCTAssertEqual(section.icon, "key")
+    }
+
+    func testVoiceSection() {
+        let section = SettingsSection.voice
+        XCTAssertEqual(section.title, "음성 합성")
+        XCTAssertEqual(section.icon, "speaker.wave.2")
+    }
+
+    func testGuideSection() {
+        let section = SettingsSection.guide
+        XCTAssertEqual(section.title, "가이드")
+        XCTAssertEqual(section.icon, "play.rectangle")
+        XCTAssertEqual(section.group, .help)
+    }
+}
+
+// MARK: - SettingsSearch Tests
+
+final class SettingsSearchTests: XCTestCase {
+
+    func testSearchByTitle() {
+        // "AI 모델" should match the aiModel section
+        XCTAssertTrue(SettingsSection.aiModel.matches(query: "AI 모델"))
+        XCTAssertTrue(SettingsSection.aiModel.matches(query: "모델"))
+        XCTAssertTrue(SettingsSection.apiKey.matches(query: "API"))
+    }
+
+    func testSearchByKeyword() {
+        // "OpenAI" should match aiModel (keyword)
+        XCTAssertTrue(SettingsSection.aiModel.matches(query: "OpenAI"))
+        // "텔레그램" should match integrations
+        XCTAssertTrue(SettingsSection.integrations.matches(query: "텔레그램"))
+        // "속도" should match voice
+        XCTAssertTrue(SettingsSection.voice.matches(query: "속도"))
+        // "캘린더" should match heartbeat
+        XCTAssertTrue(SettingsSection.heartbeat.matches(query: "캘린더"))
+        // "VRM" should match interface
+        XCTAssertTrue(SettingsSection.interface.matches(query: "VRM"))
+    }
+
+    func testSearchCaseInsensitive() {
+        // Keywords should match case-insensitively
+        XCTAssertTrue(SettingsSection.aiModel.matches(query: "openai"))
+        XCTAssertTrue(SettingsSection.account.matches(query: "supabase"))
+    }
+
+    func testSearchNoMatch() {
+        XCTAssertFalse(SettingsSection.aiModel.matches(query: "텔레그램"))
+        XCTAssertFalse(SettingsSection.voice.matches(query: "칸반"))
+        XCTAssertFalse(SettingsSection.guide.matches(query: "모델"))
+    }
+
+    func testSearchPartialMatch() {
+        // Partial title match
+        XCTAssertTrue(SettingsSection.integrations.matches(query: "통합"))
+        // Partial keyword match
+        XCTAssertTrue(SettingsSection.tools.matches(query: "권한"))
+    }
+
+    func testEveryKeywordMatchesCorrectSection() {
+        // Spot-check: each section's keywords match that section
+        for section in SettingsSection.allCases {
+            for keyword in section.searchKeywords {
+                XCTAssertTrue(
+                    section.matches(query: keyword),
+                    "Keyword '\(keyword)' should match section '\(section.title)'"
+                )
+            }
+        }
+    }
+}
+
+// MARK: - SettingsSectionGroup Tests
+
+final class SettingsSectionGroupTests: XCTestCase {
+
+    func testAllGroupsCount() {
+        XCTAssertEqual(SettingsSectionGroup.allCases.count, 6, "There should be 6 settings groups")
+    }
+
+    func testGroupRawValues() {
+        XCTAssertEqual(SettingsSectionGroup.ai.rawValue, "AI")
+        XCTAssertEqual(SettingsSectionGroup.voice.rawValue, "음성")
+        XCTAssertEqual(SettingsSectionGroup.general.rawValue, "일반")
+        XCTAssertEqual(SettingsSectionGroup.people.rawValue, "사람")
+        XCTAssertEqual(SettingsSectionGroup.connection.rawValue, "연결")
+        XCTAssertEqual(SettingsSectionGroup.help.rawValue, "도움말")
+    }
+
+    func testAIGroupSections() {
+        let sections = SettingsSectionGroup.ai.sections
+        XCTAssertEqual(sections.count, 2)
+        XCTAssertTrue(sections.contains(.aiModel))
+        XCTAssertTrue(sections.contains(.apiKey))
+    }
+
+    func testGeneralGroupSections() {
+        let sections = SettingsSectionGroup.general.sections
+        XCTAssertEqual(sections.count, 3)
+        XCTAssertTrue(sections.contains(.interface))
+        XCTAssertTrue(sections.contains(.wakeWord))
+        XCTAssertTrue(sections.contains(.heartbeat))
+    }
+
+    func testConnectionGroupSections() {
+        let sections = SettingsSectionGroup.connection.sections
+        XCTAssertEqual(sections.count, 3)
+        XCTAssertTrue(sections.contains(.tools))
+        XCTAssertTrue(sections.contains(.integrations))
+        XCTAssertTrue(sections.contains(.account))
+    }
+}
+
+// MARK: - CommandPalette Settings Items Tests
+
+final class CommandPaletteSettingsItemsTests: XCTestCase {
+
+    func testSettingsItemsExist() {
+        let settingsItems = CommandPaletteRegistry.staticItems.filter { $0.category == .settings }
+        // open-settings, reset-hints, settings.model, settings.open.ai, settings.open.apikey,
+        // settings.open.voice, settings.open.agent, settings.open.integration, settings.open.account
+        XCTAssertGreaterThanOrEqual(settingsItems.count, 9)
+    }
+
+    func testQuickModelPaletteItem() {
+        let item = CommandPaletteRegistry.staticItems.first { $0.id == "settings.model" }
+        XCTAssertNotNil(item, "Quick model palette item should exist")
+        XCTAssertEqual(item?.title, "모델 빠르게 변경")
+        XCTAssertEqual(item?.category, .settings)
+    }
+
+    func testSettingsSectionPaletteItems() {
+        let sectionIds = [
+            "settings.open.ai",
+            "settings.open.apikey",
+            "settings.open.voice",
+            "settings.open.agent",
+            "settings.open.integration",
+            "settings.open.account",
+        ]
+
+        for id in sectionIds {
+            let item = CommandPaletteRegistry.staticItems.first { $0.id == id }
+            XCTAssertNotNil(item, "Palette item '\(id)' should exist")
+            XCTAssertEqual(item?.category, .settings)
+        }
+    }
+
+    func testAllStaticItemsHaveUniqueIds() {
+        let ids = CommandPaletteRegistry.staticItems.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Static item IDs should be unique")
+    }
+}

--- a/spec/ui-inventory.md
+++ b/spec/ui-inventory.md
@@ -22,7 +22,7 @@ DochiApp (entry point)
     │   └── SidebarAuthStatusView — Supabase 로그인 상태
     ├── [Detail]
     │   ├── [대화 탭]
-    │   │   ├── SystemHealthBarView — 시스템 상태 바 (모델/동기화/하트비트/토큰) [항상 표시]
+    │   │   ├── SystemHealthBarView — 시스템 상태 바 (개별 클릭 가능: 모델→QuickModel팝오버/동기화/하트비트/토큰→상태시트) [항상 표시]
     │   │   ├── StatusBarView — 상태/토큰 (처리 중에만 표시)
     │   │   ├── ToolConfirmationBannerView — 민감 도구 승인 (카운트다운 타이머, Enter/Escape 단축키)
     │   │   ├── SystemPromptBannerView — 시스템 프롬프트 접기/펼치기 배너 (UX-8)
@@ -68,7 +68,7 @@ DochiApp (entry point)
 | MessageBubbleView | `Views/MessageBubbleView.swift` | 자동 | 개별 메시지 렌더링 (역할별 스타일), 호버 시 복사 버튼 오버레이 |
 | EmptyConversationView | `Views/ContentView.swift` | 빈 대화 | 카테고리별 제안 프롬프트, "모든 기능 보기" 링크, 단축키 힌트, 에이전트 0개 시 생성 힌트 카드, 투어 리마인더 배너, 첫 대화 힌트 버블 |
 | InputBarView | `Views/ContentView.swift` | 항상 표시 | 텍스트 입력, 마이크, 전송/취소 버튼, 슬래시 명령 |
-| SystemHealthBarView | `Views/SystemHealthBarView.swift` | 항상 표시 | 현재 모델, 동기화 상태, 하트비트, 세션 토큰 (클릭 → 상세 시트) |
+| SystemHealthBarView | `Views/SystemHealthBarView.swift` | 항상 표시 | 4개 독립 버튼: 모델(→QuickModelPopover), 동기화(→상태시트), 하트비트(→상태시트), 토큰(→상태시트). IndicatorButtonStyle 호버 |
 | MessageMetadataBadgeView | `Views/MessageBubbleView.swift` | assistant 메시지 자동 | 모델명·응답시간 배지, 호버 시 상세 팝오버 (토큰/프로바이더/폴백) |
 | StatusBarView | `Views/ContentView.swift` | 처리 중 자동 | 상태 아이콘 + 텍스트 + 토큰 사용량 |
 | ToolExecutionCardView | `Views/ToolExecutionCardView.swift` | 도구 실행 시 자동 | 접을 수 있는 실시간 도구 실행 카드 (상태 아이콘, 도구명, 입력 요약, 소요 시간, 카테고리 배지) |
@@ -100,6 +100,7 @@ DochiApp (entry point)
 | CommandPaletteView | `Views/CommandPaletteView.swift` | ⌘K | VS Code 스타일 커맨드 팔레트 오버레이 (퍼지 검색, 그룹 섹션) |
 | QuickSwitcherView | `Views/QuickSwitcherView.swift` | ⌘⇧A / ⌘⇧W / ⌘⇧U | 에이전트/워크스페이스/사용자 빠른 전환 시트 |
 | TagManagementView | `Views/Sidebar/TagManagementView.swift` | 사이드바 "태그" 버튼 또는 컨텍스트 메뉴 "태그 관리" | 태그 CRUD 시트 (360x400pt), 9색 팔레트, 사용 수 |
+| QuickModelPopoverView | `Views/QuickModelPopoverView.swift` | SystemHealthBar 모델 클릭 또는 ⌘⇧M | 프로바이더 선택 + 모델 목록 + 자동 라우팅 토글 (320pt 폭) |
 | OnboardingView | `Views/OnboardingView.swift` | 최초 실행 시 자동 | 6단계 초기 설정 위저드 + 기능 투어 연결 |
 | FeatureTourView | `Views/Guide/FeatureTourViews.swift` | 온보딩 완료 후 / 설정 > 일반 > 가이드 / 커맨드 팔레트 | 4단계 기능 투어 (개요/대화/에이전트·워크스페이스/단축키) |
 | WorkspaceManagementView | `Views/Sidebar/WorkspaceManagementView.swift` | SidebarHeader 메뉴 | 워크스페이스 생성/삭제 |
@@ -110,19 +111,29 @@ DochiApp (entry point)
 | ExportOptionsView | `Views/ExportOptionsView.swift` | 툴바 "내보내기" 버튼 (⌘⇧E) 또는 커맨드 팔레트 | 4형식 선택(Md/JSON/PDF/텍스트), 3옵션 토글, 3액션(클립보드/공유/파일 저장), 400x480pt |
 | LoginSheet | `Views/Settings/LoginSheet.swift` | 계정 설정에서 | Supabase 로그인/가입 |
 
-### 설정 (SettingsView — 9개 탭)
+### 설정 (SettingsView — NavigationSplitView, 12섹션 6그룹) (UX-10 리디자인)
 
-| 탭 | 파일 | 내용 |
-|----|------|------|
-| 일반 | `Views/SettingsView.swift` 내 | 폰트, 인터랙션 모드, 웨이크워드, 아바타, Heartbeat, 가이드 (투어/힌트 관리) |
-| AI 모델 | `Views/SettingsView.swift` 내 | 프로바이더/모델 선택, Ollama, 태스크 라우팅, 폴백 |
-| API 키 | `Views/SettingsView.swift` 내 | OpenAI/Anthropic/Z.AI/Tavily/Fal.ai 키 관리 |
-| 음성 | `Views/Settings/VoiceSettingsView.swift` | TTS 프로바이더, 음성, 속도/피치 |
-| 가족 | `Views/Settings/FamilySettingsView.swift` | 사용자 프로필 CRUD |
-| 에이전트 | `Views/Settings/AgentSettingsView.swift` → `Views/Agent/AgentCardGridView.swift` | 에이전트 카드 그리드 (편집/복제/템플릿저장/삭제 + 위저드로 생성) |
-| 도구 | `Views/Settings/ToolsSettingsView.swift` | 도구 브라우저 (검색/필터/상세) |
-| 통합 | `Views/Settings/IntegrationsSettingsView.swift` | 텔레그램, MCP, 채팅 매핑 |
-| 계정 | `Views/Settings/AccountSettingsView.swift` | Supabase 인증, 동기화 |
+SettingsView는 좌측 사이드바(SettingsSidebarView) + 우측 콘텐츠의 NavigationSplitView 구조.
+사이드바: 검색 필드 + 6개 그룹별 섹션 목록 (호버/선택 하이라이트).
+창 크기: 780×540pt (이상), 680×440pt (최소). 사이드바 폭 180pt.
+
+| 그룹 | 섹션 (rawValue) | 아이콘 | 파일 | 내용 |
+|------|----------------|--------|------|------|
+| AI | AI 모델 (`ai-model`) | brain | `Views/SettingsView.swift` 내 ModelSettingsView | 프로바이더/모델 선택, Ollama, 태스크 라우팅, 폴백 |
+| AI | API 키 (`api-key`) | key | `Views/SettingsView.swift` 내 APIKeySettingsView | OpenAI/Anthropic/Z.AI/Tavily/Fal.ai 키 관리 |
+| 음성 | 음성 합성 (`voice`) | speaker.wave.2 | `Views/Settings/VoiceSettingsView.swift` | TTS 프로바이더, 음성, 속도/피치 |
+| 일반 | 인터페이스 (`interface`) | paintbrush | `Views/SettingsView.swift` 내 InterfaceSettingsContent | 폰트, 인터랙션 모드, 아바타 |
+| 일반 | 웨이크워드 (`wake-word`) | waveform | `Views/SettingsView.swift` 내 WakeWordSettingsContent | 웨이크워드 설정 |
+| 일반 | 하트비트 (`heartbeat`) | heart.circle | `Views/SettingsView.swift` 내 HeartbeatSettingsContent | Heartbeat 간격, 캘린더/칸반/미리알림 체크 |
+| 사람 | 가족 (`family`) | person.2 | `Views/Settings/FamilySettingsView.swift` | 사용자 프로필 CRUD |
+| 사람 | 에이전트 (`agent`) | person.crop.rectangle | `Views/Settings/AgentSettingsView.swift` → `Views/Agent/AgentCardGridView.swift` | 에이전트 카드 그리드 |
+| 연결 | 도구 (`tools`) | wrench.and.screwdriver | `Views/Settings/ToolsSettingsView.swift` | 도구 브라우저 (검색/필터/상세) |
+| 연결 | 통합 (`integrations`) | puzzlepiece | `Views/Settings/IntegrationsSettingsView.swift` | 텔레그램, MCP, 채팅 매핑 |
+| 연결 | 계정 (`account`) | person.crop.circle | `Views/Settings/AccountSettingsView.swift` | Supabase 인증, 동기화 |
+| 도움말 | 가이드 (`guide`) | play.rectangle | `Views/SettingsView.swift` 내 GuideSettingsContent | 투어/힌트 관리 |
+
+지원 파일:
+- `Views/Settings/SettingsSidebarView.swift` — SettingsSection enum, SettingsSectionGroup enum, SettingsSidebarView, SettingsSidebarRow
 
 ---
 
@@ -275,7 +286,7 @@ CommandPaletteView (⌘K) -> executePaletteAction() -> 동일 흐름
 즐겨찾기: 컨텍스트 메뉴 -> viewModel.toggleFavorite() -> 대화 저장 -> 목록 리로드
 태그: 컨텍스트 메뉴/TagManagementView -> viewModel.toggleTagOnConversation() -> 대화 저장
 폴더: 컨텍스트 메뉴/드래그앤드롭 -> viewModel.moveConversationToFolder() -> 대화 저장
-일괄 선택: ⌘⇧M -> viewModel.toggleMultiSelectMode() -> BulkActionToolbar 표시
+일괄 선택: 커맨드 팔레트/툴바 -> viewModel.toggleMultiSelectMode() -> BulkActionToolbar 표시
   -> bulkDelete/bulkMoveToFolder/bulkSetFavorite/bulkAddTag
 필터: 필터 버튼 -> ConversationFilterView 팝오버 -> filter 바인딩 -> filteredConversations 업데이트
 ```
@@ -321,6 +332,18 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
   -> MessageBubbleView -> MemoryReferenceBadgeView: "메모리 N계층" 배지
   -> 호버 팝오버: 계층별 사용 여부 + 글자수
 기존 컨텍스트 인스펙터: ⌘⌥I -> showContextInspector -> ContextInspectorView (시트)
+```
+
+### 모델 빠른 변경 (UX-10 추가)
+```
+SystemHealthBarView 모델 클릭 / ⌘⇧M -> showQuickModelPopover = true
+  -> QuickModelPopoverView (320pt popover)
+  -> 프로바이더 라디오 버튼 선택 -> settings.llmProvider 변경
+  -> 모델 목록 선택 -> settings.llmModel 변경
+  -> "자동 모델 선택" 토글 -> settings.taskRoutingEnabled 변경
+  -> "설정에서 더 보기" -> 설정 창 열기 (aiModel 섹션)
+커맨드 팔레트: "모델 빠르게 변경" -> openQuickModelPopover 액션
+  "AI 모델 설정 열기" / "API 키 설정 열기" / ... -> openSettingsSection(section:) 액션
 ```
 
 ### 가이드/온보딩 (UX-9 추가)
@@ -374,7 +397,7 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 | ⌘⇧U | 사용자 빠른 전환 | ContentView (hidden button) |
 | ⌘⇧K | 칸반/대화 전환 | ContentView (onKeyPress) |
 | ⌘⇧L | 즐겨찾기 필터 토글 | ContentView (onKeyPress) |
-| ⌘⇧M | 일괄 선택 모드 토글 | ContentView (onKeyPress) |
+| ⌘⇧M | 모델 빠른 변경 (QuickModelPopover) | ContentView (onKeyPress) (UX-10 변경, 기존 일괄선택은 커맨드 팔레트/툴바로 접근) |
 | ⌘⇧T | 도구 카드 일괄 접기/펼치기 | ContentView (hidden button) |
 | Escape | 요청 취소 / 확인 배너 거부 / 팔레트 닫기 | ContentView (onKeyPress) |
 | Enter | 확인 배너 허용 / 메시지 전송 | ContentView (onKeyPress) / InputBarView |
@@ -405,6 +428,8 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 | 힌트 버블 (ViewModifier + material) | HintBubbleModifier | 일회성 맥락 힌트 (1.5초 후 fadeIn, 최대 1개, "다시 보지 않기") |
 | 설정 도움말 버튼 (? + popover) | SettingsHelpButton | 섹션 헤더 "?" 아이콘, 클릭 시 설명 팝오버 (280pt) |
 | 투어 단계 (step indicator + 콘텐츠) | FeatureTourView | 4단계 워크스루 (이전/다음/건너뛰기/시작) |
+| 인디케이터 버튼 (ButtonStyle + onHover) | SystemHealthBarView | 호버 시 배경색 표시, 개별 클릭 영역 (UX-10) |
+| 설정 사이드바 (List + 그룹 섹션) | SettingsSidebarView | 검색 필드 + 6그룹 12섹션, 호버/선택 하이라이트 (UX-10) |
 
 ---
 
@@ -485,4 +510,4 @@ SidebarHeaderView [+] / 커맨드 팔레트 "새 에이전트 생성" / EmptyCon
 
 ---
 
-*최종 업데이트: 2026-02-15 (UX-9 머지 후)*
+*최종 업데이트: 2026-02-15 (UX-10 머지 후)*


### PR DESCRIPTION
## Summary

- **SettingsView 전면 리디자인**: 9탭 TabView → 12섹션 6그룹 NavigationSplitView (좌: 사이드바 180pt, 우: 콘텐츠)
- **QuickModelPopoverView**: SystemHealthBarView 모델 클릭 또는 ⌘⇧M으로 프로바이더/모델 빠른 전환
- **SystemHealthBarView 개선**: 단일 클릭 → 4개 독립 버튼 (모델→팝오버, 동기화/하트비트/토큰→상태시트)

## Changes

### 새 파일
- `Dochi/Views/Settings/SettingsSidebarView.swift` — SettingsSection enum (12개), SettingsSectionGroup enum (6개), 사이드바 뷰, 키워드 검색
- `Dochi/Views/QuickModelPopoverView.swift` — 모델 빠른 변경 팝오버 (320pt, 프로바이더 라디오 + 모델 목록 + 자동 라우팅 토글)
- `DochiTests/SettingsRedesignTests.swift` — 28개 단위 테스트

### 수정 파일
- `Dochi/Views/SettingsView.swift` — TabView→NavigationSplitView, GeneralSettingsView를 4개 콘텐츠 뷰로 분리 (Interface/WakeWord/Heartbeat/Guide)
- `Dochi/Views/SystemHealthBarView.swift` — 4개 독립 Button + IndicatorButtonStyle (호버 효과)
- `Dochi/Views/ContentView.swift` — QuickModelPopover 연동, ⌘⇧M 단축키, 팔레트 액션 핸들러
- `Dochi/Models/CommandPaletteItem.swift` — openQuickModelPopover / openSettingsSection 액션 + 7개 설정 팔레트 항목
- `Dochi/ViewModels/DochiViewModel.swift` — keychainService 접근성 변경 (private→private(set))
- `spec/ui-inventory.md` — 설정 섹션 갱신, QuickModelPopover 추가, 단축키/데이터흐름/컴포넌트 패턴 업데이트

## Test plan
- [x] `xcodebuild build` 성공
- [x] 28개 신규 테스트 통과 (SettingsSection/Search/Group/PaletteItems)
- [x] 기존 테스트 영향 없음 (TaskQueueTests.testCheckDeadlinesExpired 실패는 main 브랜치에서도 동일하게 발생하는 기존 이슈)
- [ ] 설정 창 열기 (⌘,) → 사이드바 12섹션 탐색 확인
- [ ] 검색 필드에 키워드 입력 → 필터링 확인
- [ ] SystemHealthBar 모델 클릭 → QuickModelPopover 표시 확인
- [ ] ⌘⇧M → QuickModelPopover 표시 확인
- [ ] 커맨드 팔레트 (⌘K) → "모델", "설정" 검색 → 관련 항목 확인

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)