### PR TITLE
refactor: #214 프로액티브 알림 정책 단일화

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -569,11 +569,12 @@ struct DochiApp: App {
 
     private var proactiveSuggestionNotificationTrigger: String {
         let suggestionId = viewModel.currentSuggestion?.id.uuidString ?? "none"
-        return "\(settings.notificationProactiveSuggestionEnabled)-\(suggestionId)"
+        return "\(settings.suggestionNotificationChannel)-\(suggestionId)"
     }
 
     private func syncProactiveSuggestionNotification() async {
-        guard settings.notificationProactiveSuggestionEnabled,
+        let channel = NotificationChannel(rawValue: settings.suggestionNotificationChannel) ?? .off
+        guard channel.deliversToApp,
               let suggestion = viewModel.currentSuggestion else { return }
         guard !NSApp.isActive else { return }
 

--- a/Dochi/App/NotificationManager.swift
+++ b/Dochi/App/NotificationManager.swift
@@ -183,7 +183,8 @@ final class NotificationManager: NSObject, Observable, UNUserNotificationCenterD
     }
 
     func sendProactiveSuggestionNotification(suggestion: ProactiveSuggestion) {
-        guard settings.notificationProactiveSuggestionEnabled else { return }
+        let channel = NotificationChannel(rawValue: settings.suggestionNotificationChannel) ?? .off
+        guard channel.deliversToApp else { return }
         sendNotification(
             title: "도치 - 프로액티브 제안",
             body: "\(suggestion.title)\n\(suggestion.body)",

--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -11,9 +11,19 @@ final class AppSettings {
     ]
 
     init() {
+        let defaults = UserDefaults.standard
+
         // Remove stale keys for settings that are no longer exposed or used.
         for key in Self.deprecatedKeys {
-            UserDefaults.standard.removeObject(forKey: key)
+            defaults.removeObject(forKey: key)
+        }
+
+        // Legacy migration: proactive suggestion app notification toggle -> channel policy.
+        // If channel key does not exist, preserve old boolean behavior.
+        if defaults.string(forKey: "suggestionNotificationChannel") == nil {
+            let legacyEnabled = defaults.object(forKey: "notificationProactiveSuggestionEnabled") as? Bool ?? false
+            let migrated: NotificationChannel = legacyEnabled ? .appOnly : .off
+            defaults.set(migrated.rawValue, forKey: "suggestionNotificationChannel")
         }
     }
 
@@ -591,8 +601,29 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(suggestionTypeCostEnabled, forKey: "suggestionTypeCostEnabled") }
     }
 
-    var notificationProactiveSuggestionEnabled: Bool = UserDefaults.standard.object(forKey: "notificationProactiveSuggestionEnabled") as? Bool ?? false {
-        didSet { UserDefaults.standard.set(notificationProactiveSuggestionEnabled, forKey: "notificationProactiveSuggestionEnabled") }
+    var notificationProactiveSuggestionEnabled: Bool {
+        get {
+            let channel = NotificationChannel(rawValue: suggestionNotificationChannel) ?? .off
+            return channel.deliversToApp
+        }
+        set {
+            let current = NotificationChannel(rawValue: suggestionNotificationChannel) ?? .off
+            switch (newValue, current) {
+            case (true, .telegramOnly):
+                suggestionNotificationChannel = NotificationChannel.both.rawValue
+            case (true, .off):
+                suggestionNotificationChannel = NotificationChannel.appOnly.rawValue
+            case (true, _):
+                break
+            case (false, .both):
+                suggestionNotificationChannel = NotificationChannel.telegramOnly.rawValue
+            case (false, .appOnly):
+                suggestionNotificationChannel = NotificationChannel.off.rawValue
+            case (false, _):
+                break
+            }
+            UserDefaults.standard.set(newValue, forKey: "notificationProactiveSuggestionEnabled")
+        }
     }
 
     var proactiveSuggestionMenuBarEnabled: Bool = UserDefaults.standard.object(forKey: "proactiveSuggestionMenuBarEnabled") as? Bool ?? true {
@@ -657,7 +688,7 @@ final class AppSettings {
 
     /// Proactive suggestion notification channel: appOnly / telegramOnly / both / off
     var suggestionNotificationChannel: String =
-        UserDefaults.standard.string(forKey: "suggestionNotificationChannel") ?? "appOnly" {
+        UserDefaults.standard.string(forKey: "suggestionNotificationChannel") ?? NotificationChannel.off.rawValue {
         didSet { UserDefaults.standard.set(suggestionNotificationChannel, forKey: "suggestionNotificationChannel") }
     }
 

--- a/Dochi/Models/NotificationChannel.swift
+++ b/Dochi/Models/NotificationChannel.swift
@@ -15,4 +15,12 @@ enum NotificationChannel: String, Codable, Sendable, CaseIterable {
         case .off: return "끄기"
         }
     }
+
+    var deliversToApp: Bool {
+        self == .appOnly || self == .both
+    }
+
+    var deliversToTelegram: Bool {
+        self == .telegramOnly || self == .both
+    }
 }

--- a/Dochi/Services/Telegram/TelegramProactiveRelay.swift
+++ b/Dochi/Services/Telegram/TelegramProactiveRelay.swift
@@ -109,7 +109,7 @@ final class TelegramProactiveRelay: TelegramProactiveRelayProtocol {
     // MARK: - Channel Logic
 
     func shouldSendToTelegram(channel: NotificationChannel) -> Bool {
-        guard channel == .telegramOnly || channel == .both else { return false }
+        guard channel.deliversToTelegram else { return false }
 
         if settings.telegramSkipWhenAppActive && NSApp.isActive {
             Log.telegram.debug("앱이 활성 상태이므로 텔레그램 전송 생략")

--- a/Dochi/Views/Settings/ProactiveSuggestionSettingsView.swift
+++ b/Dochi/Views/Settings/ProactiveSuggestionSettingsView.swift
@@ -145,18 +145,28 @@ struct ProactiveSuggestionSettingsView: View {
 
             // MARK: - Notification Settings
             Section("알림") {
-                Toggle("알림 센터에 제안 표시", isOn: Binding(
-                    get: { settings.notificationProactiveSuggestionEnabled },
-                    set: { settings.notificationProactiveSuggestionEnabled = $0 }
-                ))
+                Picker("제안 전달 채널", selection: Binding(
+                    get: { NotificationChannel(rawValue: settings.suggestionNotificationChannel) ?? .off },
+                    set: { settings.suggestionNotificationChannel = $0.rawValue }
+                )) {
+                    ForEach(NotificationChannel.allCases, id: \.self) { channel in
+                        Text(channel.displayName).tag(channel)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Text("앱만/텔레그램만/둘 다/끄기 중 하나의 정책으로 제안 전달 경로를 단일 제어합니다.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
                 Toggle("메뉴바에 제안 표시", isOn: Binding(
                     get: { settings.proactiveSuggestionMenuBarEnabled },
                     set: { settings.proactiveSuggestionMenuBarEnabled = $0 }
                 ))
 
-                if settings.notificationProactiveSuggestionEnabled || settings.proactiveSuggestionMenuBarEnabled {
-                    Text("새 제안이 생성되면 알림 센터 배너와 메뉴바 팝오버 상단 카드 노출을 각각 토글로 제어합니다.")
+                let channel = NotificationChannel(rawValue: settings.suggestionNotificationChannel) ?? .off
+                if channel != .off || settings.proactiveSuggestionMenuBarEnabled {
+                    Text("새 제안이 생성되면 선택한 채널 정책과 메뉴바 카드 설정에 따라 노출됩니다.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }


### PR DESCRIPTION
## UX 점검/기획
- 문제: 프로액티브 제안 알림이 bool 토글과 채널 설정으로 이원화되어 실제 전달 경로 예측이 어려웠음
- 원칙: 정책 소스 단일화(`suggestionNotificationChannel`) + UI/런타임 동일 규칙 적용

## 구현
- 정책 단일화
  - `NotificationChannel`에 `deliversToApp`, `deliversToTelegram` 추가
  - 앱 알림 전송/텔레그램 전송 판단 모두 채널 기반으로 통일
- 런타임 정렬
  - `DochiApp.syncProactiveSuggestionNotification()`가 채널 기준으로 앱 알림 전송
  - `NotificationManager.sendProactiveSuggestionNotification()`도 채널 기준으로 가드
- 설정 정렬
  - `ProactiveSuggestionSettingsView` 알림 섹션을 토글에서 채널 세그먼트로 변경
  - 메뉴바 노출 토글은 유지
- 호환성
  - `AppSettings` init에서 레거시 bool(`notificationProactiveSuggestionEnabled`)을 채널로 1회 마이그레이션
  - 기존 bool 프로퍼티는 채널 기반 computed로 유지(호환 레이어)

## 테스트
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/NotificationCenterTests -only-testing:DochiTests/TelegramProactiveRelayTests -only-testing:DochiTests/ProactiveSuggestionTests -only-testing:DochiTests/ProactiveSuggestionServiceTests`

## 이슈
- Closes #214
