### PR TITLE
feat: setup health score and recovery deep links (#211)

### DIFF
--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -24,6 +24,23 @@ enum OperatingProfile: String, CaseIterable, Codable, Sendable {
     }
 }
 
+struct SetupHealthIssue: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let detail: String
+    let sectionRawValue: String
+    let weight: Int
+}
+
+struct SetupHealthReport: Equatable, Sendable {
+    let score: Int
+    let issues: [SetupHealthIssue]
+
+    var primaryIssue: SetupHealthIssue? {
+        issues.max { lhs, rhs in lhs.weight < rhs.weight }
+    }
+}
+
 @MainActor
 @Observable
 final class AppSettings {
@@ -468,6 +485,79 @@ final class AppSettings {
 
     var currentTTSProvider: TTSProvider {
         TTSProvider(rawValue: ttsProvider) ?? .system
+    }
+
+    /// Ephemeral settings deep-link target; not persisted.
+    var pendingSettingsDeepLinkSection: String?
+
+    /// Setup completeness score for activation UX.
+    func setupHealthReport(hasProviderAPIKey: Bool) -> SetupHealthReport {
+        var issues: [SetupHealthIssue] = []
+
+        if currentProvider.requiresAPIKey && !hasProviderAPIKey {
+            issues.append(
+                SetupHealthIssue(
+                    id: "api_key_missing",
+                    title: "API 키 설정 필요",
+                    detail: "\(currentProvider.rawValue.uppercased()) API 키가 없어 응답 생성이 제한됩니다.",
+                    sectionRawValue: "api-key",
+                    weight: 40
+                )
+            )
+        }
+
+        let supabaseURLMissing = supabaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let supabaseKeyMissing = supabaseAnonKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        if autoSyncEnabled && (supabaseURLMissing || supabaseKeyMissing) {
+            issues.append(
+                SetupHealthIssue(
+                    id: "sync_config_missing",
+                    title: "동기화 연동 설정 필요",
+                    detail: "자동 동기화가 켜져 있지만 Supabase 설정이 비어 있습니다.",
+                    sectionRawValue: "account",
+                    weight: 20
+                )
+            )
+        }
+
+        if proactiveSuggestionEnabled && suggestionNotificationChannel == NotificationChannel.off.rawValue {
+            issues.append(
+                SetupHealthIssue(
+                    id: "proactive_channel_off",
+                    title: "프로액티브 알림 채널 비활성",
+                    detail: "프로액티브 제안은 켜져 있으나 전달 채널이 꺼져 있습니다.",
+                    sectionRawValue: "proactive-suggestion",
+                    weight: 15
+                )
+            )
+        }
+
+        if heartbeatEnabled && heartbeatNotificationChannel == NotificationChannel.off.rawValue {
+            issues.append(
+                SetupHealthIssue(
+                    id: "heartbeat_channel_off",
+                    title: "하트비트 알림 채널 비활성",
+                    detail: "하트비트는 켜져 있으나 알림 채널이 꺼져 있습니다.",
+                    sectionRawValue: "heartbeat",
+                    weight: 15
+                )
+            )
+        }
+
+        if defaultUserId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            issues.append(
+                SetupHealthIssue(
+                    id: "default_user_missing",
+                    title: "기본 사용자 프로필 필요",
+                    detail: "가족/사용자 컨텍스트가 없어 개인화 품질이 낮아질 수 있습니다.",
+                    sectionRawValue: "family",
+                    weight: 10
+                )
+            )
+        }
+
+        let penalty = min(100, issues.reduce(0) { $0 + $1.weight })
+        return SetupHealthReport(score: max(0, 100 - penalty), issues: issues)
     }
 
     // MARK: - Memory Consolidation (I-2)

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -2675,6 +2675,13 @@ final class DochiViewModel {
 
     // MARK: - API Key Management
 
+    var setupHealthReport: SetupHealthReport {
+        let provider = settings.currentProvider
+        let hasKey = !loadAPIKey(for: provider).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasProviderAPIKey = !provider.requiresAPIKey || hasKey
+        return settings.setupHealthReport(hasProviderAPIKey: hasProviderAPIKey)
+    }
+
     func loadAPIKey(for provider: LLMProvider) -> String {
         keychainService.load(account: provider.keychainAccount) ?? ""
     }

--- a/Dochi/Views/ContentView.swift
+++ b/Dochi/Views/ContentView.swift
@@ -440,6 +440,17 @@ struct ContentView: View {
                 )
             }
 
+            let setupHealth = viewModel.setupHealthReport
+            if let primaryIssue = setupHealth.primaryIssue {
+                SetupRecoveryBannerView(
+                    score: setupHealth.score,
+                    issue: primaryIssue,
+                    onOpenSettings: {
+                        openSettings(sectionRawValue: primaryIssue.sectionRawValue)
+                    }
+                )
+            }
+
             // Tool confirmation banner
             if let confirmation = viewModel.pendingToolConfirmation {
                 ToolConfirmationBannerView(
@@ -732,6 +743,13 @@ struct ContentView: View {
 
     // MARK: - Palette Action Execution
 
+    private func openSettings(sectionRawValue: String? = nil) {
+        if let sectionRawValue {
+            viewModel.settings.pendingSettingsDeepLinkSection = sectionRawValue
+        }
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+
     private func executePaletteAction(_ action: CommandPaletteItem.PaletteAction) {
         viewModel.recordUserActivity()
 
@@ -745,7 +763,7 @@ struct ContentView: View {
             viewModel.switchAgent(name: name)
         case .openSettings:
             // macOS handles ⌘, natively via Settings scene
-            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            openSettings()
         case .openContextInspector:
             showContextInspector = true
         case .openMemoryPanel:
@@ -780,15 +798,15 @@ struct ContentView: View {
             HintManager.shared.resetAllHints()
         case .openQuickModelPopover:
             showQuickModelPopover = true
-        case .openSettingsSection:
+        case .openSettingsSection(let section):
             // Open settings window (the section deep-link is handled by Settings scene)
-            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            openSettings(sectionRawValue: section)
         case .syncNow:
             Task { await viewModel.syncEngine?.sync() }
         case .syncConflicts:
             showSyncConflictSheet = true
         case .cloudAccountSettings:
-            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            openSettings(sectionRawValue: SettingsSection.account.rawValue)
         case .rebuildSpotlightIndex:
             if let indexer = viewModel.spotlightIndexer {
                 Task {
@@ -806,7 +824,7 @@ struct ContentView: View {
         case .memoryChangeHistory:
             showMemoryDiffSheet = true
         case .memorySettings:
-            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            openSettings(sectionRawValue: SettingsSection.memory.rawValue)
         case .reindexDocuments:
             if let indexer = viewModel.documentIndexer {
                 Task { await indexer.reindexAll() }
@@ -1252,6 +1270,41 @@ struct StatusBarView: View {
         case .idle:
             return ""
         }
+    }
+}
+
+// MARK: - Setup Recovery Banner
+
+struct SetupRecoveryBannerView: View {
+    let score: Int
+    let issue: SetupHealthIssue
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "wrench.and.screwdriver.fill")
+                .foregroundStyle(.orange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Setup Health \(score)/100 · \(issue.title)")
+                    .font(.system(size: 12, weight: .semibold))
+                Text(issue.detail)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            Button("지금 복구") {
+                onOpenSettings()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.orange.opacity(0.08))
     }
 }
 

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -40,6 +40,12 @@ struct SettingsView: View {
         .navigationSplitViewColumnWidth(min: 180, ideal: 180, max: 180)
         .frame(minWidth: 680, minHeight: 440)
         .frame(idealWidth: 780, idealHeight: 540)
+        .onAppear {
+            applyPendingDeepLinkIfNeeded()
+        }
+        .onChange(of: settings.pendingSettingsDeepLinkSection) { _, _ in
+            applyPendingDeepLinkIfNeeded()
+        }
     }
 
     // MARK: - Content Router
@@ -218,6 +224,13 @@ struct SettingsView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func applyPendingDeepLinkIfNeeded() {
+        guard let raw = settings.pendingSettingsDeepLinkSection else { return }
+        defer { settings.pendingSettingsDeepLinkSection = nil }
+        guard let section = SettingsSection(rawValue: raw) else { return }
+        selectedSection = section
     }
 }
 

--- a/DochiTests/ModelTests.swift
+++ b/DochiTests/ModelTests.swift
@@ -442,6 +442,55 @@ final class ModelTests: XCTestCase {
 
         XCTAssertEqual(settings.operatingProfile, OperatingProfile.familyHomeAssistant.rawValue)
     }
+
+    @MainActor
+    func testSetupHealthReportPerfectScoreWhenCoreSetupIsReady() {
+        let settings = AppSettings()
+        settings.autoSyncEnabled = false
+        settings.defaultUserId = "user-1"
+        settings.proactiveSuggestionEnabled = false
+        settings.heartbeatEnabled = false
+
+        let report = settings.setupHealthReport(hasProviderAPIKey: true)
+
+        XCTAssertEqual(report.score, 100)
+        XCTAssertTrue(report.issues.isEmpty)
+        XCTAssertNil(report.primaryIssue)
+    }
+
+    @MainActor
+    func testSetupHealthReportFlagsMissingAPIKey() {
+        let settings = AppSettings()
+        settings.llmProvider = LLMProvider.openai.rawValue
+        settings.autoSyncEnabled = false
+        settings.defaultUserId = "user-1"
+        settings.proactiveSuggestionEnabled = false
+        settings.heartbeatEnabled = false
+
+        let report = settings.setupHealthReport(hasProviderAPIKey: false)
+
+        XCTAssertTrue(report.issues.contains { $0.id == "api_key_missing" })
+        XCTAssertEqual(report.primaryIssue?.sectionRawValue, "api-key")
+        XCTAssertLessThan(report.score, 100)
+    }
+
+    @MainActor
+    func testSetupHealthReportFlagsMissingSyncConfiguration() {
+        let settings = AppSettings()
+        settings.llmProvider = LLMProvider.ollama.rawValue
+        settings.autoSyncEnabled = true
+        settings.supabaseURL = ""
+        settings.supabaseAnonKey = ""
+        settings.defaultUserId = "user-1"
+        settings.proactiveSuggestionEnabled = false
+        settings.heartbeatEnabled = false
+
+        let report = settings.setupHealthReport(hasProviderAPIKey: true)
+
+        XCTAssertTrue(report.issues.contains { $0.id == "sync_config_missing" })
+        XCTAssertEqual(report.primaryIssue?.sectionRawValue, "account")
+        XCTAssertLessThan(report.score, 100)
+    }
 }
 
 // MARK: - TaskComplexityClassifier Tests


### PR DESCRIPTION
## Summary
- add `SetupHealthReport` and `SetupHealthIssue` scoring in `AppSettings` to measure setup readiness
- expose setup health via `DochiViewModel` and render a recovery banner in `ContentView` when a primary issue exists
- support settings deep-links with `pendingSettingsDeepLinkSection` so recovery CTAs open the right settings section
- route command palette settings actions through the same deep-link path (including explicit section opens)
- clear pending deep-link values safely in `SettingsView` and add model tests for setup scoring scenarios

## UX/Spec Impact
- supports proactive onboarding issue #211 by replacing passive idle state with actionable setup recovery guidance

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ModelTests -only-testing:DochiTests/SettingsSectionTests -only-testing:DochiTests/SettingsSectionGroupTests`

Closes #211
