### PR TITLE
feat: add heartbeat task opportunities and quick actions (#217)

### DIFF
--- a/Dochi/Models/TaskOpportunity.swift
+++ b/Dochi/Models/TaskOpportunity.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+enum TaskOpportunitySource: String, Codable, Sendable {
+    case calendar
+    case kanban
+    case reminder
+    case memory
+}
+
+enum TaskOpportunityActionKind: String, Codable, Sendable {
+    case createReminder
+    case createKanbanCard
+
+    var buttonTitle: String {
+        switch self {
+        case .createReminder: return "미리알림 등록"
+        case .createKanbanCard: return "칸반 등록"
+        }
+    }
+}
+
+struct TaskOpportunity: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    let source: TaskOpportunitySource
+    let title: String
+    let detail: String
+    let actionKind: TaskOpportunityActionKind
+    let suggestedTitle: String
+    let suggestedNotes: String?
+    let dueDateISO8601: String?
+    let boardName: String?
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        source: TaskOpportunitySource,
+        title: String,
+        detail: String,
+        actionKind: TaskOpportunityActionKind,
+        suggestedTitle: String,
+        suggestedNotes: String? = nil,
+        dueDateISO8601: String? = nil,
+        boardName: String? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.source = source
+        self.title = title
+        self.detail = detail
+        self.actionKind = actionKind
+        self.suggestedTitle = suggestedTitle
+        self.suggestedNotes = suggestedNotes
+        self.dueDateISO8601 = dueDateISO8601
+        self.boardName = boardName
+        self.createdAt = createdAt
+    }
+}
+
+struct TaskOpportunityActionFeedback: Equatable, Sendable {
+    let opportunityId: UUID
+    let isSuccess: Bool
+    let message: String
+}

--- a/Dochi/Services/HeartbeatService.swift
+++ b/Dochi/Services/HeartbeatService.swift
@@ -9,6 +9,23 @@ struct HeartbeatTickResult: Sendable {
     let itemsFound: Int
     let notificationSent: Bool
     let error: String?
+    let opportunities: [TaskOpportunity]
+
+    init(
+        timestamp: Date,
+        checksPerformed: [String],
+        itemsFound: Int,
+        notificationSent: Bool,
+        error: String?,
+        opportunities: [TaskOpportunity] = []
+    ) {
+        self.timestamp = timestamp
+        self.checksPerformed = checksPerformed
+        self.itemsFound = itemsFound
+        self.notificationSent = notificationSent
+        self.error = error
+        self.opportunities = opportunities
+    }
 }
 
 /// Heartbeat-based proactive agent service.
@@ -193,6 +210,13 @@ final class HeartbeatService: Observable {
             Log.app.error("HeartbeatService tick error: \(error.localizedDescription)")
         }
 
+        let opportunities = mapTaskOpportunities(
+            calendarContext: calendarContext,
+            kanbanContext: kanbanContext,
+            reminderContext: reminderContext,
+            memoryWarning: memoryWarning
+        )
+
         let notificationSent: Bool
         let itemsFound = contextParts.count
 
@@ -246,7 +270,8 @@ final class HeartbeatService: Observable {
             checksPerformed: checksPerformed,
             itemsFound: itemsFound,
             notificationSent: notificationSent,
-            error: errorMessage
+            error: errorMessage,
+            opportunities: opportunities
         )
         lastTickDate = result.timestamp
         lastTickResult = result
@@ -341,6 +366,117 @@ final class HeartbeatService: Observable {
         }
 
         return warnings.isEmpty ? nil : warnings.joined(separator: "\n")
+    }
+
+    // MARK: - Task Opportunity Mapping (D1)
+
+    func mapTaskOpportunities(
+        calendarContext: String,
+        kanbanContext: String,
+        reminderContext: String,
+        memoryWarning: String?
+    ) -> [TaskOpportunity] {
+        var opportunities: [TaskOpportunity] = []
+
+        let calendarLines = normalizedLines(from: calendarContext)
+        for line in calendarLines.prefix(2) {
+            opportunities.append(
+                TaskOpportunity(
+                    source: .calendar,
+                    title: "다가오는 일정 준비",
+                    detail: line,
+                    actionKind: .createReminder,
+                    suggestedTitle: "일정 준비: \(line)",
+                    suggestedNotes: "Heartbeat 일정 점검에서 제안된 작업입니다."
+                )
+            )
+        }
+
+        let kanbanLines = normalizedLines(from: kanbanContext)
+        for line in kanbanLines.prefix(2) {
+            let parsed = parseKanbanContextLine(line)
+            opportunities.append(
+                TaskOpportunity(
+                    source: .kanban,
+                    title: "칸반 후속 리마인더",
+                    detail: line,
+                    actionKind: .createReminder,
+                    suggestedTitle: "\(parsed.cardTitle) 확인",
+                    suggestedNotes: parsed.boardName.map { "보드: \($0)" }
+                )
+            )
+        }
+
+        let reminderLines = normalizedLines(from: reminderContext)
+        for line in reminderLines.prefix(2) {
+            let reminderTitle = parseReminderTitle(line)
+            opportunities.append(
+                TaskOpportunity(
+                    source: .reminder,
+                    title: "미리알림을 칸반으로 등록",
+                    detail: line,
+                    actionKind: .createKanbanCard,
+                    suggestedTitle: reminderTitle,
+                    suggestedNotes: "원본 미리알림: \(line)",
+                    boardName: defaultBoardName()
+                )
+            )
+        }
+
+        if let memoryWarning, !memoryWarning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            opportunities.append(
+                TaskOpportunity(
+                    source: .memory,
+                    title: "메모리 정리 작업 등록",
+                    detail: memoryWarning,
+                    actionKind: .createKanbanCard,
+                    suggestedTitle: "메모리 정리 점검",
+                    suggestedNotes: memoryWarning,
+                    boardName: defaultBoardName()
+                )
+            )
+        }
+
+        return Array(opportunities.prefix(4))
+    }
+
+    private func normalizedLines(from context: String) -> [String] {
+        context
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private func parseReminderTitle(_ line: String) -> String {
+        if let range = line.range(of: " (마감:") {
+            return String(line[..<range.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return line
+    }
+
+    private func parseKanbanContextLine(_ line: String) -> (cardTitle: String, boardName: String?) {
+        var working = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        if working.hasPrefix("- ") {
+            working.removeFirst(2)
+        }
+
+        var boardName: String?
+        if let open = working.lastIndex(of: "["), let close = working.lastIndex(of: "]"), open < close {
+            boardName = String(working[working.index(after: open)..<close]).trimmingCharacters(in: .whitespacesAndNewlines)
+            working = String(working[..<open]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let tokens = working.split(separator: " ").map(String.init)
+        if let first = tokens.first, first.rangeOfCharacter(from: .alphanumerics) == nil {
+            working = tokens.dropFirst().joined(separator: " ")
+        }
+
+        let cardTitle = working.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (cardTitle.isEmpty ? line : cardTitle, boardName)
+    }
+
+    private func defaultBoardName() -> String? {
+        KanbanManager.shared.listBoards().first?.name
     }
 
     // MARK: - Message Composition

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -96,6 +96,13 @@ final class DochiViewModel {
     private(set) var proactiveSuggestionService: ProactiveSuggestionServiceProtocol?
     var showSuggestionHistory: Bool = false
 
+    // MARK: - Task Opportunity (D1)
+    private(set) var completedTaskOpportunityIDs: Set<UUID> = []
+    var taskOpportunityActionInFlightID: UUID?
+    var taskOpportunityActionFeedback: TaskOpportunityActionFeedback?
+    var reminderOpportunityExecutor: ((TaskOpportunity) async -> ToolResult)?
+    var kanbanOpportunityExecutor: ((TaskOpportunity) -> Bool)?
+
     // MARK: - Interest Discovery (K-3)
     private(set) var interestDiscoveryService: InterestDiscoveryServiceProtocol?
 
@@ -445,6 +452,101 @@ final class DochiViewModel {
         guard let service = proactiveSuggestionService else { return }
         service.isPaused.toggle()
         Log.app.info("Proactive suggestion \(service.isPaused ? "paused" : "resumed")")
+    }
+
+    func executeTaskOpportunity(_ opportunity: TaskOpportunity) {
+        taskOpportunityActionInFlightID = opportunity.id
+
+        Task { @MainActor in
+            let feedback = await performTaskOpportunity(opportunity)
+            taskOpportunityActionInFlightID = nil
+            taskOpportunityActionFeedback = feedback
+
+            if feedback.isSuccess {
+                completedTaskOpportunityIDs.insert(opportunity.id)
+            } else {
+                errorMessage = feedback.message
+            }
+
+            let opportunityId = opportunity.id
+            try? await Task.sleep(for: .seconds(3))
+            if taskOpportunityActionFeedback?.opportunityId == opportunityId {
+                taskOpportunityActionFeedback = nil
+            }
+        }
+    }
+
+    private func performTaskOpportunity(_ opportunity: TaskOpportunity) async -> TaskOpportunityActionFeedback {
+        switch opportunity.actionKind {
+        case .createReminder:
+            let result: ToolResult
+            if let reminderOpportunityExecutor {
+                result = await reminderOpportunityExecutor(opportunity)
+            } else {
+                result = await registerReminderFromOpportunity(opportunity)
+            }
+
+            return TaskOpportunityActionFeedback(
+                opportunityId: opportunity.id,
+                isSuccess: !result.isError,
+                message: result.content
+            )
+
+        case .createKanbanCard:
+            let isSuccess: Bool
+            if let kanbanOpportunityExecutor {
+                isSuccess = kanbanOpportunityExecutor(opportunity)
+            } else {
+                isSuccess = registerKanbanFromOpportunity(opportunity)
+            }
+
+            let message: String
+            if isSuccess {
+                message = "칸반에 '\(opportunity.suggestedTitle)' 항목을 등록했습니다."
+            } else {
+                message = "칸반 등록에 실패했습니다. 보드/컬럼 설정을 확인해주세요."
+            }
+
+            return TaskOpportunityActionFeedback(
+                opportunityId: opportunity.id,
+                isSuccess: isSuccess,
+                message: message
+            )
+        }
+    }
+
+    private func registerReminderFromOpportunity(_ opportunity: TaskOpportunity) async -> ToolResult {
+        var arguments: [String: Any] = [
+            "title": opportunity.suggestedTitle
+        ]
+        if let notes = opportunity.suggestedNotes, !notes.isEmpty {
+            arguments["notes"] = notes
+        }
+        if let dueDate = opportunity.dueDateISO8601, !dueDate.isEmpty {
+            arguments["due_date"] = dueDate
+        }
+
+        let tool = CreateReminderTool()
+        return await tool.execute(arguments: arguments)
+    }
+
+    private func registerKanbanFromOpportunity(_ opportunity: TaskOpportunity) -> Bool {
+        let targetBoardName: String
+        if let boardName = opportunity.boardName?.trimmingCharacters(in: .whitespacesAndNewlines), !boardName.isEmpty {
+            targetBoardName = boardName
+        } else {
+            targetBoardName = "기본 보드"
+        }
+
+        let board = KanbanManager.shared.board(name: targetBoardName) ?? KanbanManager.shared.createBoard(name: targetBoardName)
+        let description = opportunity.suggestedNotes ?? "Heartbeat opportunity"
+
+        return KanbanManager.shared.addCard(
+            boardId: board.id,
+            title: opportunity.suggestedTitle,
+            priority: .medium,
+            description: description
+        ) != nil
     }
 
     func dismissScheduleExecutionBanner() {

--- a/Dochi/Views/ContentView.swift
+++ b/Dochi/Views/ContentView.swift
@@ -554,12 +554,45 @@ struct ContentView: View {
             }
 
             // K-2: Proactive suggestion bubble
+            let heartbeatOpportunities = recentHeartbeatOpportunities
             if let suggestion = viewModel.currentSuggestion {
                 SuggestionBubbleView(
                     suggestion: suggestion,
                     onAccept: { withAnimation(.easeOut(duration: 0.25)) { viewModel.acceptSuggestion(suggestion) } },
                     onDefer: { withAnimation(.easeOut(duration: 0.25)) { viewModel.deferSuggestion(suggestion) } },
-                    onDismissType: { withAnimation(.easeOut(duration: 0.25)) { viewModel.dismissSuggestionType(suggestion) } }
+                    onDismissType: { withAnimation(.easeOut(duration: 0.25)) { viewModel.dismissSuggestionType(suggestion) } },
+                    opportunities: heartbeatOpportunities,
+                    opportunityActionInFlightID: viewModel.taskOpportunityActionInFlightID,
+                    opportunityActionFeedback: viewModel.taskOpportunityActionFeedback,
+                    onOpportunityAction: { opportunity in
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            viewModel.executeTaskOpportunity(opportunity)
+                        }
+                    }
+                )
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            } else if !heartbeatOpportunities.isEmpty {
+                SuggestionBubbleView(
+                    suggestion: ProactiveSuggestion(
+                        type: .kanbanCheck,
+                        title: "하트비트 할거리 제안",
+                        body: "점검 결과를 바로 미리알림/칸반에 등록할 수 있습니다.",
+                        suggestedPrompt: ""
+                    ),
+                    onAccept: {},
+                    onDefer: {},
+                    onDismissType: {},
+                    opportunities: heartbeatOpportunities,
+                    opportunityActionInFlightID: viewModel.taskOpportunityActionInFlightID,
+                    opportunityActionFeedback: viewModel.taskOpportunityActionFeedback,
+                    onOpportunityAction: { opportunity in
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            viewModel.executeTaskOpportunity(opportunity)
+                        }
+                    },
+                    showsSuggestionActions: false
                 )
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
@@ -742,6 +775,12 @@ struct ContentView: View {
     }
 
     // MARK: - Palette Action Execution
+
+    private var recentHeartbeatOpportunities: [TaskOpportunity] {
+        guard let result = heartbeatService?.lastTickResult else { return [] }
+        guard Date().timeIntervalSince(result.timestamp) <= 30 * 60 else { return [] }
+        return result.opportunities.filter { !viewModel.completedTaskOpportunityIDs.contains($0.id) }
+    }
 
     private func openSettings(sectionRawValue: String? = nil) {
         if let sectionRawValue {

--- a/Dochi/Views/SuggestionBubbleView.swift
+++ b/Dochi/Views/SuggestionBubbleView.swift
@@ -12,8 +12,35 @@ struct SuggestionBubbleView: View {
     let onAccept: () -> Void
     let onDefer: () -> Void
     let onDismissType: () -> Void
+    let opportunities: [TaskOpportunity]
+    let opportunityActionInFlightID: UUID?
+    let opportunityActionFeedback: TaskOpportunityActionFeedback?
+    let onOpportunityAction: (TaskOpportunity) -> Void
+    let showsSuggestionActions: Bool
 
     @State private var showDismissConfirmation = false
+
+    init(
+        suggestion: ProactiveSuggestion,
+        onAccept: @escaping () -> Void,
+        onDefer: @escaping () -> Void,
+        onDismissType: @escaping () -> Void,
+        opportunities: [TaskOpportunity] = [],
+        opportunityActionInFlightID: UUID? = nil,
+        opportunityActionFeedback: TaskOpportunityActionFeedback? = nil,
+        onOpportunityAction: @escaping (TaskOpportunity) -> Void = { _ in },
+        showsSuggestionActions: Bool = true
+    ) {
+        self.suggestion = suggestion
+        self.onAccept = onAccept
+        self.onDefer = onDefer
+        self.onDismissType = onDismissType
+        self.opportunities = opportunities
+        self.opportunityActionInFlightID = opportunityActionInFlightID
+        self.opportunityActionFeedback = opportunityActionFeedback
+        self.onOpportunityAction = onOpportunityAction
+        self.showsSuggestionActions = showsSuggestionActions
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -49,32 +76,38 @@ struct SuggestionBubbleView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(3)
 
+                if !opportunities.isEmpty {
+                    opportunityList
+                }
+
                 // Action buttons
-                HStack(spacing: 8) {
-                    Button {
-                        onAccept()
-                    } label: {
-                        Label("수락", systemImage: "checkmark")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
+                if showsSuggestionActions {
+                    HStack(spacing: 8) {
+                        Button {
+                            onAccept()
+                        } label: {
+                            Label("수락", systemImage: "checkmark")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
 
-                    Button("나중에") {
-                        onDefer()
-                    }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                        Button("나중에") {
+                            onDefer()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
 
-                    Spacer()
+                        Spacer()
 
-                    Button("이런 제안 그만") {
-                        showDismissConfirmation = true
-                    }
-                    .buttonStyle(.plain)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .popover(isPresented: $showDismissConfirmation) {
-                        dismissConfirmationPopover
+                        Button("이런 제안 그만") {
+                            showDismissConfirmation = true
+                        }
+                        .buttonStyle(.plain)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .popover(isPresented: $showDismissConfirmation) {
+                            dismissConfirmationPopover
+                        }
                     }
                 }
             }
@@ -116,6 +149,58 @@ struct SuggestionBubbleView: View {
         case "green": return .green
         case "red": return .red
         default: return .gray
+        }
+    }
+
+    // MARK: - Opportunity Actions
+
+    private var opportunityList: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("지금 바로 등록")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            ForEach(opportunities.prefix(3)) { opportunity in
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(alignment: .top, spacing: 8) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(opportunity.title)
+                                .font(.system(size: 12, weight: .semibold))
+                            Text(opportunity.detail)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+
+                        Spacer()
+
+                        if opportunityActionInFlightID == opportunity.id {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Button(opportunity.actionKind.buttonTitle) {
+                                onOpportunityAction(opportunity)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+                    }
+
+                    if let feedback = opportunityActionFeedback, feedback.opportunityId == opportunity.id {
+                        HStack(spacing: 4) {
+                            Image(systemName: feedback.isSuccess ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                                .foregroundStyle(feedback.isSuccess ? .green : .orange)
+                            Text(feedback.message)
+                                .font(.system(size: 10))
+                                .foregroundStyle(feedback.isSuccess ? .green : .orange)
+                                .lineLimit(2)
+                        }
+                    }
+                }
+                .padding(8)
+                .background(Color.secondary.opacity(0.06))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
         }
     }
 

--- a/DochiTests/HeartbeatServiceTests.swift
+++ b/DochiTests/HeartbeatServiceTests.swift
@@ -4,6 +4,26 @@ import XCTest
 @MainActor
 final class HeartbeatServiceTests: XCTestCase {
 
+    private func makeViewModelForOpportunityTests() -> DochiViewModel {
+        let contextService = MockContextService()
+        let settings = AppSettings()
+        let keychainService = MockKeychainService()
+        keychainService.store["openai_api_key"] = "sk-test"
+
+        return DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: contextService,
+            conversationService: MockConversationService(),
+            keychainService: keychainService,
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: SessionContext(workspaceId: UUID())
+        )
+    }
+
     // MARK: - HeartbeatTickResult
 
     func testTickResultStoresAllFields() {
@@ -45,6 +65,37 @@ final class HeartbeatServiceTests: XCTestCase {
 
     func testMaxHistoryCount() {
         XCTAssertEqual(HeartbeatService.maxHistoryCount, 20)
+    }
+
+    func testMapTaskOpportunitiesBuildsStructuredActions() {
+        let settings = AppSettings()
+        let service = HeartbeatService(settings: settings)
+
+        let opportunities = service.mapTaskOpportunities(
+            calendarContext: "오전 9:00 팀 스탠드업",
+            kanbanContext: "- 🔥 배포 체크 [제품 운영]",
+            reminderContext: "계약서 확인 (마감: 오후 3:00)",
+            memoryWarning: nil
+        )
+
+        XCTAssertGreaterThanOrEqual(opportunities.count, 3)
+        XCTAssertTrue(opportunities.contains { $0.actionKind == .createReminder })
+        XCTAssertTrue(opportunities.contains { $0.actionKind == .createKanbanCard })
+        XCTAssertTrue(opportunities.allSatisfy { !$0.suggestedTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+    }
+
+    func testMapTaskOpportunitiesCapsResultSize() {
+        let settings = AppSettings()
+        let service = HeartbeatService(settings: settings)
+
+        let opportunities = service.mapTaskOpportunities(
+            calendarContext: "a\nb\nc",
+            kanbanContext: "- x [A]\n- y [B]\n- z [C]",
+            reminderContext: "r1 (마감: 10:00)\nr2 (마감: 11:00)\nr3 (마감: 12:00)",
+            memoryWarning: "메모리 경고"
+        )
+
+        XCTAssertEqual(opportunities.count, 4)
     }
 
     // MARK: - Start/Stop
@@ -223,5 +274,56 @@ final class HeartbeatServiceTests: XCTestCase {
         viewModel.injectProactiveMessage("no conversation")
         // Should not crash
         XCTAssertNil(viewModel.currentConversation)
+    }
+
+    func testExecuteTaskOpportunityTriggersKanbanActionAndShowsSuccessFeedback() async {
+        let viewModel = makeViewModelForOpportunityTests()
+        let opportunity = TaskOpportunity(
+            source: .reminder,
+            title: "칸반 등록",
+            detail: "테스트",
+            actionKind: .createKanbanCard,
+            suggestedTitle: "테스트 작업"
+        )
+
+        let called = expectation(description: "kanban action called")
+        viewModel.kanbanOpportunityExecutor = { _ in
+            called.fulfill()
+            return true
+        }
+
+        viewModel.executeTaskOpportunity(opportunity)
+        await fulfillment(of: [called], timeout: 1.0)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(viewModel.taskOpportunityActionFeedback?.opportunityId, opportunity.id)
+        XCTAssertEqual(viewModel.taskOpportunityActionFeedback?.isSuccess, true)
+        XCTAssertTrue(viewModel.completedTaskOpportunityIDs.contains(opportunity.id))
+    }
+
+    func testExecuteTaskOpportunityFailureShowsErrorFeedback() async {
+        let viewModel = makeViewModelForOpportunityTests()
+        let opportunity = TaskOpportunity(
+            source: .calendar,
+            title: "미리알림 등록",
+            detail: "테스트",
+            actionKind: .createReminder,
+            suggestedTitle: "테스트 리마인더"
+        )
+
+        let called = expectation(description: "reminder action called")
+        viewModel.reminderOpportunityExecutor = { _ in
+            called.fulfill()
+            return ToolResult(toolCallId: "", content: "미리알림 생성 실패", isError: true)
+        }
+
+        viewModel.executeTaskOpportunity(opportunity)
+        await fulfillment(of: [called], timeout: 1.0)
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(viewModel.taskOpportunityActionFeedback?.opportunityId, opportunity.id)
+        XCTAssertEqual(viewModel.taskOpportunityActionFeedback?.isSuccess, false)
+        XCTAssertEqual(viewModel.errorMessage, "미리알림 생성 실패")
+        XCTAssertFalse(viewModel.completedTaskOpportunityIDs.contains(opportunity.id))
     }
 }


### PR DESCRIPTION
## Summary
- add `TaskOpportunity` model and action metadata for heartbeat-driven action conversion
- extend `HeartbeatTickResult` with structured `opportunities` and map calendar/kanban/reminder/memory contexts into action-ready items
- wire `SuggestionBubbleView` with opportunity CTA buttons (`미리알림 등록` / `칸반 등록`) plus in-bubble success/failure feedback
- add `DochiViewModel.executeTaskOpportunity` action pipeline with live state (`inFlight`, feedback, completed IDs)
- surface heartbeat-only opportunity bubble fallback when no proactive suggestion is currently shown

## UX/Spec Impact
- implements #217 by turning heartbeat output into immediate action affordances instead of passive notifications only

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/HeartbeatServiceTests -only-testing:DochiTests/ProactiveSuggestionTests -only-testing:DochiTests/SettingsSectionTests`

Closes #217
