### PR TITLE
feat: improve bridge.open repo-root UX

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -1132,11 +1132,58 @@ struct DochiApp: App {
         }
 
         let profileName = nonEmptyString(params["profile_name"]) ?? preset.defaultProfileName
-        let workingDirectory = nonEmptyString(params["working_directory"]) ?? "~"
+        let requestedWorkingDirectory = nonEmptyString(params["working_directory"])
+        let forceWorkingDirectory = boolValue(params["force_working_directory"]) ?? false
         let arguments = params["arguments"] as? [String] ?? []
 
+        let existingProfile = await MainActor.run { () -> ExternalToolProfile? in
+            externalToolManager.profiles.first(where: { $0.name == profileName })
+        }
+
+        if let existingProfile {
+            let existingSessionPayload = await MainActor.run { () -> UncheckedJSONObject? in
+                guard let payload = existingBridgeSessionPayload(for: existingProfile.id, manager: externalToolManager) else {
+                    return nil
+                }
+                return UncheckedJSONObject(value: payload)
+            }
+            if let existingSessionPayload {
+                let decision = BridgeWorkingDirectorySelector.decideForActiveSession(
+                    profileWorkingDirectory: existingProfile.workingDirectory,
+                    requestedWorkingDirectory: requestedWorkingDirectory,
+                    forceWorkingDirectory: forceWorkingDirectory
+                )
+                var payload = existingSessionPayload.value
+                payload["reused"] = true
+                payload["working_directory"] = decision.workingDirectory
+                payload["selection_reason"] = decision.selectionReason.rawValue
+                payload["selection_detail"] = decision.selectionDetail
+                return .ok(payload)
+            }
+        }
+
+        let recommendedRoots: [GitRepositoryInsight]
+        if existingProfile == nil, requestedWorkingDirectory == nil {
+            recommendedRoots = await externalToolManager.discoverGitRepositoryInsights(
+                searchPaths: nil,
+                limit: 10
+            )
+        } else {
+            recommendedRoots = []
+        }
+        let decision = BridgeWorkingDirectorySelector.decide(
+            existingProfile: existingProfile,
+            requestedWorkingDirectory: requestedWorkingDirectory,
+            forceWorkingDirectory: forceWorkingDirectory,
+            recommendedRoots: recommendedRoots
+        )
+
         let profile = await MainActor.run { () -> ExternalToolProfile in
-            if let existing = externalToolManager.profiles.first(where: { $0.name == profileName }) {
+            if var existing = existingProfile {
+                if decision.selectionReason == .existingProfileOverridden {
+                    existing.workingDirectory = decision.workingDirectory
+                    externalToolManager.saveProfile(existing)
+                }
                 return existing
             }
 
@@ -1144,23 +1191,11 @@ struct DochiApp: App {
                 name: profileName,
                 command: preset.command,
                 arguments: arguments,
-                workingDirectory: workingDirectory,
+                workingDirectory: decision.workingDirectory,
                 healthCheckPatterns: preset.healthPatterns
             )
             externalToolManager.saveProfile(created)
             return created
-        }
-
-        let existingSessionPayload = await MainActor.run { () -> UncheckedJSONObject? in
-            guard let payload = existingBridgeSessionPayload(for: profile.id, manager: externalToolManager) else {
-                return nil
-            }
-            return UncheckedJSONObject(value: payload)
-        }
-        if let existingSessionPayload {
-            var payload = existingSessionPayload.value
-            payload["reused"] = true
-            return .ok(payload)
         }
 
         do {
@@ -1181,6 +1216,9 @@ struct DochiApp: App {
 
         var payload = createdSessionPayload.value
         payload["reused"] = false
+        payload["working_directory"] = decision.workingDirectory
+        payload["selection_reason"] = decision.selectionReason.rawValue
+        payload["selection_detail"] = decision.selectionDetail
         return .ok(payload)
     }
 
@@ -1207,11 +1245,13 @@ struct DochiApp: App {
 
         let sessionsPayload = await MainActor.run { () -> UncheckedJSONArray in
             let sessions: [[String: Any]] = externalToolManager.sessions.map { session in
-                let profileName = externalToolManager.profiles.first(where: { $0.id == session.profileId })?.name ?? "unknown"
+                let profile = externalToolManager.profiles.first(where: { $0.id == session.profileId })
+                let profileName = profile?.name ?? "unknown"
                 return [
                     "session_id": session.id.uuidString,
                     "profile_id": session.profileId.uuidString,
                     "profile_name": profileName,
+                    "working_directory": profile?.workingDirectory ?? "~",
                     "status": session.status.rawValue,
                     "started_at": session.startedAt.map(isoTimestamp(_:)) ?? NSNull(),
                     "last_activity": session.lastActivityText ?? NSNull(),
@@ -1329,11 +1369,13 @@ struct DochiApp: App {
         guard let session = manager.sessions.first(where: { $0.profileId == profileId && $0.status != .dead }) else {
             return nil
         }
-        let profileName = manager.profiles.first(where: { $0.id == session.profileId })?.name ?? "unknown"
+        let profile = manager.profiles.first(where: { $0.id == session.profileId })
+        let profileName = profile?.name ?? "unknown"
         return [
             "session_id": session.id.uuidString,
             "profile_id": session.profileId.uuidString,
             "profile_name": profileName,
+            "working_directory": profile?.workingDirectory ?? "~",
             "status": session.status.rawValue,
             "started_at": session.startedAt.map(isoTimestamp(_:)) ?? NSNull(),
             "last_activity": session.lastActivityText ?? NSNull(),
@@ -1348,11 +1390,13 @@ struct DochiApp: App {
         guard let session = manager.sessions.first(where: { $0.id == sessionId }) else {
             return nil
         }
-        let profileName = manager.profiles.first(where: { $0.id == session.profileId })?.name ?? "unknown"
+        let profile = manager.profiles.first(where: { $0.id == session.profileId })
+        let profileName = profile?.name ?? "unknown"
         return [
             "session_id": session.id.uuidString,
             "profile_id": session.profileId.uuidString,
             "profile_name": profileName,
+            "working_directory": profile?.workingDirectory ?? "~",
             "status": session.status.rawValue,
             "started_at": session.startedAt.map(isoTimestamp(_:)) ?? NSNull(),
             "last_activity": session.lastActivityText ?? NSNull(),
@@ -1363,6 +1407,27 @@ struct DochiApp: App {
         guard let raw = value as? String else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    nonisolated private static func boolValue(_ value: Any?) -> Bool? {
+        switch value {
+        case let bool as Bool:
+            return bool
+        case let number as NSNumber:
+            return number.boolValue
+        case let string as String:
+            let normalized = string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            switch normalized {
+            case "1", "true", "yes", "y":
+                return true
+            case "0", "false", "no", "n":
+                return false
+            default:
+                return nil
+            }
+        default:
+            return nil
+        }
     }
 
     nonisolated private static func isoTimestamp(_ date: Date = Date()) -> String {

--- a/Dochi/CLIShared/CLICommandSurface.swift
+++ b/Dochi/CLIShared/CLICommandSurface.swift
@@ -40,7 +40,7 @@ enum CLIDevAction: Equatable, Sendable {
     case logRecent(minutes: Int)
     case logTail(seconds: Int, category: String?, level: String?, contains: String?)
     case chatStream(prompt: String)
-    case bridgeOpen(agent: String)
+    case bridgeOpen(agent: String, profileName: String?, workingDirectory: String?, forceWorkingDirectory: Bool)
     case bridgeRoots(limit: Int, searchPaths: [String])
     case bridgeStatus(sessionId: String?)
     case bridgeSend(sessionId: String, command: String)
@@ -319,8 +319,45 @@ enum CLICommandParser {
             let rest = Array(args.dropFirst(2))
             switch sub {
             case "open":
-                let agent = rest.first ?? "codex"
-                return .dev(.bridgeOpen(agent: agent))
+                var agent = "codex"
+                var profileName: String?
+                var workingDirectory: String?
+                var forceWorkingDirectory = false
+                var index = 0
+
+                if index < rest.count, !rest[index].hasPrefix("--") {
+                    agent = rest[index]
+                    index += 1
+                }
+
+                while index < rest.count {
+                    switch rest[index] {
+                    case "--profile":
+                        guard index + 1 < rest.count else {
+                            throw CLIParseError.invalidUsage("dev bridge open --profile <name> 형식이 필요합니다.")
+                        }
+                        profileName = rest[index + 1]
+                        index += 2
+                    case "--working-directory", "--cwd":
+                        guard index + 1 < rest.count else {
+                            throw CLIParseError.invalidUsage("dev bridge open --working-directory <DIR> 형식이 필요합니다.")
+                        }
+                        workingDirectory = rest[index + 1]
+                        index += 2
+                    case "--force-working-directory":
+                        forceWorkingDirectory = true
+                        index += 1
+                    default:
+                        throw CLIParseError.invalidUsage("dev bridge open의 알 수 없는 옵션입니다: \(rest[index])")
+                    }
+                }
+
+                return .dev(.bridgeOpen(
+                    agent: agent,
+                    profileName: profileName,
+                    workingDirectory: workingDirectory,
+                    forceWorkingDirectory: forceWorkingDirectory
+                ))
             case "roots":
                 var limit = 20
                 var searchPaths: [String] = []

--- a/Dochi/Services/BridgeWorkingDirectorySelector.swift
+++ b/Dochi/Services/BridgeWorkingDirectorySelector.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+enum BridgeWorkingDirectorySelectionReason: String, Sendable {
+    case existingSessionReused = "existing_session_reused"
+    case existingSessionReusedForceIgnored = "existing_session_reused_force_ignored"
+    case existingProfilePreserved = "existing_profile_preserved"
+    case existingProfileOverridden = "existing_profile_overridden"
+    case requestedWorkingDirectory = "requested_working_directory"
+    case recommendedGitRoot = "recommended_git_root"
+    case fallbackHomeDirectory = "fallback_home_directory"
+}
+
+struct BridgeWorkingDirectoryDecision: Sendable, Equatable {
+    let workingDirectory: String
+    let selectionReason: BridgeWorkingDirectorySelectionReason
+    let selectionDetail: String
+}
+
+enum BridgeWorkingDirectorySelector {
+    static func decideForActiveSession(
+        profileWorkingDirectory: String,
+        requestedWorkingDirectory: String?,
+        forceWorkingDirectory: Bool
+    ) -> BridgeWorkingDirectoryDecision {
+        if forceWorkingDirectory, let requestedWorkingDirectory {
+            return BridgeWorkingDirectoryDecision(
+                workingDirectory: profileWorkingDirectory,
+                selectionReason: .existingSessionReusedForceIgnored,
+                selectionDetail: "active session reused; requested '\(requestedWorkingDirectory)' ignored because running session cwd cannot be overwritten"
+            )
+        }
+        return BridgeWorkingDirectoryDecision(
+            workingDirectory: profileWorkingDirectory,
+            selectionReason: .existingSessionReused,
+            selectionDetail: "active session already exists for profile; reusing profile working directory"
+        )
+    }
+
+    static func decide(
+        existingProfile: ExternalToolProfile?,
+        requestedWorkingDirectory: String?,
+        forceWorkingDirectory: Bool,
+        recommendedRoots: [GitRepositoryInsight]
+    ) -> BridgeWorkingDirectoryDecision {
+        if let existingProfile {
+            if let requestedWorkingDirectory, forceWorkingDirectory {
+                return BridgeWorkingDirectoryDecision(
+                    workingDirectory: requestedWorkingDirectory,
+                    selectionReason: .existingProfileOverridden,
+                    selectionDetail: "existing profile working_directory overridden by force_working_directory"
+                )
+            }
+
+            if let requestedWorkingDirectory {
+                return BridgeWorkingDirectoryDecision(
+                    workingDirectory: existingProfile.workingDirectory,
+                    selectionReason: .existingProfilePreserved,
+                    selectionDetail: "existing profile working_directory preserved; requested '\(requestedWorkingDirectory)' ignored (use force_working_directory=true to override)"
+                )
+            }
+
+            return BridgeWorkingDirectoryDecision(
+                workingDirectory: existingProfile.workingDirectory,
+                selectionReason: .existingProfilePreserved,
+                selectionDetail: "reusing existing profile working_directory"
+            )
+        }
+
+        if let requestedWorkingDirectory {
+            return BridgeWorkingDirectoryDecision(
+                workingDirectory: requestedWorkingDirectory,
+                selectionReason: .requestedWorkingDirectory,
+                selectionDetail: "working_directory was explicitly provided"
+            )
+        }
+
+        if let recommended = recommendedRoots.first {
+            let dirtySummary = "\(recommended.changedFileCount)+\(recommended.untrackedFileCount)"
+            return BridgeWorkingDirectoryDecision(
+                workingDirectory: recommended.path,
+                selectionReason: .recommendedGitRoot,
+                selectionDetail: "selected top recommended git root '\(recommended.name)' (score=\(recommended.score), last_commit=\(recommended.lastCommitRelative), dirty=\(dirtySummary))"
+            )
+        }
+
+        return BridgeWorkingDirectoryDecision(
+            workingDirectory: "~",
+            selectionReason: .fallbackHomeDirectory,
+            selectionDetail: "no recommended git root found; fallback to home directory"
+        )
+    }
+}

--- a/Dochi/Services/Tools/DochiDevBridgeTool.swift
+++ b/Dochi/Services/Tools/DochiDevBridgeTool.swift
@@ -82,6 +82,10 @@ final class DochiBridgeOpenTool: BuiltInToolProtocol {
                     "description": "브리지에 연결할 에이전트 종류 (기본: codex)",
                 ],
                 "working_directory": ["type": "string", "description": "작업 디렉토리 (기본: ~)"],
+                "force_working_directory": [
+                    "type": "boolean",
+                    "description": "기존 프로파일의 working_directory를 강제로 덮어씁니다.",
+                ],
                 "profile_name": ["type": "string", "description": "브리지 프로파일 이름 (기본: 에이전트별 기본값)"],
                 "arguments": [
                     "type": "array",
@@ -104,32 +108,63 @@ final class DochiBridgeOpenTool: BuiltInToolProtocol {
 
         let customName = (arguments["profile_name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let profileName = (customName?.isEmpty == false) ? customName! : preset.defaultProfileName
-        let workingDirectory = (arguments["working_directory"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedWorkingDirectory = (workingDirectory?.isEmpty == false) ? workingDirectory! : "~"
+        let requestedWorkingDirectoryRaw = (arguments["working_directory"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let requestedWorkingDirectory = (requestedWorkingDirectoryRaw?.isEmpty == false)
+            ? requestedWorkingDirectoryRaw
+            : nil
+        let forceWorkingDirectory = arguments["force_working_directory"] as? Bool ?? false
         let extraArgs = arguments["arguments"] as? [String] ?? []
 
+        let existingProfile = manager.profiles.first(where: { $0.name == profileName })
+        if let existingProfile,
+           let active = manager.sessions.first(where: { $0.profileId == existingProfile.id && $0.status != .dead }) {
+            let decision = BridgeWorkingDirectorySelector.decideForActiveSession(
+                profileWorkingDirectory: existingProfile.workingDirectory,
+                requestedWorkingDirectory: requestedWorkingDirectory,
+                forceWorkingDirectory: forceWorkingDirectory
+            )
+            return ToolResult(toolCallId: "", content: """
+                브리지 채널이 이미 열려 있습니다.
+                - profile: \(existingProfile.name) (\(existingProfile.id.uuidString))
+                - session_id: \(active.id.uuidString)
+                - status: \(active.status.rawValue)
+                - working_directory: \(decision.workingDirectory)
+                - selection_reason: \(decision.selectionReason.rawValue)
+                - selection_detail: \(decision.selectionDetail)
+                """)
+        }
+
+        let recommendedRoots: [GitRepositoryInsight]
+        if existingProfile == nil, requestedWorkingDirectory == nil {
+            recommendedRoots = await manager.discoverGitRepositoryInsights(searchPaths: nil, limit: 10)
+        } else {
+            recommendedRoots = []
+        }
+        let decision = BridgeWorkingDirectorySelector.decide(
+            existingProfile: existingProfile,
+            requestedWorkingDirectory: requestedWorkingDirectory,
+            forceWorkingDirectory: forceWorkingDirectory,
+            recommendedRoots: recommendedRoots
+        )
+
         let profile: ExternalToolProfile
-        if let existing = manager.profiles.first(where: { $0.name == profileName }) {
+        if var existing = existingProfile {
+            if decision.selectionReason == .existingProfileOverridden {
+                existing.workingDirectory = decision.workingDirectory
+                manager.saveProfile(existing)
+            }
             profile = existing
         } else {
             let created = ExternalToolProfile(
                 name: profileName,
                 command: preset.command,
                 arguments: extraArgs,
-                workingDirectory: resolvedWorkingDirectory,
+                workingDirectory: decision.workingDirectory,
                 healthCheckPatterns: preset.healthPatterns
             )
             manager.saveProfile(created)
             profile = created
-        }
-
-        if let active = manager.sessions.first(where: { $0.profileId == profile.id && $0.status != .dead }) {
-            return ToolResult(toolCallId: "", content: """
-                브리지 채널이 이미 열려 있습니다.
-                - profile: \(profile.name) (\(profile.id.uuidString))
-                - session_id: \(active.id.uuidString)
-                - status: \(active.status.rawValue)
-                """)
         }
 
         do {
@@ -143,6 +178,9 @@ final class DochiBridgeOpenTool: BuiltInToolProtocol {
                 - profile: \(profile.name) (\(profile.id.uuidString))
                 - session_id: \(session.id.uuidString)
                 - status: \(session.status.rawValue)
+                - working_directory: \(decision.workingDirectory)
+                - selection_reason: \(decision.selectionReason.rawValue)
+                - selection_detail: \(decision.selectionDetail)
                 다음 단계:
                 1) dochi.bridge_send로 명령 전달
                 2) dochi.bridge_read로 출력 확인

--- a/Dochi/ViewModels/ExternalToolProfileEditorViewModel.swift
+++ b/Dochi/ViewModels/ExternalToolProfileEditorViewModel.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+@MainActor
+@Observable
+final class ExternalToolProfileEditorViewModel {
+    private let manager: ExternalToolSessionManagerProtocol
+
+    var recommendedRoots: [GitRepositoryInsight] = []
+    var isLoadingRecommendations = false
+    var hasLoadedRecommendations = false
+
+    init(manager: ExternalToolSessionManagerProtocol) {
+        self.manager = manager
+    }
+
+    func refreshRecommendedRoots(limit: Int = 12) async {
+        isLoadingRecommendations = true
+        defer {
+            isLoadingRecommendations = false
+            hasLoadedRecommendations = true
+        }
+
+        let normalizedLimit = max(1, min(30, limit))
+        recommendedRoots = await manager.discoverGitRepositoryInsights(
+            searchPaths: nil,
+            limit: normalizedLimit
+        )
+    }
+
+    func applyRecommendedRoot(_ root: GitRepositoryInsight) -> String {
+        root.path
+    }
+}

--- a/Dochi/Views/ExternalToolProfileEditorView.swift
+++ b/Dochi/Views/ExternalToolProfileEditorView.swift
@@ -21,6 +21,7 @@ struct ExternalToolProfileEditorView: View {
     @State private var waitingPattern: String = ""
     @State private var errorPattern: String = ""
     @State private var selectedPreset: ExternalToolPreset? = nil
+    @State private var viewModel: ExternalToolProfileEditorViewModel
 
     private let iconOptions = ["terminal.fill", "hammer", "wrench", "chevron.left.forwardslash.chevron.right", "cpu"]
 
@@ -29,6 +30,7 @@ struct ExternalToolProfileEditorView: View {
         self.existingProfile = existingProfile
         self.onSave = onSave
         self.onCancel = onCancel
+        _viewModel = State(initialValue: ExternalToolProfileEditorViewModel(manager: manager))
     }
 
     var body: some View {
@@ -57,6 +59,63 @@ struct ExternalToolProfileEditorView: View {
                             .font(.system(.body, design: .monospaced))
                         Button("선택") {
                             selectDirectory()
+                        }
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack(spacing: 8) {
+                            Button {
+                                Task { await viewModel.refreshRecommendedRoots() }
+                            } label: {
+                                Label("추천 Git 루트 불러오기", systemImage: "sparkles.rectangle.stack")
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+
+                            if viewModel.isLoadingRecommendations {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else if !viewModel.recommendedRoots.isEmpty {
+                                Text("\(viewModel.recommendedRoots.count)개 추천")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        if !viewModel.recommendedRoots.isEmpty {
+                            VStack(alignment: .leading, spacing: 6) {
+                                ForEach(viewModel.recommendedRoots, id: \.path) { root in
+                                    Button {
+                                        workingDirectory = viewModel.applyRecommendedRoot(root)
+                                    } label: {
+                                        VStack(alignment: .leading, spacing: 3) {
+                                            Text("[\(root.score)] \(root.name) · \(root.branch)")
+                                                .font(.system(size: 11, weight: .semibold))
+                                                .foregroundStyle(.primary)
+                                            Text("최근 \(root.lastCommitRelative) · dirty \(root.changedFileCount)+\(root.untrackedFileCount)")
+                                                .font(.system(size: 10))
+                                                .foregroundStyle(.secondary)
+                                            Text(root.path)
+                                                .font(.system(size: 10, design: .monospaced))
+                                                .foregroundStyle(.secondary)
+                                                .lineLimit(1)
+                                                .truncationMode(.middle)
+                                        }
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 6)
+                                        .background(
+                                            RoundedRectangle(cornerRadius: 6)
+                                                .fill(workingDirectory == root.path ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08))
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
+                                }
+                            }
+                        } else if viewModel.hasLoadedRecommendations, !viewModel.isLoadingRecommendations {
+                            Text("추천 가능한 Git 루트를 찾지 못했습니다.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }
@@ -157,7 +216,7 @@ struct ExternalToolProfileEditorView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
         }
-        .frame(width: 500, height: 600)
+        .frame(width: 520, height: 680)
         .onAppear {
             loadExistingProfile()
         }

--- a/DochiCLI/README.md
+++ b/DochiCLI/README.md
@@ -63,7 +63,8 @@ dochi dev tool conversation.search '{"query":"회의","limit":5}'
 dochi dev log recent --minutes 15
 dochi dev log tail --seconds 30 --category App --level info
 dochi dev chat stream "최근 대화 3개를 요약해줘"
-dochi dev bridge open codex
+dochi dev bridge open codex --cwd ~/repo/dochi
+dochi dev bridge open codex --profile "Dochi Bridge Codex" --cwd ~/work/app --force-working-directory
 dochi dev bridge roots --limit 10
 dochi dev bridge roots --path ~/repo --path ~/work --limit 20
 dochi dev bridge status

--- a/DochiCLI/main.swift
+++ b/DochiCLI/main.swift
@@ -462,14 +462,31 @@ enum DochiCLI {
                 return CLIResult(exitCode: .runtimeError, command: "dev.tool", message: "요청 실패: \(error.localizedDescription)")
             }
 
-        case .bridgeOpen(let agent):
+        case .bridgeOpen(let agent, let profileName, let workingDirectory, let forceWorkingDirectory):
             do {
-                let result = try client.call(method: "bridge.open", params: ["agent": agent])
+                var params: [String: Any] = ["agent": agent]
+                if let profileName, !profileName.isEmpty {
+                    params["profile_name"] = profileName
+                }
+                if let workingDirectory, !workingDirectory.isEmpty {
+                    params["working_directory"] = workingDirectory
+                }
+                if forceWorkingDirectory {
+                    params["force_working_directory"] = true
+                }
+
+                let result = try client.call(method: "bridge.open", params: params)
                 let sessionId = result["session_id"] as? String ?? "-"
                 let profile = result["profile_name"] as? String ?? "-"
+                let cwd = result["working_directory"] as? String ?? "-"
+                let selectionReason = result["selection_reason"] as? String ?? "-"
+                let selectionDetail = result["selection_detail"] as? String ?? "-"
                 let status = result["status"] as? String ?? "-"
                 let reused = (result["reused"] as? Bool == true) ? "재사용" : "새로 생성"
-                let message = "bridge.open \(reused): profile=\(profile), session_id=\(sessionId), status=\(status)"
+                let message = """
+                bridge.open \(reused): profile=\(profile), session_id=\(sessionId), status=\(status), cwd=\(cwd), reason=\(selectionReason)
+                detail: \(selectionDetail)
+                """
                 return CLIResult(exitCode: .success, command: "dev.bridge.open", message: message, data: result)
             } catch let error as CLIControlPlaneError {
                 return mapControlPlaneError(error, command: "dev.bridge.open")
@@ -950,7 +967,7 @@ enum DochiCLI {
           dochi dev log recent [--minutes N]
           dochi dev log tail [--seconds N] [--category C] [--level L] [--contains K]
           dochi dev chat stream <prompt>
-          dochi dev bridge open [agent]
+          dochi dev bridge open [agent] [--profile NAME] [--cwd DIR] [--force-working-directory]
           dochi dev bridge roots [--limit N] [--path DIR]...
           dochi dev bridge status [session_id]
           dochi dev bridge send <session_id> <command>

--- a/DochiTests/BridgeWorkingDirectorySelectorTests.swift
+++ b/DochiTests/BridgeWorkingDirectorySelectorTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Dochi
+
+final class BridgeWorkingDirectorySelectorTests: XCTestCase {
+
+    func testDecideReturnsRecommendedRootForNewProfile() {
+        let decision = BridgeWorkingDirectorySelector.decide(
+            existingProfile: nil,
+            requestedWorkingDirectory: nil,
+            forceWorkingDirectory: false,
+            recommendedRoots: [sampleInsight(path: "/Users/me/repo/top", score: 70)]
+        )
+
+        XCTAssertEqual(decision.workingDirectory, "/Users/me/repo/top")
+        XCTAssertEqual(decision.selectionReason, .recommendedGitRoot)
+    }
+
+    func testDecideFallsBackToHomeWhenNoRecommendation() {
+        let decision = BridgeWorkingDirectorySelector.decide(
+            existingProfile: nil,
+            requestedWorkingDirectory: nil,
+            forceWorkingDirectory: false,
+            recommendedRoots: []
+        )
+
+        XCTAssertEqual(decision.workingDirectory, "~")
+        XCTAssertEqual(decision.selectionReason, .fallbackHomeDirectory)
+    }
+
+    func testDecidePreservesExistingProfileWithoutForce() {
+        let existing = ExternalToolProfile(name: "Bridge", command: "codex", workingDirectory: "~/repo/existing")
+
+        let decision = BridgeWorkingDirectorySelector.decide(
+            existingProfile: existing,
+            requestedWorkingDirectory: "/tmp/new",
+            forceWorkingDirectory: false,
+            recommendedRoots: []
+        )
+
+        XCTAssertEqual(decision.workingDirectory, "~/repo/existing")
+        XCTAssertEqual(decision.selectionReason, .existingProfilePreserved)
+    }
+
+    func testDecideOverridesExistingProfileWithForce() {
+        let existing = ExternalToolProfile(name: "Bridge", command: "codex", workingDirectory: "~/repo/existing")
+
+        let decision = BridgeWorkingDirectorySelector.decide(
+            existingProfile: existing,
+            requestedWorkingDirectory: "/tmp/new",
+            forceWorkingDirectory: true,
+            recommendedRoots: []
+        )
+
+        XCTAssertEqual(decision.workingDirectory, "/tmp/new")
+        XCTAssertEqual(decision.selectionReason, .existingProfileOverridden)
+    }
+
+    func testDecideForActiveSessionIgnoresForcedOverride() {
+        let decision = BridgeWorkingDirectorySelector.decideForActiveSession(
+            profileWorkingDirectory: "~/repo/existing",
+            requestedWorkingDirectory: "/tmp/new",
+            forceWorkingDirectory: true
+        )
+
+        XCTAssertEqual(decision.workingDirectory, "~/repo/existing")
+        XCTAssertEqual(decision.selectionReason, .existingSessionReusedForceIgnored)
+    }
+
+    private func sampleInsight(path: String, score: Int) -> GitRepositoryInsight {
+        GitRepositoryInsight(
+            workDomain: "company",
+            workDomainConfidence: 0.8,
+            workDomainReason: "test",
+            path: path,
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            branch: "main",
+            originURL: "git@github.com:acme/sample.git",
+            remoteHost: "github.com",
+            remoteOwner: "acme",
+            remoteRepository: "sample",
+            lastCommitEpoch: 1_700_000_000,
+            lastCommitISO8601: "2023-11-14T22:13:20.000Z",
+            lastCommitRelative: "1d ago",
+            upstreamLastCommitEpoch: 1_700_000_000,
+            upstreamLastCommitISO8601: "2023-11-14T22:13:20.000Z",
+            upstreamLastCommitRelative: "1d ago",
+            daysSinceLastCommit: 1,
+            recentCommitCount30d: 10,
+            changedFileCount: 2,
+            untrackedFileCount: 1,
+            aheadCount: 0,
+            behindCount: 0,
+            score: score
+        )
+    }
+}

--- a/DochiTests/CLICommandSurfaceTests.swift
+++ b/DochiTests/CLICommandSurfaceTests.swift
@@ -37,6 +37,32 @@ final class CLICommandSurfaceTests: XCTestCase {
         XCTAssertEqual(invocation.command, .dev(.bridgeSend(sessionId: "abc-123", command: "run tests")))
     }
 
+    func testParseDevBridgeOpenWithOptions() throws {
+        let invocation = try CLICommandParser.parse([
+            "dev", "bridge", "open", "codex",
+            "--profile", "Dochi Bridge Codex",
+            "--cwd", "~/repo/dochi",
+            "--force-working-directory",
+        ])
+        XCTAssertEqual(
+            invocation.command,
+            .dev(.bridgeOpen(
+                agent: "codex",
+                profileName: "Dochi Bridge Codex",
+                workingDirectory: "~/repo/dochi",
+                forceWorkingDirectory: true
+            ))
+        )
+    }
+
+    func testParseDevBridgeOpenWithoutOptionsDefaultsToCodex() throws {
+        let invocation = try CLICommandParser.parse(["dev", "bridge", "open"])
+        XCTAssertEqual(
+            invocation.command,
+            .dev(.bridgeOpen(agent: "codex", profileName: nil, workingDirectory: nil, forceWorkingDirectory: false))
+        )
+    }
+
     func testParseDevBridgeRootsWithOptions() throws {
         let invocation = try CLICommandParser.parse([
             "dev", "bridge", "roots",

--- a/DochiTests/DochiDevBridgeToolTests.swift
+++ b/DochiTests/DochiDevBridgeToolTests.swift
@@ -18,6 +18,7 @@ final class DochiDevBridgeToolTests: XCTestCase {
         XCTAssertEqual(manager.startSessionCallCount, 1)
         XCTAssertEqual(manager.sessions.count, 1)
         XCTAssertTrue(result.content.contains("session_id"))
+        XCTAssertTrue(result.content.contains("selection_reason: requested_working_directory"))
     }
 
     func testBridgeOpenReusesExistingSession() async throws {
@@ -36,6 +37,118 @@ final class DochiDevBridgeToolTests: XCTestCase {
         XCTAssertFalse(result.isError)
         XCTAssertEqual(manager.startSessionCallCount, 1)
         XCTAssertTrue(result.content.contains("이미 열려 있습니다"))
+        XCTAssertTrue(result.content.contains("selection_reason: existing_session_reused"))
+    }
+
+    func testBridgeOpenPreservesExistingProfileWorkingDirectoryWithoutForce() async {
+        let manager = MockExternalToolSessionManager()
+        let existingProfile = ExternalToolProfile(
+            name: "Dochi Bridge Codex",
+            command: "codex",
+            workingDirectory: "~/repo/existing"
+        )
+        manager.saveProfile(existingProfile)
+        let tool = DochiBridgeOpenTool(manager: manager)
+
+        let result = await tool.execute(arguments: [
+            "agent": "codex",
+            "working_directory": "/tmp/new"
+        ])
+
+        XCTAssertFalse(result.isError)
+        XCTAssertEqual(manager.startSessionCallCount, 1)
+        let saved = manager.profiles.first(where: { $0.id == existingProfile.id })
+        XCTAssertEqual(saved?.workingDirectory, "~/repo/existing")
+        XCTAssertTrue(result.content.contains("working_directory: ~/repo/existing"))
+        XCTAssertTrue(result.content.contains("selection_reason: existing_profile_preserved"))
+    }
+
+    func testBridgeOpenForceWorkingDirectoryOverridesExistingProfile() async {
+        let manager = MockExternalToolSessionManager()
+        let existingProfile = ExternalToolProfile(
+            name: "Dochi Bridge Codex",
+            command: "codex",
+            workingDirectory: "~/repo/existing"
+        )
+        manager.saveProfile(existingProfile)
+        let tool = DochiBridgeOpenTool(manager: manager)
+
+        let result = await tool.execute(arguments: [
+            "agent": "codex",
+            "working_directory": "/tmp/new",
+            "force_working_directory": true,
+        ])
+
+        XCTAssertFalse(result.isError)
+        XCTAssertEqual(manager.startSessionCallCount, 1)
+        let saved = manager.profiles.first(where: { $0.id == existingProfile.id })
+        XCTAssertEqual(saved?.workingDirectory, "/tmp/new")
+        XCTAssertTrue(result.content.contains("working_directory: /tmp/new"))
+        XCTAssertTrue(result.content.contains("selection_reason: existing_profile_overridden"))
+    }
+
+    func testBridgeOpenFallsBackToRecommendedRootForNewProfile() async {
+        let manager = MockExternalToolSessionManager()
+        manager.mockGitRepositoryInsights = [
+            GitRepositoryInsight(
+                workDomain: "company",
+                workDomainConfidence: 0.9,
+                workDomainReason: "test",
+                path: "/Users/me/repo/top",
+                name: "top",
+                branch: "main",
+                originURL: "git@github.com:acme/top.git",
+                remoteHost: "github.com",
+                remoteOwner: "acme",
+                remoteRepository: "top",
+                lastCommitEpoch: 1_700_000_000,
+                lastCommitISO8601: "2023-11-14T22:13:20.000Z",
+                lastCommitRelative: "1d ago",
+                upstreamLastCommitEpoch: 1_700_000_000,
+                upstreamLastCommitISO8601: "2023-11-14T22:13:20.000Z",
+                upstreamLastCommitRelative: "1d ago",
+                daysSinceLastCommit: 1,
+                recentCommitCount30d: 12,
+                changedFileCount: 3,
+                untrackedFileCount: 1,
+                aheadCount: 0,
+                behindCount: 0,
+                score: 67
+            )
+        ]
+        let tool = DochiBridgeOpenTool(manager: manager)
+
+        let result = await tool.execute(arguments: ["agent": "codex"])
+
+        XCTAssertFalse(result.isError)
+        XCTAssertEqual(manager.startSessionCallCount, 1)
+        let saved = manager.profiles.first(where: { $0.name == "Dochi Bridge Codex" })
+        XCTAssertEqual(saved?.workingDirectory, "/Users/me/repo/top")
+        XCTAssertTrue(result.content.contains("working_directory: /Users/me/repo/top"))
+        XCTAssertTrue(result.content.contains("selection_reason: recommended_git_root"))
+    }
+
+    func testBridgeOpenIgnoresForceWhenSessionAlreadyRunning() async throws {
+        let manager = MockExternalToolSessionManager()
+        let existingProfile = ExternalToolProfile(
+            name: "Dochi Bridge Codex",
+            command: "codex",
+            workingDirectory: "~/repo/existing"
+        )
+        manager.saveProfile(existingProfile)
+        try await manager.startSession(profileId: existingProfile.id)
+        let tool = DochiBridgeOpenTool(manager: manager)
+
+        let result = await tool.execute(arguments: [
+            "agent": "codex",
+            "working_directory": "/tmp/new",
+            "force_working_directory": true,
+        ])
+
+        XCTAssertFalse(result.isError)
+        XCTAssertEqual(manager.startSessionCallCount, 1)
+        XCTAssertTrue(result.content.contains("working_directory: ~/repo/existing"))
+        XCTAssertTrue(result.content.contains("selection_reason: existing_session_reused_force_ignored"))
     }
 
     func testBridgeSendDispatchesCommand() async throws {

--- a/DochiTests/ExternalToolProfileEditorViewModelTests.swift
+++ b/DochiTests/ExternalToolProfileEditorViewModelTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class ExternalToolProfileEditorViewModelTests: XCTestCase {
+
+    func testRefreshRecommendedRootsLoadsInsights() async {
+        let manager = MockExternalToolSessionManager()
+        manager.mockGitRepositoryInsights = [
+            sampleInsight(path: "/Users/me/repo/a", score: 60),
+            sampleInsight(path: "/Users/me/repo/b", score: 42),
+        ]
+        let viewModel = ExternalToolProfileEditorViewModel(manager: manager)
+
+        await viewModel.refreshRecommendedRoots(limit: 1)
+
+        XCTAssertFalse(viewModel.isLoadingRecommendations)
+        XCTAssertTrue(viewModel.hasLoadedRecommendations)
+        XCTAssertEqual(viewModel.recommendedRoots.count, 1)
+        XCTAssertEqual(viewModel.recommendedRoots.first?.path, "/Users/me/repo/a")
+    }
+
+    func testApplyRecommendedRootReturnsPath() {
+        let manager = MockExternalToolSessionManager()
+        let viewModel = ExternalToolProfileEditorViewModel(manager: manager)
+        let root = sampleInsight(path: "/Users/me/repo/a", score: 60)
+
+        let path = viewModel.applyRecommendedRoot(root)
+
+        XCTAssertEqual(path, "/Users/me/repo/a")
+    }
+
+    private func sampleInsight(path: String, score: Int) -> GitRepositoryInsight {
+        GitRepositoryInsight(
+            workDomain: "company",
+            workDomainConfidence: 0.8,
+            workDomainReason: "test",
+            path: path,
+            name: URL(fileURLWithPath: path).lastPathComponent,
+            branch: "main",
+            originURL: "git@github.com:acme/sample.git",
+            remoteHost: "github.com",
+            remoteOwner: "acme",
+            remoteRepository: "sample",
+            lastCommitEpoch: 1_700_000_000,
+            lastCommitISO8601: "2023-11-14T22:13:20.000Z",
+            lastCommitRelative: "1d ago",
+            upstreamLastCommitEpoch: 1_700_000_000,
+            upstreamLastCommitISO8601: "2023-11-14T22:13:20.000Z",
+            upstreamLastCommitRelative: "1d ago",
+            daysSinceLastCommit: 1,
+            recentCommitCount30d: 10,
+            changedFileCount: 2,
+            untrackedFileCount: 1,
+            aheadCount: 0,
+            behindCount: 0,
+            score: score
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Reworked `bridge.open` cwd selection around repository-root UX with explicit decision metadata.
- Added `working_directory`, `selection_reason`, and `selection_detail` to `bridge.open` responses.
- Added `force_working_directory` handling for existing profile reuse paths.
- Added profile editor UX to load recommended Git roots (score/recent commit/dirty) and apply with one click.
- Extended CLI `dev bridge open` options (`--profile`, `--cwd`, `--force-working-directory`) and surfaced cwd selection reason in output.

## UX details
- New profile without `working_directory` now defaults to top recommended Git root (fallback to `~` when unavailable).
- Existing profile reuse is explicit in response, and force overwrite behavior is visible.
- Active session reuse clearly reports when force overwrite cannot be applied to a running session.

## Tests
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/CLICommandSurfaceTests -only-testing:DochiTests/DochiDevBridgeToolTests -only-testing:DochiTests/BridgeWorkingDirectorySelectorTests -only-testing:DochiTests/ExternalToolProfileEditorViewModelTests`
- `xcodebuild -project Dochi.xcodeproj -scheme DochiCLI -configuration Debug build`

## Spec Impact
- Behavior changed for bridge open cwd resolution and CLI options.
- User-facing CLI examples updated in `DochiCLI/README.md`.

Closes #240
