### PR TITLE
fix: PR #172 리뷰 수정 — DI, tautological condition, 실서비스 테스트

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -61,7 +61,7 @@ struct DochiApp: App {
     private let pluginManager: PluginManager
     private let resourceOptimizer: any ResourceOptimizerProtocol
     private let terminalService: any TerminalServiceProtocol
-    private let proactiveSuggestionService: ProactiveSuggestionService
+    private let proactiveSuggestionService: any ProactiveSuggestionServiceProtocol
     private let interestDiscoveryService: InterestDiscoveryService
     private let externalToolManager: ExternalToolSessionManager
 
@@ -163,10 +163,8 @@ struct DochiApp: App {
         // Proactive Suggestion Service (K-2)
         let proactiveSuggestionService = ProactiveSuggestionService(
             settings: settings,
-            llmService: llmService,
             contextService: contextService,
             conversationService: conversationService,
-            keychainService: keychainService,
             sessionContext: sessionContext
         )
         self.proactiveSuggestionService = proactiveSuggestionService

--- a/Dochi/Services/ProactiveSuggestionService.swift
+++ b/Dochi/Services/ProactiveSuggestionService.swift
@@ -36,10 +36,8 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
 
     init(
         settings: AppSettings,
-        llmService: LLMServiceProtocol? = nil,
         contextService: ContextServiceProtocol,
-        conversationService: ConversationServiceProtocol = ConversationService(),
-        keychainService: KeychainServiceProtocol? = nil,
+        conversationService: ConversationServiceProtocol,
         sessionContext: SessionContext
     ) {
         self.settings = settings
@@ -108,16 +106,14 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
         currentSuggestion = nil
         state = .cooldown
 
-        // Disable this suggestion type via per-type settings key
-        let key = suggestion.type.settingsKey
-        switch key {
-        case "suggestionTypeNewsEnabled": settings.suggestionTypeNewsEnabled = false
-        case "suggestionTypeDeepDiveEnabled": settings.suggestionTypeDeepDiveEnabled = false
-        case "suggestionTypeResearchEnabled": settings.suggestionTypeResearchEnabled = false
-        case "suggestionTypeKanbanEnabled": settings.suggestionTypeKanbanEnabled = false
-        case "suggestionTypeMemoryEnabled": settings.suggestionTypeMemoryEnabled = false
-        case "suggestionTypeCostEnabled": settings.suggestionTypeCostEnabled = false
-        default: break
+        // Disable this suggestion type
+        switch suggestion.type {
+        case .newsTrend: settings.suggestionTypeNewsEnabled = false
+        case .deepDive: settings.suggestionTypeDeepDiveEnabled = false
+        case .relatedResearch: settings.suggestionTypeResearchEnabled = false
+        case .kanbanCheck: settings.suggestionTypeKanbanEnabled = false
+        case .memoryRemind: settings.suggestionTypeMemoryEnabled = false
+        case .costReport: settings.suggestionTypeCostEnabled = false
         }
         Log.app.info("Suggestion type dismissed: \(suggestion.type.rawValue)")
     }
@@ -369,9 +365,13 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
         }
     }
 
-    private static func dateString(from date: Date) -> String {
+    private static let dayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    private static func dateString(from date: Date) -> String {
+        dayFormatter.string(from: date)
     }
 }

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -712,7 +712,7 @@ struct HeartbeatSettingsContent: View {
                 helpContent: "사용자가 일정 시간 유휴 상태일 때, 칸반 진행 상황/메모리 기한/대화 주제 등을 기반으로 자동 제안합니다. 조용한 시간 설정은 하트비트와 공유합니다."
             )
         }
-        .disabled(!settings.proactiveSuggestionEnabled && !settings.proactiveSuggestionEnabled)
+        .disabled(!settings.proactiveSuggestionEnabled)
 
         Section("제안 유형") {
             ForEach(SuggestionType.allCases, id: \.rawValue) { type in


### PR DESCRIPTION
## Summary
- C-1: DochiApp `proactiveSuggestionService` → `any ProactiveSuggestionServiceProtocol`
- C-2: `ProactiveSuggestionService.init`에서 `ConversationService()` 기본값 제거
- C-3: SettingsView tautological `.disabled` 조건 수정
- C-4: `ProactiveSuggestionService` 실서비스 단위 테스트 12건 추가
- S-2: `dismissSuggestionType` string switch → type switch
- S-6: 미사용 `llmService`/`keychainService` 파라미터 제거
- N-1: `DateFormatter` → `static let`

## Test plan
- [x] 빌드 성공
- [x] 1566 테스트 전체 통과 (known failure 1건 제외)
- [x] 새 ProactiveSuggestionServiceTests 12건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)