### PR TITLE
feat: 메뉴바 퀵 액세스 (H-1)

### DIFF
--- a/Dochi/App/MenuBarManager.swift
+++ b/Dochi/App/MenuBarManager.swift
@@ -1,0 +1,208 @@
+import AppKit
+import SwiftUI
+
+/// NSStatusItem + NSPopover 관리, 글로벌 핫키 등록 (H-1)
+@MainActor
+final class MenuBarManager {
+
+    // MARK: - State
+
+    enum StatusIconState {
+        case normal
+        case processing
+        case error
+    }
+
+    // MARK: - Properties
+
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+    private var globalMonitor: Any?
+    private var localMonitor: Any?
+    private var eventMonitor: Any?
+
+    private let settings: AppSettings
+    private weak var viewModel: DochiViewModel?
+
+    private(set) var iconState: StatusIconState = .normal
+
+    // MARK: - Init
+
+    init(settings: AppSettings, viewModel: DochiViewModel) {
+        self.settings = settings
+        self.viewModel = viewModel
+    }
+
+    // MARK: - Setup / Teardown
+
+    func setup() {
+        guard settings.menuBarEnabled else { return }
+
+        let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        if let button = item.button {
+            let image = NSImage(systemSymbolName: "bubble.left.fill", accessibilityDescription: "도치 퀵 액세스")
+            image?.isTemplate = true
+            let config = NSImage.SymbolConfiguration(pointSize: 18, weight: .regular)
+            button.image = image?.withSymbolConfiguration(config)
+            button.action = #selector(AppDelegate.toggleMenuBarPopover)
+            button.target = nil // Sends up responder chain to AppDelegate
+        }
+        self.statusItem = item
+
+        let pop = NSPopover()
+        pop.behavior = .transient
+        pop.contentSize = NSSize(width: 380, height: 480)
+        pop.animates = true
+
+        if let viewModel {
+            let popoverView = MenuBarPopoverView(viewModel: viewModel, onClose: { [weak self] in
+                self?.closePopover()
+            }, onOpenMainApp: { [weak self] in
+                self?.openMainApp()
+            })
+            pop.contentViewController = NSHostingController(rootView: popoverView)
+        }
+        self.popover = pop
+
+        registerGlobalShortcut()
+
+        Log.app.info("MenuBarManager: setup completed")
+    }
+
+    func teardown() {
+        unregisterGlobalShortcut()
+
+        if let item = statusItem {
+            NSStatusBar.system.removeStatusItem(item)
+        }
+        statusItem = nil
+        popover?.close()
+        popover = nil
+
+        Log.app.info("MenuBarManager: teardown completed")
+    }
+
+    // MARK: - Popover Control
+
+    func togglePopover() {
+        guard let popover, let button = statusItem?.button else { return }
+
+        if popover.isShown {
+            closePopover()
+        } else {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            // Bring popover window to front
+            popover.contentViewController?.view.window?.makeKey()
+        }
+    }
+
+    func closePopover() {
+        popover?.performClose(nil)
+    }
+
+    var isPopoverShown: Bool {
+        popover?.isShown ?? false
+    }
+
+    // MARK: - Icon State
+
+    func updateIconState(_ state: StatusIconState) {
+        iconState = state
+        guard let button = statusItem?.button else { return }
+
+        let baseImage = NSImage(systemSymbolName: "bubble.left.fill", accessibilityDescription: "도치 퀵 액세스")
+        baseImage?.isTemplate = true
+        let config = NSImage.SymbolConfiguration(pointSize: 18, weight: .regular)
+        let configuredImage = baseImage?.withSymbolConfiguration(config)
+
+        switch state {
+        case .normal:
+            button.image = configuredImage
+        case .processing:
+            // Use the template image with a blue tint via compositing
+            let tintConfig = NSImage.SymbolConfiguration(paletteColors: [.systemBlue])
+            button.image = configuredImage?.withSymbolConfiguration(tintConfig)
+        case .error:
+            let tintConfig = NSImage.SymbolConfiguration(paletteColors: [.systemRed])
+            button.image = configuredImage?.withSymbolConfiguration(tintConfig)
+        }
+    }
+
+    // MARK: - Open Main App
+
+    func openMainApp() {
+        closePopover()
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.windows.first { $0.className.contains("AppKit") == false && $0.isVisible == false }?.makeKeyAndOrderFront(nil)
+        // Fallback: bring any main window forward
+        if let mainWindow = NSApp.windows.first(where: { $0.className != "NSStatusBarWindow" && $0.className != "_NSPopoverWindow" }) {
+            mainWindow.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    // MARK: - Global Shortcut (Cmd+Shift+D)
+
+    private func registerGlobalShortcut() {
+        guard settings.menuBarGlobalShortcutEnabled else { return }
+
+        // Global monitor (when app is not in focus)
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleShortcutEvent(event)
+        }
+
+        // Local monitor (when app is in focus)
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if self?.handleShortcutEvent(event) == true {
+                return nil // consume the event
+            }
+            return event
+        }
+
+        Log.app.info("MenuBarManager: global shortcut registered (Cmd+Shift+D)")
+    }
+
+    private func unregisterGlobalShortcut() {
+        if let globalMonitor {
+            NSEvent.removeMonitor(globalMonitor)
+            self.globalMonitor = nil
+        }
+        if let localMonitor {
+            NSEvent.removeMonitor(localMonitor)
+            self.localMonitor = nil
+        }
+
+        Log.app.info("MenuBarManager: global shortcut unregistered")
+    }
+
+    @discardableResult
+    private func handleShortcutEvent(_ event: NSEvent) -> Bool {
+        // Cmd+Shift+D
+        guard event.modifierFlags.contains([.command, .shift]),
+              event.keyCode == 2 else { // 2 = 'D' key
+            return false
+        }
+
+        Task { @MainActor in
+            self.togglePopover()
+        }
+        return true
+    }
+
+    // MARK: - Settings Observation
+
+    func handleSettingsChange() {
+        if settings.menuBarEnabled {
+            if statusItem == nil {
+                setup()
+            }
+        } else {
+            teardown()
+        }
+
+        // Re-register or unregister global shortcut
+        unregisterGlobalShortcut()
+        if settings.menuBarEnabled {
+            registerGlobalShortcut()
+        }
+    }
+}

--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -300,6 +300,16 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(conflictResolutionStrategy, forKey: "conflictResolutionStrategy") }
     }
 
+    // MARK: - Menu Bar (H-1)
+
+    var menuBarEnabled: Bool = UserDefaults.standard.object(forKey: "menuBarEnabled") as? Bool ?? true {
+        didSet { UserDefaults.standard.set(menuBarEnabled, forKey: "menuBarEnabled") }
+    }
+
+    var menuBarGlobalShortcutEnabled: Bool = UserDefaults.standard.object(forKey: "menuBarGlobalShortcutEnabled") as? Bool ?? true {
+        didSet { UserDefaults.standard.set(menuBarGlobalShortcutEnabled, forKey: "menuBarGlobalShortcutEnabled") }
+    }
+
     // MARK: - Computed
 
     var currentProvider: LLMProvider {

--- a/Dochi/Models/CommandPaletteItem.swift
+++ b/Dochi/Models/CommandPaletteItem.swift
@@ -43,6 +43,7 @@ struct CommandPaletteItem: Identifiable, Sendable {
         case syncNow
         case syncConflicts
         case cloudAccountSettings
+        case toggleMenuBar
         case custom(id: String)
     }
 }
@@ -300,6 +301,15 @@ enum CommandPaletteRegistry {
             subtitle: "",
             category: .settings,
             action: .openSettingsSection(section: "ai-model")
+        ),
+        // H-1: 메뉴바 퀵 액세스
+        CommandPaletteItem(
+            id: "toggle-menu-bar",
+            icon: "menubar.rectangle",
+            title: "메뉴바 퀵 액세스 토글",
+            subtitle: "⌘⇧D",
+            category: .navigation,
+            action: .toggleMenuBar
         ),
         // G-3: 동기화 명령
         CommandPaletteItem(

--- a/Dochi/Views/ContentView.swift
+++ b/Dochi/Views/ContentView.swift
@@ -570,6 +570,11 @@ struct ContentView: View {
             showSyncConflictSheet = true
         case .cloudAccountSettings:
             NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        case .toggleMenuBar:
+            // Toggle menu bar popover via AppDelegate
+            if let appDelegate = NSApp.delegate as? AppDelegate {
+                appDelegate.menuBarManager?.togglePopover()
+            }
         case .custom(let id):
             if id.hasPrefix("switchUser-") {
                 let userIdStr = String(id.dropFirst("switchUser-".count))

--- a/Dochi/Views/KeyboardShortcutHelpView.swift
+++ b/Dochi/Views/KeyboardShortcutHelpView.swift
@@ -48,6 +48,13 @@ struct KeyboardShortcutHelpView: View {
             ]
         ),
         (
+            title: "메뉴바",
+            icon: "menubar.rectangle",
+            entries: [
+                ShortcutEntry(keys: "⌘⇧D", description: "메뉴바 퀵 액세스 토글 (글로벌)"),
+            ]
+        ),
+        (
             title: "명령 팔레트",
             icon: "command",
             entries: [

--- a/Dochi/Views/MenuBarPopoverView.swift
+++ b/Dochi/Views/MenuBarPopoverView.swift
@@ -1,0 +1,341 @@
+import SwiftUI
+
+/// 메뉴바 팝업 전체 SwiftUI 뷰 (H-1)
+/// 헤더 + 대화 영역 + 입력바 + 푸터
+struct MenuBarPopoverView: View {
+    @Bindable var viewModel: DochiViewModel
+    var onClose: () -> Void
+    var onOpenMainApp: () -> Void
+
+    @State private var inputText: String = ""
+    @FocusState private var isInputFocused: Bool
+
+    // MARK: - Computed
+
+    /// 최근 메시지 10개 (user + assistant만)
+    private var recentMessages: [Message] {
+        let messages = viewModel.currentConversation?.messages
+            .filter { $0.role == .user || $0.role == .assistant } ?? []
+        return Array(messages.suffix(10))
+    }
+
+    private var isProcessing: Bool {
+        viewModel.interactionState == .processing
+    }
+
+    private var currentModelName: String {
+        viewModel.settings.llmModel
+    }
+
+    private var currentAgentName: String {
+        viewModel.settings.activeAgentName
+    }
+
+    private var currentWorkspaceName: String {
+        let wsId = viewModel.sessionContext.workspaceId
+        if wsId == UUID(uuidString: "00000000-0000-0000-0000-000000000000") {
+            return "기본"
+        }
+        return String(wsId.uuidString.prefix(8))
+    }
+
+    // MARK: - Suggestion Chips
+
+    private let suggestionChips = [
+        "오늘 할 일 정리",
+        "간단한 질문하기",
+        "일정 확인"
+    ]
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerView
+            Divider()
+            conversationArea
+            Divider()
+            inputBarView
+            Divider()
+            footerView
+        }
+        .frame(width: 380, height: 480)
+        .onAppear {
+            isInputFocused = true
+        }
+    }
+
+    // MARK: - Header (36pt)
+
+    private var headerView: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "person.crop.circle.fill")
+                .font(.system(size: 16))
+                .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(currentAgentName)
+                    .font(.system(size: 12, weight: .semibold))
+                    .lineLimit(1)
+
+                Text(currentWorkspaceName)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Button {
+                onClose()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("닫기 (Esc)")
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 36)
+    }
+
+    // MARK: - Conversation Area
+
+    @ViewBuilder
+    private var conversationArea: some View {
+        if recentMessages.isEmpty && !isProcessing {
+            emptyStateView
+        } else {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 6) {
+                        ForEach(recentMessages) { message in
+                            compactBubble(message: message)
+                                .id(message.id)
+                        }
+
+                        // Streaming text
+                        if isProcessing && !viewModel.streamingText.isEmpty {
+                            streamingBubble
+                                .id("streaming")
+                        } else if isProcessing {
+                            processingIndicator
+                                .id("processing")
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+                .onChange(of: viewModel.streamingText) { _, _ in
+                    withAnimation(.easeOut(duration: 0.1)) {
+                        if isProcessing {
+                            proxy.scrollTo("streaming", anchor: .bottom)
+                        }
+                    }
+                }
+                .onChange(of: recentMessages.count) { _, _ in
+                    if let lastId = recentMessages.last?.id {
+                        withAnimation(.easeOut(duration: 0.1)) {
+                            proxy.scrollTo(lastId, anchor: .bottom)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: 12) {
+            Spacer()
+
+            Image(systemName: "bubble.left.fill")
+                .font(.system(size: 32))
+                .foregroundStyle(.quaternary)
+
+            Text("무엇이든 물어보세요")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            // Suggestion chips
+            VStack(spacing: 6) {
+                ForEach(suggestionChips, id: \.self) { chip in
+                    Button {
+                        inputText = chip
+                        sendMessage()
+                    } label: {
+                        Text(chip)
+                            .font(.system(size: 11))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(Color.accentColor.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Compact Bubble
+
+    private func compactBubble(message: Message) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            if message.role == .assistant {
+                Image(systemName: "sparkle")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 3)
+            }
+
+            Text(message.content)
+                .font(.callout)
+                .foregroundStyle(message.role == .user ? .primary : .primary)
+                .textSelection(.enabled)
+                .lineLimit(6)
+                .frame(maxWidth: .infinity, alignment: message.role == .user ? .trailing : .leading)
+
+            if message.role == .user {
+                Image(systemName: "person.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 3)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(message.role == .user
+                      ? Color.accentColor.opacity(0.08)
+                      : Color.secondary.opacity(0.06))
+        )
+    }
+
+    // MARK: - Streaming Bubble
+
+    private var streamingBubble: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: "sparkle")
+                .font(.system(size: 9))
+                .foregroundStyle(.blue)
+                .padding(.top, 3)
+
+            Text(viewModel.streamingText)
+                .font(.callout)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.blue.opacity(0.06))
+        )
+    }
+
+    // MARK: - Processing Indicator
+
+    private var processingIndicator: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.small)
+            Text("생각하는 중...")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Input Bar (44pt)
+
+    private var inputBarView: some View {
+        HStack(spacing: 8) {
+            TextField("메시지 입력...", text: $inputText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(.system(size: 13))
+                .lineLimit(1...3)
+                .focused($isInputFocused)
+                .onSubmit {
+                    sendMessage()
+                }
+
+            if isProcessing {
+                Button {
+                    viewModel.cancelRequest()
+                } label: {
+                    Image(systemName: "stop.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundStyle(.red)
+                }
+                .buttonStyle(.plain)
+                .help("중지")
+            } else {
+                Button {
+                    sendMessage()
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundColor(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? .secondary : .accentColor)
+                }
+                .buttonStyle(.plain)
+                .disabled(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .help("전송 (Enter)")
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(minHeight: 44)
+    }
+
+    // MARK: - Footer (30pt)
+
+    private var footerView: some View {
+        HStack(spacing: 8) {
+            Text(currentModelName)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            Spacer()
+
+            Button {
+                viewModel.newConversation()
+            } label: {
+                Image(systemName: "plus.bubble")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("새 대화 (Cmd+N)")
+
+            Button {
+                onOpenMainApp()
+            } label: {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("메인 앱 열기 (Cmd+O)")
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 30)
+    }
+
+    // MARK: - Actions
+
+    private func sendMessage() {
+        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+
+        viewModel.inputText = text
+        inputText = ""
+        viewModel.sendMessage()
+    }
+}

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -210,6 +210,33 @@ struct InterfaceSettingsContent: View {
                 helpContent: "VRM 형식의 3D 아바타를 대화 영역 위에 표시합니다. macOS 15 이상에서 사용 가능합니다. Resources/Models/에 VRM 파일이 필요합니다."
             )
         }
+
+        Section {
+            Toggle("메뉴바 아이콘 표시", isOn: Binding(
+                get: { settings.menuBarEnabled },
+                set: { settings.menuBarEnabled = $0 }
+            ))
+
+            Text("메뉴바에서 바로 도치와 대화할 수 있습니다")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if settings.menuBarEnabled {
+                Toggle("글로벌 단축키 (Cmd+Shift+D)", isOn: Binding(
+                    get: { settings.menuBarGlobalShortcutEnabled },
+                    set: { settings.menuBarGlobalShortcutEnabled = $0 }
+                ))
+
+                Text("다른 앱 사용 중에도 단축키로 퀵 액세스 팝업을 열 수 있습니다")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            SettingsSectionHeader(
+                title: "메뉴바 퀵 액세스",
+                helpContent: "메뉴바 아이콘을 통해 메인 앱을 열지 않고도 빠르게 도치와 대화할 수 있습니다. Cmd+Shift+D로 어디서든 팝업을 토글할 수 있습니다."
+            )
+        }
     }
 }
 

--- a/DochiTests/MenuBarTests.swift
+++ b/DochiTests/MenuBarTests.swift
@@ -1,0 +1,270 @@
+import XCTest
+@testable import Dochi
+
+// MARK: - MenuBar AppSettings Tests
+
+final class MenuBarSettingsTests: XCTestCase {
+
+    @MainActor
+    func testDefaultMenuBarEnabled() {
+        // Clean up UserDefaults for this test
+        UserDefaults.standard.removeObject(forKey: "menuBarEnabled")
+        let settings = AppSettings()
+        XCTAssertTrue(settings.menuBarEnabled, "menuBarEnabled should default to true")
+    }
+
+    @MainActor
+    func testDefaultMenuBarGlobalShortcutEnabled() {
+        UserDefaults.standard.removeObject(forKey: "menuBarGlobalShortcutEnabled")
+        let settings = AppSettings()
+        XCTAssertTrue(settings.menuBarGlobalShortcutEnabled, "menuBarGlobalShortcutEnabled should default to true")
+    }
+
+    @MainActor
+    func testMenuBarEnabledPersistence() {
+        let settings = AppSettings()
+        settings.menuBarEnabled = false
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "menuBarEnabled"))
+
+        settings.menuBarEnabled = true
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "menuBarEnabled"))
+    }
+
+    @MainActor
+    func testMenuBarGlobalShortcutPersistence() {
+        let settings = AppSettings()
+        settings.menuBarGlobalShortcutEnabled = false
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: "menuBarGlobalShortcutEnabled"))
+
+        settings.menuBarGlobalShortcutEnabled = true
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "menuBarGlobalShortcutEnabled"))
+    }
+}
+
+// MARK: - MenuBarManager Tests
+
+final class MenuBarManagerTests: XCTestCase {
+
+    @MainActor
+    private func makeViewModel() -> DochiViewModel {
+        let settings = AppSettings()
+        let sessionContext = SessionContext(
+            workspaceId: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
+            currentUserId: nil
+        )
+        return DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: sessionContext
+        )
+    }
+
+    @MainActor
+    func testSetupCreatesStatusItem() {
+        let settings = AppSettings()
+        settings.menuBarEnabled = true
+        let viewModel = makeViewModel()
+        let manager = MenuBarManager(settings: settings, viewModel: viewModel)
+
+        manager.setup()
+        // After setup, popover should not be shown initially
+        XCTAssertFalse(manager.isPopoverShown, "Popover should not be shown after setup")
+
+        manager.teardown()
+    }
+
+    @MainActor
+    func testSetupSkippedWhenDisabled() {
+        let settings = AppSettings()
+        settings.menuBarEnabled = false
+        let viewModel = makeViewModel()
+        let manager = MenuBarManager(settings: settings, viewModel: viewModel)
+
+        manager.setup()
+        // When disabled, popover should not exist
+        XCTAssertFalse(manager.isPopoverShown, "Popover should not be available when disabled")
+
+        manager.teardown()
+    }
+
+    @MainActor
+    func testTeardownCleansUp() {
+        let settings = AppSettings()
+        settings.menuBarEnabled = true
+        let viewModel = makeViewModel()
+        let manager = MenuBarManager(settings: settings, viewModel: viewModel)
+
+        manager.setup()
+        manager.teardown()
+        XCTAssertFalse(manager.isPopoverShown, "Popover should not be shown after teardown")
+    }
+
+    @MainActor
+    func testIconStateDefault() {
+        let settings = AppSettings()
+        settings.menuBarEnabled = true
+        let viewModel = makeViewModel()
+        let manager = MenuBarManager(settings: settings, viewModel: viewModel)
+
+        manager.setup()
+        XCTAssertEqual(manager.iconState, .normal, "Initial icon state should be .normal")
+
+        manager.teardown()
+    }
+
+    @MainActor
+    func testUpdateIconState() {
+        let settings = AppSettings()
+        settings.menuBarEnabled = true
+        let viewModel = makeViewModel()
+        let manager = MenuBarManager(settings: settings, viewModel: viewModel)
+
+        manager.setup()
+
+        manager.updateIconState(.processing)
+        XCTAssertEqual(manager.iconState, .processing)
+
+        manager.updateIconState(.error)
+        XCTAssertEqual(manager.iconState, .error)
+
+        manager.updateIconState(.normal)
+        XCTAssertEqual(manager.iconState, .normal)
+
+        manager.teardown()
+    }
+
+    @MainActor
+    func testHandleSettingsChangeEnables() {
+        let settings = AppSettings()
+        settings.menuBarEnabled = false
+        let viewModel = makeViewModel()
+        let manager = MenuBarManager(settings: settings, viewModel: viewModel)
+
+        manager.setup()
+        // Now enable
+        settings.menuBarEnabled = true
+        manager.handleSettingsChange()
+        // Manager should now have status item (we check via isPopoverShown which is false but no crash)
+        XCTAssertFalse(manager.isPopoverShown)
+
+        manager.teardown()
+    }
+
+    @MainActor
+    func testHandleSettingsChangeDisables() {
+        let settings = AppSettings()
+        settings.menuBarEnabled = true
+        let viewModel = makeViewModel()
+        let manager = MenuBarManager(settings: settings, viewModel: viewModel)
+
+        manager.setup()
+        // Now disable
+        settings.menuBarEnabled = false
+        manager.handleSettingsChange()
+        XCTAssertFalse(manager.isPopoverShown)
+    }
+
+    @MainActor
+    func testIconStateEquatable() {
+        let state1: MenuBarManager.StatusIconState = .normal
+        let state2: MenuBarManager.StatusIconState = .normal
+        let state3: MenuBarManager.StatusIconState = .processing
+        XCTAssertEqual(state1, state2)
+        XCTAssertNotEqual(state1, state3)
+    }
+}
+
+// MARK: - CommandPalette MenuBar Item Tests
+
+final class CommandPaletteMenuBarTests: XCTestCase {
+
+    func testMenuBarPaletteItemExists() {
+        let item = CommandPaletteRegistry.staticItems.first { $0.id == "toggle-menu-bar" }
+        XCTAssertNotNil(item, "Menu bar palette item should exist")
+        XCTAssertEqual(item?.title, "메뉴바 퀵 액세스 토글")
+        XCTAssertEqual(item?.subtitle, "⌘⇧D")
+        XCTAssertEqual(item?.category, .navigation)
+    }
+
+    func testAllStaticItemsUniqueIds() {
+        let ids = CommandPaletteRegistry.staticItems.map(\.id)
+        XCTAssertEqual(Set(ids).count, ids.count, "Static item IDs should be unique")
+    }
+}
+
+// MARK: - MenuBarPopoverView Data Tests
+
+final class MenuBarPopoverDataTests: XCTestCase {
+
+    @MainActor
+    func testEmptyConversationShowsEmptyState() {
+        let settings = AppSettings()
+        let sessionContext = SessionContext(
+            workspaceId: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
+            currentUserId: nil
+        )
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: sessionContext
+        )
+
+        // No current conversation means empty state
+        XCTAssertNil(viewModel.currentConversation, "Should have no conversation initially")
+        XCTAssertEqual(viewModel.interactionState, .idle, "Should be idle initially")
+    }
+
+    @MainActor
+    func testMenuBarSharesViewModelState() {
+        let settings = AppSettings()
+        settings.activeAgentName = "테스트 에이전트"
+        let sessionContext = SessionContext(
+            workspaceId: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!,
+            currentUserId: nil
+        )
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: sessionContext
+        )
+
+        // Setting inputText on viewModel should be visible
+        viewModel.inputText = "테스트 입력"
+        XCTAssertEqual(viewModel.inputText, "테스트 입력")
+        XCTAssertEqual(viewModel.settings.activeAgentName, "테스트 에이전트")
+    }
+}
+
+// MARK: - StatusIconState Equatable
+
+extension MenuBarManager.StatusIconState: @retroactive Equatable {
+    public static func == (lhs: MenuBarManager.StatusIconState, rhs: MenuBarManager.StatusIconState) -> Bool {
+        switch (lhs, rhs) {
+        case (.normal, .normal): return true
+        case (.processing, .processing): return true
+        case (.error, .error): return true
+        default: return false
+        }
+    }
+}

--- a/spec/ui-inventory.md
+++ b/spec/ui-inventory.md
@@ -10,6 +10,13 @@
 
 ```
 DochiApp (entry point)
+├── MenuBarManager (NSStatusItem + NSPopover) (H-1)
+│   └── MenuBarPopoverView — 메뉴바 퀵 액세스 팝업 (380x480pt)
+│       ├── 헤더 (36pt) — 에이전트 아이콘+이름, 워크스페이스명, 닫기 버튼
+│       ├── 대화 영역 — 최근 메시지 10개 (컴팩트 버블), 스트리밍 표시
+│       ├── 빈 상태 — 도치 아이콘 + "무엇이든 물어보세요" + 제안 칩 3개
+│       ├── 입력바 (44pt) — TextField + 전송/중지 버튼
+│       └── 푸터 (30pt) — 모델명, 새 대화 버튼, 메인 앱 열기 버튼
 └── ContentView (NavigationSplitView + ZStack)
     ├── [Sidebar] SidebarView
     │   ├── SidebarHeaderView — 워크스페이스/에이전트/사용자 전환
@@ -59,6 +66,7 @@ DochiApp (entry point)
 
 | 화면 | 파일 | 접근 방법 | 설명 |
 |------|------|-----------|------|
+| MenuBarPopoverView | `Views/MenuBarPopoverView.swift` | 메뉴바 아이콘 클릭 또는 Cmd+Shift+D (글로벌) | 메뉴바 퀵 액세스 팝업 (380x480pt): 헤더+대화+입력+푸터 (H-1) |
 | ContentView | `Views/ContentView.swift` | 앱 시작 | 메인 레이아웃 (사이드바 + 디테일 + 커맨드 팔레트 오버레이) |
 | SidebarView | `Views/ContentView.swift` | 항상 표시 | 대화 목록, 검색, 필터, 섹션 탭 |
 | SidebarHeaderView | `Views/Sidebar/SidebarHeaderView.swift` | 사이드바 상단 | 워크스페이스/에이전트/사용자 드롭다운 |
@@ -298,6 +306,7 @@ MemoryContextInfo 필드:
 | 가이드 | `hintsEnabled`, `featureTourCompleted`, `featureTourSkipped`, `featureTourBannerDismissed` |
 | 예산 (G-4) | `budgetEnabled`, `monthlyBudgetUSD`, `budgetAlert50`, `budgetAlert80`, `budgetAlert100`, `budgetBlockOnExceed` |
 | 동기화 (G-3) | `autoSyncEnabled`, `realtimeSyncEnabled`, `syncConversations`, `syncMemory`, `syncKanban`, `syncProfiles`, `conflictResolutionStrategy` |
+| 메뉴바 (H-1) | `menuBarEnabled`, `menuBarGlobalShortcutEnabled` |
 | 기타 | `chatFontSize`, `currentWorkspaceId`, `defaultUserId`, `activeAgentName` |
 
 ---
@@ -425,6 +434,18 @@ ONNX 모델 관리:
   -> 설치된 모델 Picker로 선택 -> settings.onnxModelId 변경
 ```
 
+### 메뉴바 퀵 액세스 (H-1 추가)
+```
+메뉴바 아이콘 클릭 / ⌘⇧D (글로벌) → MenuBarManager.togglePopover()
+  → NSPopover → MenuBarPopoverView (viewModel 공유)
+  → 입력 → viewModel.inputText 설정 → viewModel.sendMessage()
+  → 메인 앱에도 동일 대화 반영 (동일 참조)
+  → 새 대화: viewModel.newConversation()
+  → 메인 앱 열기: NSApp.activate() + 메인 윈도우 표시
+설정: settings.menuBarEnabled → MenuBarManager.setup()/teardown()
+  settings.menuBarGlobalShortcutEnabled → 글로벌 단축키 등록/해제
+```
+
 ### 가이드/온보딩 (UX-9 추가)
 ```
 기능 투어: 온보딩 완료 → "기능 둘러보기" 버튼 → FeatureTourView (4단계)
@@ -477,6 +498,7 @@ ONNX 모델 관리:
 | ⌘⇧K | 칸반/대화 전환 | ContentView (onKeyPress) |
 | ⌘⇧L | 즐겨찾기 필터 토글 | ContentView (onKeyPress) |
 | ⌘⇧M | 모델 빠른 변경 (QuickModelPopover) | ContentView (onKeyPress) (UX-10 변경, 기존 일괄선택은 커맨드 팔레트/툴바로 접근) |
+| ⌘⇧D | 메뉴바 퀵 액세스 토글 (글로벌) | MenuBarManager (NSEvent monitor) (H-1) |
 | ⌘⇧T | 도구 카드 일괄 접기/펼치기 | ContentView (hidden button) |
 | Escape | 요청 취소 / 확인 배너 거부 / 팔레트 닫기 | ContentView (onKeyPress) |
 | Enter | 확인 배너 허용 / 메시지 전송 | ContentView (onKeyPress) / InputBarView |
@@ -527,6 +549,7 @@ ONNX 모델 관리:
 | 개인 메모리 없음 (사용자 미설정) | "사용자가 설정되지 않아 표시할 수 없습니다" | MemoryPanelView |
 | 투어 미완료 (건너뜀) | "도치의 주요 기능을 알아보세요" 배너 + "둘러보기" | EmptyConversationView |
 | 첫 대화 힌트 | "첫 대화를 시작해보세요!" 힌트 버블 | EmptyConversationView |
+| 메뉴바 빈 대화 | 도치 아이콘 + "무엇이든 물어보세요" + 제안 칩 3개 | MenuBarPopoverView |
 
 ---
 
@@ -590,4 +613,4 @@ ONNX 모델 관리:
 
 ---
 
-*최종 업데이트: 2026-02-15 (G-4 사용량 대시보드 머지 후)*
+*최종 업데이트: 2026-02-15 (H-1 메뉴바 퀵 액세스 머지 후)*


### PR DESCRIPTION
## Summary

- 메뉴바 아이콘(NSStatusItem)에서 바로 질문하고 답변받는 팝업 인터페이스 구현
- 글로벌 단축키 Cmd+Shift+D로 어디서든 팝업 토글 가능
- DochiViewModel 인스턴스를 메인 앱과 공유하여 대화 컨텍스트 유지

## Changes

### 신규 파일
- `Dochi/App/MenuBarManager.swift` — NSStatusItem + NSPopover 관리, 글로벌 핫키 등록, 상태별 아이콘 업데이트
- `Dochi/Views/MenuBarPopoverView.swift` — 컴팩트 SwiftUI 팝업 뷰 (380x480pt): 헤더(에이전트/워크스페이스) + 대화 영역(최근 10개 메시지) + 빈 상태(제안 칩) + 입력바 + 푸터(모델명/새 대화/메인 앱 열기)
- `DochiTests/MenuBarTests.swift` — 단위 테스트 16개

### 수정 파일
- `Dochi/App/DochiApp.swift` — AppDelegate에서 MenuBarManager 초기화, settings onChange 연동
- `Dochi/Models/AppSettings.swift` — `menuBarEnabled` (기본 true), `menuBarGlobalShortcutEnabled` (기본 true) 추가
- `Dochi/Models/CommandPaletteItem.swift` — `toggleMenuBar` 액션 + 팔레트 아이템 추가
- `Dochi/Views/ContentView.swift` — 커맨드 팔레트 toggleMenuBar 액션 핸들링
- `Dochi/Views/SettingsView.swift` — 인터페이스 설정에 메뉴바 퀵 액세스 토글 섹션 추가
- `Dochi/Views/KeyboardShortcutHelpView.swift` — Cmd+Shift+D 항목 추가
- `spec/ui-inventory.md` — MenuBarManager/MenuBarPopoverView 항목, 단축키, 데이터 흐름, 빈 상태 추가

## Test plan

- [x] `xcodebuild build` 통과 확인
- [x] 신규 단위 테스트 16개 통과 (MenuBarSettingsTests, MenuBarManagerTests, CommandPaletteMenuBarTests, MenuBarPopoverDataTests)
- [x] 기존 관련 테스트 통과 (SettingsSectionTests, CommandPaletteSettingsItemsTests)
- [ ] 메뉴바 아이콘 클릭 → 팝업 표시 확인
- [ ] Cmd+Shift+D → 팝업 토글 확인 (앱 비활성 상태에서도)
- [ ] 팝업에서 메시지 전송 → 메인 앱에 반영 확인
- [ ] 설정에서 메뉴바 토글 → 즉시 반영 확인
- [ ] 메인 앱 열기 버튼 동작 확인

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)