### PR TITLE
feat: #212 프로액티브 일일 캡 실적용

### DIFF
--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -573,6 +573,10 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(proactiveSuggestionCooldownMinutes, forKey: "proactiveSuggestionCooldownMinutes") }
     }
 
+    var proactiveDailyCap: Int = UserDefaults.standard.object(forKey: "proactiveDailyCap") as? Int ?? 5 {
+        didSet { UserDefaults.standard.set(proactiveDailyCap, forKey: "proactiveDailyCap") }
+    }
+
     var proactiveSuggestionQuietHoursEnabled: Bool = UserDefaults.standard.object(forKey: "proactiveSuggestionQuietHoursEnabled") as? Bool ?? true {
         didSet { UserDefaults.standard.set(proactiveSuggestionQuietHoursEnabled, forKey: "proactiveSuggestionQuietHoursEnabled") }
     }

--- a/Dochi/Services/ProactiveSuggestionService.swift
+++ b/Dochi/Services/ProactiveSuggestionService.swift
@@ -148,6 +148,11 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
             todaySuggestionCount = 0
         }
 
+        if hasReachedDailyCap() {
+            state = .cooldown
+            return
+        }
+
         let elapsed = Date().timeIntervalSince(lastActivityDate)
         let idleThreshold = TimeInterval(settings.proactiveSuggestionIdleMinutes * 60)
         guard elapsed >= idleThreshold else { return }
@@ -173,6 +178,11 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
     // MARK: - Suggestion Generation
 
     private func generateSuggestion() async {
+        guard !hasReachedDailyCap() else {
+            state = .cooldown
+            return
+        }
+
         let enabledTypes = activeTypes()
         guard !enabledTypes.isEmpty else {
             state = .idle
@@ -377,6 +387,11 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
         if suggestionHistory.count > Self.maxHistoryCount {
             suggestionHistory = Array(suggestionHistory.prefix(Self.maxHistoryCount))
         }
+    }
+
+    private func hasReachedDailyCap() -> Bool {
+        let cap = max(settings.proactiveDailyCap, 0)
+        return todaySuggestionCount >= cap
     }
 
     private static let dayFormatter: DateFormatter = {

--- a/Dochi/Views/Settings/ProactiveSuggestionSettingsView.swift
+++ b/Dochi/Views/Settings/ProactiveSuggestionSettingsView.swift
@@ -130,6 +130,20 @@ struct ProactiveSuggestionSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
+                Stepper(
+                    value: Binding(
+                        get: { settings.proactiveDailyCap },
+                        set: { settings.proactiveDailyCap = min(max($0, 0), 20) }
+                    ),
+                    in: 0...20
+                ) {
+                    Text("일일 제안 한도: \(settings.proactiveDailyCap)개")
+                }
+
+                Text("하루 생성 가능한 제안 수를 제한합니다. 0이면 제안을 생성하지 않습니다.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 Toggle("조용한 시간 적용", isOn: Binding(
                     get: { settings.proactiveSuggestionQuietHoursEnabled },
                     set: { settings.proactiveSuggestionQuietHoursEnabled = $0 }

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -766,6 +766,16 @@ struct HeartbeatSettingsContent: View {
                     )
                 }
 
+                Stepper(
+                    value: Binding(
+                        get: { settings.proactiveDailyCap },
+                        set: { settings.proactiveDailyCap = min(max($0, 0), 20) }
+                    ),
+                    in: 0...20
+                ) {
+                    Text("일일 제안 한도: \(settings.proactiveDailyCap)개")
+                }
+
                 Toggle("조용한 시간에 제안 중지", isOn: Binding(
                     get: { settings.proactiveSuggestionQuietHoursEnabled },
                     set: { settings.proactiveSuggestionQuietHoursEnabled = $0 }

--- a/DochiTests/ProactiveSuggestionTests.swift
+++ b/DochiTests/ProactiveSuggestionTests.swift
@@ -258,6 +258,7 @@ final class ProactiveSuggestionTests: XCTestCase {
         _ = settings.proactiveSuggestionEnabled
         _ = settings.proactiveSuggestionIdleMinutes
         _ = settings.proactiveSuggestionCooldownMinutes
+        _ = settings.proactiveDailyCap
         _ = settings.proactiveSuggestionQuietHoursEnabled
         _ = settings.suggestionTypeNewsEnabled
         _ = settings.suggestionTypeDeepDiveEnabled
@@ -267,6 +268,15 @@ final class ProactiveSuggestionTests: XCTestCase {
         _ = settings.suggestionTypeCostEnabled
         _ = settings.notificationProactiveSuggestionEnabled
         _ = settings.proactiveSuggestionMenuBarEnabled
+    }
+
+    func testAppSettingsProactiveDailyCapPersistence() {
+        let settings = AppSettings()
+
+        settings.proactiveDailyCap = 7
+
+        XCTAssertEqual(settings.proactiveDailyCap, 7)
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "proactiveDailyCap") as? Int, 7)
     }
 
     // MARK: - SuggestionType Priority Tests


### PR DESCRIPTION
## UX 점검/기획
- 문제: `todaySuggestionCount`는 추적되지만 생성 제한에 연결되지 않아 과다 제안 가능성이 있음
- 원칙: 설정 가능한 일일 캡을 서비스 생성 경로에 강제 적용

## 구현
- `AppSettings`에 `proactiveDailyCap` 추가 (기본 5)
- `ProactiveSuggestionService`의 idle 체크/생성 경로에 일일 캡 가드 추가
  - 캡 도달 시 같은 날 신규 제안 생성 중단
  - 기존 날짜 변경 시 카운트 리셋 로직과 결합
- 설정 UI 노출
  - `ProactiveSuggestionSettingsView`에 일일 한도 Stepper 추가
  - `HeartbeatSettingsContent`의 프로액티브 섹션에도 동일 제어 추가

## 테스트
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ProactiveSuggestionTests -only-testing:DochiTests/ProactiveSuggestionServiceTests -only-testing:DochiTests/SettingsSectionTests`
- 추가: `testAppSettingsProactiveDailyCapPersistence`

## 이슈
- Closes #212
