### PR TITLE
feat: add advanced Typecast TTS settings and voice controls

### DIFF
--- a/Dochi/Models/AppGuideContent.swift
+++ b/Dochi/Models/AppGuideContent.swift
@@ -232,7 +232,7 @@ enum AppGuideContentBuilder {
             GuideItem(title: "일반", description: "글꼴 크기, 상호작용 모드, 웨이크워드, 아바타, 하트비트 설정", shortcut: "⌘,", category: "설정", example: nil),
             GuideItem(title: "AI 모델", description: "LLM 프로바이더 선택, 컨텍스트 크기, 용도별 모델 라우팅 (자동 선택)", shortcut: nil, category: "설정", example: "모델 바꿔줘"),
             GuideItem(title: "API 키", description: "프로바이더별 API 키 관리 (macOS 키체인 암호화 저장)", shortcut: nil, category: "설정", example: nil),
-            GuideItem(title: "음성", description: "TTS 프로바이더 선택 (시스템/Google Cloud/Supertonic), 속도, 음높이", shortcut: nil, category: "설정", example: nil),
+            GuideItem(title: "음성", description: "TTS 프로바이더 선택 (시스템/Google Cloud/Typecast/Supertonic), 속도, 음높이", shortcut: nil, category: "설정", example: nil),
             GuideItem(title: "가족", description: "여러 사용자가 하나의 도치를 공유. 각 사용자별 메모리/대화 분리", shortcut: nil, category: "설정", example: nil),
             GuideItem(title: "에이전트", description: "에이전트 생성/편집/삭제. 템플릿, 페르소나, 도구 권한 설정", shortcut: nil, category: "설정", example: nil),
             GuideItem(title: "도구", description: "35개+ 내장 도구 목록 확인. 기본/조건부 도구, 권한 등급 표시", shortcut: nil, category: "설정", example: nil),
@@ -318,7 +318,7 @@ enum AppGuideContentBuilder {
         [
             GuideItem(title: "음성 입력", description: "마이크 버튼을 클릭하거나 웨이크워드를 말해 음성 입력을 시작합니다.", shortcut: nil, category: "사용법", example: nil),
             GuideItem(title: "웨이크워드", description: "기본값 \"도치야\". 설정에서 변경 가능. \"항상 대기 모드\"를 켜면 앱이 활성화된 동안 계속 감지합니다.", shortcut: nil, category: "설정", example: nil),
-            GuideItem(title: "TTS (텍스트→음성)", description: "AI 응답을 음성으로 읽어줍니다. 시스템 TTS, Google Cloud TTS, Supertonic(로컬 ONNX) 중 선택.", shortcut: nil, category: "설정", example: nil),
+            GuideItem(title: "TTS (텍스트→음성)", description: "AI 응답을 음성으로 읽어줍니다. 시스템 TTS, Google Cloud TTS, Typecast TTS, Supertonic(로컬 ONNX) 중 선택.", shortcut: nil, category: "설정", example: nil),
             GuideItem(title: "상호작용 모드", description: "\"음성 + 텍스트\" 또는 \"텍스트 전용\" 모드를 선택합니다. 텍스트 전용이면 음성 기능 비활성화.", shortcut: nil, category: "설정", example: nil),
             GuideItem(title: "침묵 감지", description: "말하다 멈추면 자동으로 음성 입력을 종료합니다. 감지 시간은 설정에서 조절.", shortcut: nil, category: "설정", example: nil),
         ]

--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -145,6 +145,45 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(googleCloudVoiceName, forKey: "googleCloudVoiceName") }
     }
 
+    var typecastVoiceId: String = UserDefaults.standard.string(forKey: "typecastVoiceId") ?? "" {
+        didSet { UserDefaults.standard.set(typecastVoiceId, forKey: "typecastVoiceId") }
+    }
+
+    var typecastModel: String = UserDefaults.standard.string(forKey: "typecastModel") ?? "ssfm-v30" {
+        didSet { UserDefaults.standard.set(typecastModel, forKey: "typecastModel") }
+    }
+
+    var typecastLanguage: String = UserDefaults.standard.string(forKey: "typecastLanguage") ?? "kor" {
+        didSet { UserDefaults.standard.set(typecastLanguage, forKey: "typecastLanguage") }
+    }
+
+    /// preset | smart
+    var typecastEmotionType: String = UserDefaults.standard.string(forKey: "typecastEmotionType") ?? "preset" {
+        didSet { UserDefaults.standard.set(typecastEmotionType, forKey: "typecastEmotionType") }
+    }
+
+    /// normal | happy | sad | angry | whisper | toneup | tonedown
+    var typecastEmotionPreset: String = UserDefaults.standard.string(forKey: "typecastEmotionPreset") ?? "normal" {
+        didSet { UserDefaults.standard.set(typecastEmotionPreset, forKey: "typecastEmotionPreset") }
+    }
+
+    var typecastEmotionIntensity: Double = UserDefaults.standard.object(forKey: "typecastEmotionIntensity") as? Double ?? 1.0 {
+        didSet { UserDefaults.standard.set(typecastEmotionIntensity, forKey: "typecastEmotionIntensity") }
+    }
+
+    var typecastVolume: Int = UserDefaults.standard.object(forKey: "typecastVolume") as? Int ?? 100 {
+        didSet { UserDefaults.standard.set(typecastVolume, forKey: "typecastVolume") }
+    }
+
+    var typecastAudioPitch: Int = UserDefaults.standard.object(forKey: "typecastAudioPitch") as? Int ?? 0 {
+        didSet { UserDefaults.standard.set(typecastAudioPitch, forKey: "typecastAudioPitch") }
+    }
+
+    /// wav | mp3
+    var typecastAudioFormat: String = UserDefaults.standard.string(forKey: "typecastAudioFormat") ?? "wav" {
+        didSet { UserDefaults.standard.set(typecastAudioFormat, forKey: "typecastAudioFormat") }
+    }
+
     // MARK: - P4 Settings
 
     var telegramEnabled: Bool = UserDefaults.standard.object(forKey: "telegramEnabled") as? Bool ?? false {

--- a/Dochi/Models/TTSProvider.swift
+++ b/Dochi/Models/TTSProvider.swift
@@ -3,12 +3,14 @@ import Foundation
 enum TTSProvider: String, Codable, CaseIterable, Sendable {
     case system
     case googleCloud
+    case typecast
     case onnxLocal
 
     var displayName: String {
         switch self {
         case .system: "시스템 TTS"
         case .googleCloud: "Google Cloud TTS"
+        case .typecast: "Typecast TTS"
         case .onnxLocal: "로컬 TTS (ONNX)"
         }
     }
@@ -17,6 +19,7 @@ enum TTSProvider: String, Codable, CaseIterable, Sendable {
         switch self {
         case .system: "macOS 내장 음성 합성 — 추가 설정 불필요"
         case .googleCloud: "Google Cloud 고품질 음성 — API 키 필요"
+        case .typecast: "Typecast 감정형 음성 합성 — API 키 필요"
         case .onnxLocal: "Piper ONNX 로컬 추론 — 오프라인 사용 가능"
         }
     }
@@ -25,6 +28,7 @@ enum TTSProvider: String, Codable, CaseIterable, Sendable {
         switch self {
         case .system: false
         case .googleCloud: true
+        case .typecast: true
         case .onnxLocal: false
         }
     }
@@ -33,6 +37,7 @@ enum TTSProvider: String, Codable, CaseIterable, Sendable {
         switch self {
         case .system: ""
         case .googleCloud: "google_cloud_tts_api_key"
+        case .typecast: "typecast_tts_api_key"
         case .onnxLocal: ""
         }
     }
@@ -41,7 +46,7 @@ enum TTSProvider: String, Codable, CaseIterable, Sendable {
     var isLocal: Bool {
         switch self {
         case .system, .onnxLocal: true
-        case .googleCloud: false
+        case .googleCloud, .typecast: false
         }
     }
 }

--- a/Dochi/Services/TTS/TTSRouter.swift
+++ b/Dochi/Services/TTS/TTSRouter.swift
@@ -7,6 +7,7 @@ final class TTSRouter: TTSServiceProtocol {
 
     private let systemTTS = SystemTTSService()
     private let googleCloudTTS = GoogleCloudTTSService()
+    private let typecastTTS = TypecastTTSService()
     private let supertonicTTS = SupertonicService()
 
     /// Tracks whether we're currently using a fallback provider.
@@ -21,6 +22,7 @@ final class TTSRouter: TTSServiceProtocol {
         didSet {
             systemTTS.onComplete = onComplete
             googleCloudTTS.onComplete = onComplete
+            typecastTTS.onComplete = onComplete
             supertonicTTS.onComplete = onComplete
         }
     }
@@ -30,7 +32,7 @@ final class TTSRouter: TTSServiceProtocol {
     }
 
     var isSpeaking: Bool {
-        systemTTS.isSpeaking || googleCloudTTS.isSpeaking || supertonicTTS.isSpeaking
+        systemTTS.isSpeaking || googleCloudTTS.isSpeaking || typecastTTS.isSpeaking || supertonicTTS.isSpeaking
     }
 
     init(settings: AppSettings, keychainService: KeychainServiceProtocol) {
@@ -44,6 +46,8 @@ final class TTSRouter: TTSServiceProtocol {
         switch settings.currentTTSProvider {
         case .googleCloud:
             return googleCloudTTS
+        case .typecast:
+            return typecastTTS
         case .system:
             return systemTTS
         case .onnxLocal:
@@ -62,6 +66,18 @@ final class TTSRouter: TTSServiceProtocol {
         googleCloudTTS.pitch = Float(settings.ttsPitch)
         googleCloudTTS.voiceName = settings.googleCloudVoiceName
         googleCloudTTS.apiKey = keychainService.load(account: TTSProvider.googleCloud.keychainAccount) ?? ""
+
+        typecastTTS.speed = speed
+        typecastTTS.voiceId = settings.typecastVoiceId
+        typecastTTS.model = settings.typecastModel
+        typecastTTS.language = settings.typecastLanguage
+        typecastTTS.emotionType = settings.typecastEmotionType
+        typecastTTS.emotionPreset = settings.typecastEmotionPreset
+        typecastTTS.emotionIntensity = Float(settings.typecastEmotionIntensity)
+        typecastTTS.volume = settings.typecastVolume
+        typecastTTS.audioPitch = settings.typecastAudioPitch
+        typecastTTS.audioFormat = settings.typecastAudioFormat
+        typecastTTS.apiKey = keychainService.load(account: TTSProvider.typecast.keychainAccount) ?? ""
 
         supertonicTTS.speed = speed
         supertonicTTS.diffusionSteps = settings.ttsDiffusionSteps
@@ -89,6 +105,7 @@ final class TTSRouter: TTSServiceProtocol {
     func unloadEngine() {
         systemTTS.unloadEngine()
         googleCloudTTS.unloadEngine()
+        typecastTTS.unloadEngine()
         supertonicTTS.unloadEngine()
     }
 
@@ -100,6 +117,7 @@ final class TTSRouter: TTSServiceProtocol {
     func stopAndClear() {
         systemTTS.stopAndClear()
         googleCloudTTS.stopAndClear()
+        typecastTTS.stopAndClear()
         supertonicTTS.stopAndClear()
     }
 

--- a/Dochi/Services/TTS/TypecastTTSService.swift
+++ b/Dochi/Services/TTS/TypecastTTSService.swift
@@ -1,0 +1,266 @@
+import Foundation
+import AVFoundation
+
+@MainActor
+final class TypecastTTSService: NSObject, TTSServiceProtocol {
+    static let defaultModel = "ssfm-v30"
+
+    private(set) var engineState: TTSEngineState = .unloaded
+    private(set) var isSpeaking: Bool = false
+    var onComplete: (@MainActor () -> Void)?
+
+    private var sentenceQueue: [String] = []
+    private var isProcessing: Bool = false
+    private var audioPlayer: AVAudioPlayer?
+    private var playbackContinuation: CheckedContinuation<Void, Never>?
+
+    // Settings
+    var apiKey: String = ""
+    var voiceId: String = ""
+    var model: String = TypecastTTSService.defaultModel
+    var language: String = "kor"
+    var emotionType: String = "preset"
+    var emotionPreset: String = "normal"
+    var emotionIntensity: Float = 1.0
+    var volume: Int = 100
+    var audioPitch: Int = 0
+    var audioFormat: String = "wav"
+    var speed: Float = 1.0
+
+    private static let apiURL = URL(string: "https://api.typecast.ai/v1/text-to-speech")!
+    private let maxTextLength = 5_000
+
+    // MARK: - Engine Lifecycle
+
+    func loadEngine() async throws {
+        guard isUnloadedOrError else { return }
+        engineState = .loading
+        Log.tts.info("Loading Typecast TTS engine...")
+        engineState = .ready
+        Log.tts.info("Typecast TTS engine ready")
+    }
+
+    func unloadEngine() {
+        stopAndClear()
+        engineState = .unloaded
+        Log.tts.info("Typecast TTS engine unloaded")
+    }
+
+    // MARK: - Sentence Queue
+
+    func enqueueSentence(_ text: String) {
+        let cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return }
+
+        let chunks = splitText(cleaned, maxLength: maxTextLength)
+        sentenceQueue.append(contentsOf: chunks)
+        Log.tts.debug("Typecast TTS enqueued (\(self.sentenceQueue.count) in queue)")
+        processQueueIfNeeded()
+    }
+
+    func stopAndClear() {
+        sentenceQueue.removeAll()
+        audioPlayer?.stop()
+        audioPlayer = nil
+        playbackContinuation?.resume()
+        playbackContinuation = nil
+        isSpeaking = false
+        isProcessing = false
+        Log.tts.info("Typecast TTS stopped and queue cleared")
+    }
+
+    // MARK: - Queue Processing
+
+    private func processQueueIfNeeded() {
+        guard !isProcessing, !sentenceQueue.isEmpty else { return }
+        isProcessing = true
+        isSpeaking = true
+
+        Task {
+            while !sentenceQueue.isEmpty {
+                let sentence = sentenceQueue.removeFirst()
+                guard let audioData = await synthesize(sentence) else { continue }
+                await playAudioData(audioData)
+            }
+
+            isProcessing = false
+            isSpeaking = false
+            onComplete?()
+        }
+    }
+
+    private func synthesize(_ text: String) async -> Data? {
+        Log.tts.debug("Typecast TTS synthesizing: \(text.prefix(30))...")
+
+        guard !apiKey.isEmpty else {
+            Log.tts.error("Typecast TTS API key not set")
+            return nil
+        }
+
+        guard !voiceId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            Log.tts.error("Typecast voice_id not set")
+            return nil
+        }
+
+        do {
+            return try await callAPI(text: text)
+        } catch {
+            Log.tts.error("Typecast TTS synthesis failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: - Typecast API
+
+    private func callAPI(text: String) async throws -> Data {
+        var request = URLRequest(url: Self.apiURL)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "X-API-KEY")
+
+        var prompt: [String: Any] = [
+            "emotion_type": emotionType == "smart" ? "smart" : "preset",
+        ]
+        if emotionType != "smart" {
+            prompt["emotion_preset"] = emotionPreset
+            prompt["emotion_intensity"] = Double(clampEmotionIntensity(emotionIntensity))
+        }
+
+        let output: [String: Any] = [
+            "volume": clampVolume(volume),
+            "audio_pitch": clampAudioPitch(audioPitch),
+            "audio_tempo": Double(clampTempo(speed)),
+            "audio_format": (audioFormat == "mp3") ? "mp3" : "wav",
+        ]
+
+        let requestBody: [String: Any] = [
+            "voice_id": voiceId,
+            "text": text,
+            "model": model,
+            "language": language,
+            "prompt": prompt,
+            "output": output,
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw TypecastTTSError.invalidResponse
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
+            Log.tts.error("Typecast API error \(httpResponse.statusCode): \(errorBody)")
+            throw TypecastTTSError.apiError(statusCode: httpResponse.statusCode, message: errorBody)
+        }
+
+        return data
+    }
+
+    // MARK: - Audio Playback
+
+    private func playAudioData(_ data: Data) async {
+        await withCheckedContinuation { continuation in
+            playbackContinuation = continuation
+
+            do {
+                let player = try AVAudioPlayer(data: data)
+                player.delegate = self
+                player.prepareToPlay()
+                audioPlayer = player
+
+                if !player.play() {
+                    throw TypecastTTSError.playbackFailed
+                }
+            } catch {
+                Log.tts.error("Typecast audio playback failed: \(error.localizedDescription)")
+                playbackContinuation?.resume()
+                playbackContinuation = nil
+                audioPlayer = nil
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var isUnloadedOrError: Bool {
+        switch engineState {
+        case .unloaded, .error: true
+        default: false
+        }
+    }
+
+    private func splitText(_ text: String, maxLength: Int) -> [String] {
+        guard text.count > maxLength else { return [text] }
+
+        var chunks: [String] = []
+        var start = text.startIndex
+
+        while start < text.endIndex {
+            let end = text.index(start, offsetBy: maxLength, limitedBy: text.endIndex) ?? text.endIndex
+            chunks.append(String(text[start..<end]))
+            start = end
+        }
+
+        return chunks
+    }
+
+    private func clampTempo(_ value: Float) -> Float {
+        min(max(value, 0.5), 2.0)
+    }
+
+    private func clampEmotionIntensity(_ value: Float) -> Float {
+        min(max(value, 0.0), 2.0)
+    }
+
+    private func clampVolume(_ value: Int) -> Int {
+        min(max(value, 0), 200)
+    }
+
+    private func clampAudioPitch(_ value: Int) -> Int {
+        min(max(value, -12), 12)
+    }
+}
+
+// MARK: - AVAudioPlayerDelegate
+
+extension TypecastTTSService: AVAudioPlayerDelegate {
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            playbackContinuation?.resume()
+            playbackContinuation = nil
+            audioPlayer = nil
+        }
+    }
+
+    nonisolated func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: (any Error)?) {
+        Task { @MainActor in
+            if let error {
+                Log.tts.error("Typecast audio decode failed: \(error.localizedDescription)")
+            }
+            playbackContinuation?.resume()
+            playbackContinuation = nil
+            audioPlayer = nil
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum TypecastTTSError: Error, LocalizedError {
+    case invalidResponse
+    case apiError(statusCode: Int, message: String)
+    case playbackFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            "서버 응답이 올바르지 않습니다"
+        case .apiError(let statusCode, let message):
+            "API 오류 (\(statusCode)): \(message)"
+        case .playbackFailed:
+            "오디오 재생을 시작할 수 없습니다"
+        }
+    }
+}

--- a/Dochi/Views/Settings/VoiceSettingsView.swift
+++ b/Dochi/Views/Settings/VoiceSettingsView.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 struct VoiceSettingsView: View {
@@ -8,7 +9,16 @@ struct VoiceSettingsView: View {
 
     @State private var testPlaying = false
     @State private var gcpAPIKey: String = ""
-    @State private var saveStatus: String?
+    @State private var typecastAPIKey: String = ""
+    @State private var gcpSaveStatus: String?
+    @State private var typecastSaveStatus: String?
+    @State private var typecastVoices: [TypecastVoiceOption] = []
+    @State private var isLoadingTypecastVoices = false
+    @State private var typecastVoiceLoadError: String?
+
+    private static let typecastDefaultEmotions = [
+        "normal", "happy", "sad", "angry", "whisper", "toneup", "tonedown",
+    ]
 
     var body: some View {
         Form {
@@ -35,7 +45,7 @@ struct VoiceSettingsView: View {
             } header: {
                 SettingsSectionHeader(
                     title: "TTS 프로바이더",
-                    helpContent: "텍스트를 음성으로 변환하는 엔진을 선택합니다. \"시스템 TTS\"는 추가 설정 없이 사용 가능하며, Google Cloud TTS는 고품질 클라우드 음성을, 로컬 TTS (ONNX)는 오프라인 음성 합성을 제공합니다."
+                    helpContent: "텍스트를 음성으로 변환하는 엔진을 선택합니다. \"시스템 TTS\"는 추가 설정 없이 사용 가능하며, Google Cloud/Typecast는 클라우드 음성을, 로컬 TTS (ONNX)는 오프라인 음성 합성을 제공합니다."
                 )
             }
 
@@ -72,7 +82,153 @@ struct VoiceSettingsView: View {
                         }
                     }
 
-                    if let status = saveStatus {
+                    if let status = gcpSaveStatus {
+                        Text(status)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if settings.currentTTSProvider == .typecast {
+                Section("Typecast TTS") {
+                    HStack(spacing: 8) {
+                        Button {
+                            Task { await loadTypecastVoices() }
+                        } label: {
+                            Label("음성 목록 새로고침", systemImage: "arrow.clockwise")
+                        }
+                        .disabled(isLoadingTypecastVoices)
+
+                        if isLoadingTypecastVoices {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+
+                    if let error = typecastVoiceLoadError {
+                        Text(error)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+
+                    if !typecastVoicesForSelectedModel.isEmpty {
+                        Picker("음성", selection: Binding(
+                            get: { settings.typecastVoiceId },
+                            set: { settings.typecastVoiceId = $0 }
+                        )) {
+                            ForEach(typecastVoicesForSelectedModel) { voice in
+                                Text(typecastVoiceDisplayName(voice)).tag(voice.voiceId)
+                            }
+                        }
+                    } else {
+                        Text("선택한 모델(\(settings.typecastModel))에 맞는 음성을 불러오지 못했습니다. Voice ID를 직접 입력하세요.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    TextField("Voice ID (직접 입력)", text: Binding(
+                        get: { settings.typecastVoiceId },
+                        set: { settings.typecastVoiceId = $0 }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, design: .monospaced))
+
+                    Picker("모델", selection: Binding(
+                        get: { settings.typecastModel },
+                        set: { settings.typecastModel = $0 }
+                    )) {
+                        Text("ssfm-v30").tag("ssfm-v30")
+                        Text("ssfm-v21").tag("ssfm-v21")
+                    }
+
+                    Picker("언어", selection: Binding(
+                        get: { settings.typecastLanguage },
+                        set: { settings.typecastLanguage = $0 }
+                    )) {
+                        Text("한국어 (kor)").tag("kor")
+                        Text("영어 (eng)").tag("eng")
+                        Text("일본어 (jpn)").tag("jpn")
+                    }
+
+                    Picker("감정 모드", selection: Binding(
+                        get: { settings.typecastEmotionType },
+                        set: { settings.typecastEmotionType = $0 }
+                    )) {
+                        Text("Preset").tag("preset")
+                        Text("Smart").tag("smart")
+                    }
+
+                    if settings.typecastEmotionType == "preset" {
+                        Picker("감정 프리셋", selection: Binding(
+                            get: { settings.typecastEmotionPreset },
+                            set: { settings.typecastEmotionPreset = $0 }
+                        )) {
+                            ForEach(typecastEmotionPresetsForCurrentSelection, id: \.self) { emotion in
+                                Text(emotion).tag(emotion)
+                            }
+                        }
+
+                        HStack {
+                            Text("감정 강도: \(String(format: "%.1f", settings.typecastEmotionIntensity))")
+                            Slider(value: Binding(
+                                get: { settings.typecastEmotionIntensity },
+                                set: { settings.typecastEmotionIntensity = $0 }
+                            ), in: 0.0...2.0, step: 0.1)
+                        }
+                    } else {
+                        Text("Smart 모드는 텍스트 문맥 기반으로 감정을 자동 추론합니다.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack {
+                        Text("볼륨: \(settings.typecastVolume)")
+                        Slider(value: Binding(
+                            get: { Double(settings.typecastVolume) },
+                            set: { settings.typecastVolume = Int($0.rounded()) }
+                        ), in: 0...200, step: 1)
+                    }
+
+                    HStack {
+                        Text("피치: \(settings.typecastAudioPitch)")
+                        Slider(value: Binding(
+                            get: { Double(settings.typecastAudioPitch) },
+                            set: { settings.typecastAudioPitch = Int($0.rounded()) }
+                        ), in: -12...12, step: 1)
+                    }
+
+                    Picker("출력 포맷", selection: Binding(
+                        get: { settings.typecastAudioFormat },
+                        set: { settings.typecastAudioFormat = $0 }
+                    )) {
+                        Text("WAV").tag("wav")
+                        Text("MP3").tag("mp3")
+                    }
+
+                    Text("속도 슬라이더 값은 Typecast audio_tempo(0.5~2.0)로 전달됩니다.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        SecureField("Typecast API 키", text: $typecastAPIKey)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(size: 12, design: .monospaced))
+
+                        Button("저장") {
+                            saveTypecastKey()
+                        }
+
+                        if let account = keychainService?.load(account: TTSProvider.typecast.keychainAccount),
+                           !account.isEmpty {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                                .font(.caption)
+                                .help("저장됨")
+                        }
+                    }
+
+                    if let status = typecastSaveStatus {
                         Text(status)
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -188,6 +344,23 @@ struct VoiceSettingsView: View {
         .padding()
         .onAppear {
             gcpAPIKey = keychainService?.load(account: TTSProvider.googleCloud.keychainAccount) ?? ""
+            typecastAPIKey = keychainService?.load(account: TTSProvider.typecast.keychainAccount) ?? ""
+            normalizeTypecastSettings()
+            if settings.currentTTSProvider == .typecast, !typecastAPIKey.isEmpty {
+                Task { await loadTypecastVoices() }
+            }
+        }
+        .onChange(of: settings.typecastModel) { _ in
+            syncSelectedTypecastVoiceForCurrentModel()
+            normalizeTypecastEmotionPreset()
+        }
+        .onChange(of: settings.typecastVoiceId) { _ in
+            normalizeTypecastEmotionPreset()
+        }
+        .onChange(of: settings.ttsProvider) { _ in
+            if settings.currentTTSProvider == .typecast, !typecastAPIKey.isEmpty, typecastVoices.isEmpty {
+                Task { await loadTypecastVoices() }
+            }
         }
     }
 
@@ -219,6 +392,113 @@ struct VoiceSettingsView: View {
         }
     }
 
+    private var typecastVoicesForSelectedModel: [TypecastVoiceOption] {
+        typecastVoices.filter { voice in
+            voice.models.contains(where: { $0.version == settings.typecastModel })
+        }
+    }
+
+    private var selectedTypecastVoice: TypecastVoiceOption? {
+        typecastVoices.first { $0.voiceId == settings.typecastVoiceId }
+    }
+
+    private var typecastEmotionPresetsForCurrentSelection: [String] {
+        guard let selectedTypecastVoice else { return Self.typecastDefaultEmotions }
+        let emotions = selectedTypecastVoice.models
+            .first(where: { $0.version == settings.typecastModel })?
+            .emotions
+            .filter { !$0.isEmpty } ?? []
+        return emotions.isEmpty ? Self.typecastDefaultEmotions : emotions
+    }
+
+    private func typecastVoiceDisplayName(_ voice: TypecastVoiceOption) -> String {
+        let gender = (voice.gender?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false) ? (voice.gender ?? "unknown") : "unknown"
+        let age = (voice.age?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false) ? (voice.age ?? "unknown") : "unknown"
+        return "\(voice.voiceName) (\(gender), \(age))"
+    }
+
+    private func normalizeTypecastSettings() {
+        let allowedEmotionTypes = ["preset", "smart"]
+        if !allowedEmotionTypes.contains(settings.typecastEmotionType) {
+            settings.typecastEmotionType = "preset"
+        }
+
+        let allowedFormats = ["wav", "mp3"]
+        if !allowedFormats.contains(settings.typecastAudioFormat) {
+            settings.typecastAudioFormat = "wav"
+        }
+
+        if settings.typecastLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            settings.typecastLanguage = "kor"
+        }
+
+        settings.typecastEmotionIntensity = min(max(settings.typecastEmotionIntensity, 0.0), 2.0)
+        settings.typecastVolume = min(max(settings.typecastVolume, 0), 200)
+        settings.typecastAudioPitch = min(max(settings.typecastAudioPitch, -12), 12)
+        normalizeTypecastEmotionPreset()
+    }
+
+    private func normalizeTypecastEmotionPreset() {
+        let allowed = typecastEmotionPresetsForCurrentSelection
+        if !allowed.contains(settings.typecastEmotionPreset) {
+            settings.typecastEmotionPreset = allowed.first ?? "normal"
+        }
+    }
+
+    private func syncSelectedTypecastVoiceForCurrentModel() {
+        guard !typecastVoicesForSelectedModel.isEmpty else { return }
+        let current = settings.typecastVoiceId
+        let supported = typecastVoicesForSelectedModel.contains { $0.voiceId == current }
+        if !supported {
+            settings.typecastVoiceId = typecastVoicesForSelectedModel[0].voiceId
+        }
+    }
+
+    private func loadTypecastVoices() async {
+        guard let keychainService else {
+            typecastVoiceLoadError = "키체인 서비스를 찾을 수 없습니다."
+            return
+        }
+
+        let apiKey = keychainService.load(account: TTSProvider.typecast.keychainAccount) ?? ""
+        guard !apiKey.isEmpty else {
+            typecastVoiceLoadError = "Typecast API 키를 먼저 저장하세요."
+            return
+        }
+
+        isLoadingTypecastVoices = true
+        typecastVoiceLoadError = nil
+        defer { isLoadingTypecastVoices = false }
+
+        do {
+            var request = URLRequest(url: URL(string: "https://api.typecast.ai/v2/voices")!)
+            request.httpMethod = "GET"
+            request.setValue(apiKey, forHTTPHeaderField: "X-API-KEY")
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw TypecastVoiceLoadError.invalidResponse
+            }
+            guard (200...299).contains(http.statusCode) else {
+                let message = String(data: data, encoding: .utf8) ?? "unknown"
+                throw TypecastVoiceLoadError.httpError(statusCode: http.statusCode, message: message)
+            }
+
+            let decoded = try JSONDecoder().decode([TypecastVoiceOption].self, from: data)
+            typecastVoices = decoded.sorted { lhs, rhs in
+                lhs.voiceName.localizedCaseInsensitiveCompare(rhs.voiceName) == .orderedAscending
+            }
+            syncSelectedTypecastVoiceForCurrentModel()
+            normalizeTypecastEmotionPreset()
+
+            if typecastVoicesForSelectedModel.isEmpty {
+                typecastVoiceLoadError = "선택한 모델(\(settings.typecastModel))을 지원하는 음성이 없습니다."
+            }
+        } catch {
+            typecastVoiceLoadError = "음성 목록 로드 실패: \(error.localizedDescription)"
+        }
+    }
+
     private func saveGCPKey() {
         guard let keychainService else { return }
         do {
@@ -227,16 +507,77 @@ struct VoiceSettingsView: View {
             } else {
                 try keychainService.save(account: TTSProvider.googleCloud.keychainAccount, value: gcpAPIKey)
             }
-            saveStatus = "저장 완료"
+            gcpSaveStatus = "저장 완료"
             Log.app.info("Google Cloud TTS API key saved")
         } catch {
-            saveStatus = "저장 실패: \(error.localizedDescription)"
+            gcpSaveStatus = "저장 실패: \(error.localizedDescription)"
             Log.app.error("Google Cloud TTS API key save failed: \(error.localizedDescription)")
         }
 
         Task {
             try? await Task.sleep(for: .seconds(3))
-            saveStatus = nil
+            gcpSaveStatus = nil
+        }
+    }
+
+    private func saveTypecastKey() {
+        guard let keychainService else { return }
+        do {
+            if typecastAPIKey.isEmpty {
+                try keychainService.delete(account: TTSProvider.typecast.keychainAccount)
+            } else {
+                try keychainService.save(account: TTSProvider.typecast.keychainAccount, value: typecastAPIKey)
+            }
+            typecastSaveStatus = "저장 완료"
+            Log.app.info("Typecast TTS API key saved")
+            Task { await loadTypecastVoices() }
+        } catch {
+            typecastSaveStatus = "저장 실패: \(error.localizedDescription)"
+            Log.app.error("Typecast TTS API key save failed: \(error.localizedDescription)")
+        }
+
+        Task {
+            try? await Task.sleep(for: .seconds(3))
+            typecastSaveStatus = nil
+        }
+    }
+
+    private struct TypecastVoiceOption: Identifiable, Decodable {
+        let voiceId: String
+        let voiceName: String
+        let models: [TypecastVoiceModel]
+        let gender: String?
+        let age: String?
+        let useCases: [String]
+
+        var id: String { voiceId }
+
+        enum CodingKeys: String, CodingKey {
+            case voiceId = "voice_id"
+            case voiceName = "voice_name"
+            case models
+            case gender
+            case age
+            case useCases = "use_cases"
+        }
+    }
+
+    private struct TypecastVoiceModel: Decodable {
+        let version: String
+        let emotions: [String]
+    }
+
+    private enum TypecastVoiceLoadError: LocalizedError {
+        case invalidResponse
+        case httpError(statusCode: Int, message: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidResponse:
+                return "Typecast 음성 목록 응답이 올바르지 않습니다."
+            case let .httpError(statusCode, message):
+                return "Typecast API 오류 (\(statusCode)): \(message)"
+            }
         }
     }
 

--- a/DochiTests/ONNXTTSTests.swift
+++ b/DochiTests/ONNXTTSTests.swift
@@ -21,6 +21,12 @@ final class ONNXTTSTests: XCTestCase {
         XCTAssertFalse(TTSProvider.googleCloud.isLocal)
     }
 
+    func testTTSProviderTypecastRequiresAPIKey() {
+        XCTAssertTrue(TTSProvider.typecast.requiresAPIKey)
+        XCTAssertFalse(TTSProvider.typecast.isLocal)
+        XCTAssertEqual(TTSProvider.typecast.keychainAccount, "typecast_tts_api_key")
+    }
+
     func testTTSProviderShortDescription() {
         for provider in TTSProvider.allCases {
             XCTAssertFalse(provider.shortDescription.isEmpty, "Provider \(provider) should have a short description")
@@ -29,7 +35,8 @@ final class ONNXTTSTests: XCTestCase {
 
     func testTTSProviderAllCasesIncludesOnnxLocal() {
         XCTAssertTrue(TTSProvider.allCases.contains(.onnxLocal))
-        XCTAssertEqual(TTSProvider.allCases.count, 3)
+        XCTAssertTrue(TTSProvider.allCases.contains(.typecast))
+        XCTAssertEqual(TTSProvider.allCases.count, 4)
     }
 
     func testTTSProviderRawValueRoundTrip() {
@@ -53,6 +60,30 @@ final class ONNXTTSTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: "ttsOfflineFallbackEnabled")
         let settings = AppSettings()
         XCTAssertFalse(settings.ttsOfflineFallbackEnabled)
+    }
+
+    @MainActor
+    func testAppSettingsTypecastDefaults() {
+        UserDefaults.standard.removeObject(forKey: "typecastVoiceId")
+        UserDefaults.standard.removeObject(forKey: "typecastModel")
+        UserDefaults.standard.removeObject(forKey: "typecastLanguage")
+        UserDefaults.standard.removeObject(forKey: "typecastEmotionType")
+        UserDefaults.standard.removeObject(forKey: "typecastEmotionPreset")
+        UserDefaults.standard.removeObject(forKey: "typecastEmotionIntensity")
+        UserDefaults.standard.removeObject(forKey: "typecastVolume")
+        UserDefaults.standard.removeObject(forKey: "typecastAudioPitch")
+        UserDefaults.standard.removeObject(forKey: "typecastAudioFormat")
+
+        let settings = AppSettings()
+        XCTAssertEqual(settings.typecastVoiceId, "")
+        XCTAssertEqual(settings.typecastModel, "ssfm-v30")
+        XCTAssertEqual(settings.typecastLanguage, "kor")
+        XCTAssertEqual(settings.typecastEmotionType, "preset")
+        XCTAssertEqual(settings.typecastEmotionPreset, "normal")
+        XCTAssertEqual(settings.typecastEmotionIntensity, 1.0, accuracy: 0.001)
+        XCTAssertEqual(settings.typecastVolume, 100)
+        XCTAssertEqual(settings.typecastAudioPitch, 0)
+        XCTAssertEqual(settings.typecastAudioFormat, "wav")
     }
 
     @MainActor
@@ -80,6 +111,40 @@ final class ONNXTTSTests: XCTestCase {
         XCTAssertEqual(settings.currentTTSProvider, .onnxLocal)
         // Cleanup
         settings.ttsProvider = TTSProvider.system.rawValue
+    }
+
+    @MainActor
+    func testAppSettingsTypecastPersistence() {
+        let settings = AppSettings()
+        settings.typecastVoiceId = "voice-123"
+        settings.typecastModel = "ssfm-v21"
+        settings.typecastLanguage = "eng"
+        settings.typecastEmotionType = "smart"
+        settings.typecastEmotionPreset = "happy"
+        settings.typecastEmotionIntensity = 1.4
+        settings.typecastVolume = 120
+        settings.typecastAudioPitch = 2
+        settings.typecastAudioFormat = "mp3"
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "typecastVoiceId"), "voice-123")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "typecastModel"), "ssfm-v21")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "typecastLanguage"), "eng")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "typecastEmotionType"), "smart")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "typecastEmotionPreset"), "happy")
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "typecastEmotionIntensity") as? Double ?? 0.0, 1.4, accuracy: 0.001)
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "typecastVolume") as? Int, 120)
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "typecastAudioPitch") as? Int, 2)
+        XCTAssertEqual(UserDefaults.standard.string(forKey: "typecastAudioFormat"), "mp3")
+
+        UserDefaults.standard.removeObject(forKey: "typecastVoiceId")
+        UserDefaults.standard.removeObject(forKey: "typecastModel")
+        UserDefaults.standard.removeObject(forKey: "typecastLanguage")
+        UserDefaults.standard.removeObject(forKey: "typecastEmotionType")
+        UserDefaults.standard.removeObject(forKey: "typecastEmotionPreset")
+        UserDefaults.standard.removeObject(forKey: "typecastEmotionIntensity")
+        UserDefaults.standard.removeObject(forKey: "typecastVolume")
+        UserDefaults.standard.removeObject(forKey: "typecastAudioPitch")
+        UserDefaults.standard.removeObject(forKey: "typecastAudioFormat")
     }
 
     // MARK: - PiperModelInfo Tests
@@ -241,6 +306,10 @@ final class ONNXTTSTests: XCTestCase {
 
         // Switch to onnxLocal
         settings.ttsProvider = TTSProvider.onnxLocal.rawValue
+        _ = router.engineState
+
+        // Switch to Typecast
+        settings.ttsProvider = TTSProvider.typecast.rawValue
         _ = router.engineState
 
         // Cleanup


### PR DESCRIPTION
## Summary
- add a new TypecastTTSService provider implementation and route it through TTSRouter
- expand Typecast settings to support language, emotion mode/preset/intensity, volume, pitch, and output format
- upgrade Voice settings UI for Typecast with live voice catalog loading from GET /v2/voices and model-aware voice selection
- align Typecast API payloads to include prompt and output parameter blocks
- update TTS guide copy and extend unit tests for Typecast defaults/persistence and router selection

## Test Evidence
- xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ONNXTTSTests
- xcodebuild -project Dochi.xcodeproj -scheme Dochi -configuration Debug build

## Spec Impact
- None (feature extension within existing Voice/TTS surface; no spec contract changes required)
