### PR TITLE
fix: #215 프로액티브 마스터 토글 disabled 결함 수정

### DIFF
--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -741,41 +741,43 @@ struct HeartbeatSettingsContent: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
-            HStack {
-                Text("유휴 감지: \(settings.proactiveSuggestionIdleMinutes)분")
-                Slider(
-                    value: Binding(
-                        get: { Double(settings.proactiveSuggestionIdleMinutes) },
-                        set: { settings.proactiveSuggestionIdleMinutes = Int($0.rounded()) }
-                    ),
-                    in: 5...120,
-                    step: 5
-                )
-            }
+            Group {
+                HStack {
+                    Text("유휴 감지: \(settings.proactiveSuggestionIdleMinutes)분")
+                    Slider(
+                        value: Binding(
+                            get: { Double(settings.proactiveSuggestionIdleMinutes) },
+                            set: { settings.proactiveSuggestionIdleMinutes = Int($0.rounded()) }
+                        ),
+                        in: 5...120,
+                        step: 5
+                    )
+                }
 
-            HStack {
-                Text("쿨다운: \(settings.proactiveSuggestionCooldownMinutes)분")
-                Slider(
-                    value: Binding(
-                        get: { Double(settings.proactiveSuggestionCooldownMinutes) },
-                        set: { settings.proactiveSuggestionCooldownMinutes = Int($0.rounded()) }
-                    ),
-                    in: 10...240,
-                    step: 10
-                )
-            }
+                HStack {
+                    Text("쿨다운: \(settings.proactiveSuggestionCooldownMinutes)분")
+                    Slider(
+                        value: Binding(
+                            get: { Double(settings.proactiveSuggestionCooldownMinutes) },
+                            set: { settings.proactiveSuggestionCooldownMinutes = Int($0.rounded()) }
+                        ),
+                        in: 10...240,
+                        step: 10
+                    )
+                }
 
-            Toggle("조용한 시간에 제안 중지", isOn: Binding(
-                get: { settings.proactiveSuggestionQuietHoursEnabled },
-                set: { settings.proactiveSuggestionQuietHoursEnabled = $0 }
-            ))
+                Toggle("조용한 시간에 제안 중지", isOn: Binding(
+                    get: { settings.proactiveSuggestionQuietHoursEnabled },
+                    set: { settings.proactiveSuggestionQuietHoursEnabled = $0 }
+                ))
+            }
+            .disabled(!settings.proactiveSuggestionEnabled)
         } header: {
             SettingsSectionHeader(
                 title: "프로액티브 제안",
                 helpContent: "사용자가 일정 시간 유휴 상태일 때, 칸반 진행 상황/메모리 기한/대화 주제 등을 기반으로 자동 제안합니다. 조용한 시간 설정은 하트비트와 공유합니다."
             )
         }
-        .disabled(!settings.proactiveSuggestionEnabled)
 
         Section("제안 유형") {
             ForEach(SuggestionType.allCases, id: \.rawValue) { type in


### PR DESCRIPTION
## UX 점검/기획
- 문제: 마스터 토글이 disabled 섹션에 포함되어 OFF 상태에서 재활성화가 불가능함
- 원칙: 마스터 토글은 항상 인터랙션 가능, 하위 옵션만 조건부 disabled

## 구현
- `HeartbeatSettingsContent`의 프로액티브 섹션에서 마스터 토글과 하위 제어 분리
- 하위 제어(`유휴 감지/쿨다운/조용한 시간`)에만 `.disabled(!settings.proactiveSuggestionEnabled)` 적용

## 테스트
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/SettingsSectionTests -only-testing:DochiTests/SettingsSearchTests -only-testing:DochiTests/SettingsSectionGroupTests`

## 이슈
- Closes #215
