### PR TITLE
fix: 설정/온보딩 액션 실패를 UI에 가시화

### DIFF
--- a/Dochi/Utilities/KeychainWriteCoordinator.swift
+++ b/Dochi/Utilities/KeychainWriteCoordinator.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum KeychainWriteCoordinator {
+    @MainActor
+    static func saveRequiredValue(
+        _ value: String,
+        account: String,
+        keychain: KeychainServiceProtocol
+    ) -> Result<Void, Error> {
+        do {
+            try keychain.save(account: account, value: value)
+            return .success(())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    @MainActor
+    static func saveTrimmedToken(
+        _ token: String,
+        account: String,
+        keychain: KeychainServiceProtocol
+    ) -> Result<Bool, Error> {
+        let trimmed = token.trimmingCharacters(in: .whitespaces)
+        do {
+            if trimmed.isEmpty {
+                try keychain.delete(account: account)
+                return .success(false)
+            }
+            try keychain.save(account: account, value: trimmed)
+            return .success(true)
+        } catch {
+            return .failure(error)
+        }
+    }
+}

--- a/Dochi/Views/OnboardingView.swift
+++ b/Dochi/Views/OnboardingView.swift
@@ -449,8 +449,18 @@ struct OnboardingView: View {
         guard !apiKey.isEmpty else { return }
         errorMessage = nil
 
-        // Save key immediately
-        try? keychainService.save(account: selectedProvider.keychainAccount, value: apiKey)
+        // Save key immediately and block step transition on failure.
+        switch KeychainWriteCoordinator.saveRequiredValue(
+            apiKey,
+            account: selectedProvider.keychainAccount,
+            keychain: keychainService
+        ) {
+        case .success:
+            break
+        case .failure(let error):
+            errorMessage = "API 키 저장 실패: \(error.localizedDescription)"
+            return
+        }
 
         withAnimation {
             step = .profile

--- a/Dochi/Views/Settings/AccountSettingsView.swift
+++ b/Dochi/Views/Settings/AccountSettingsView.swift
@@ -15,6 +15,8 @@ struct AccountSettingsView: View {
     @State private var lastSyncTime: Date?
     @State private var showInitialSyncWizard = false
     @State private var showConflictSheet = false
+    @State private var isSigningOut = false
+    @State private var authStatusMessage: String?
 
     var body: some View {
         Form {
@@ -65,13 +67,34 @@ struct AccountSettingsView: View {
                         Text(authEmail ?? "로그인됨")
                             .font(.system(size: 13))
                         Spacer()
-                        Button("로그아웃") {
-                            Task {
-                                try? await service.signOut()
+                        Button {
+                            Task { @MainActor in
+                                isSigningOut = true
+                                defer { isSigningOut = false }
+                                do {
+                                    try await service.signOut()
+                                    authStatusMessage = "로그아웃 완료"
+                                } catch {
+                                    authStatusMessage = "로그아웃 실패: \(error.localizedDescription)"
+                                }
+                            }
+                        } label: {
+                            HStack(spacing: 4) {
+                                if isSigningOut {
+                                    ProgressView()
+                                        .scaleEffect(0.5)
+                                }
+                                Text("로그아웃")
                             }
                         }
+                        .disabled(isSigningOut)
                         .buttonStyle(.bordered)
                         .controlSize(.small)
+                    }
+                    if let authStatusMessage {
+                        Text(authStatusMessage)
+                            .font(.caption)
+                            .foregroundStyle(authStatusMessage.contains("실패") ? .red : .secondary)
                     }
                 } else {
                     HStack {

--- a/Dochi/Views/Settings/IntegrationsSettingsView.swift
+++ b/Dochi/Views/Settings/IntegrationsSettingsView.swift
@@ -11,6 +11,8 @@ struct IntegrationsSettingsView: View {
     @State private var botUsername: String?
     @State private var botCheckError: String?
     @State private var isCheckingBot = false
+    @State private var telegramSaveStatus: String?
+    @State private var connectionErrorMessage: String?
 
     // MCP state
     @State private var showMCPServerEdit = false
@@ -117,6 +119,18 @@ struct IntegrationsSettingsView: View {
                     .foregroundStyle(.red)
             }
 
+            if let status = telegramSaveStatus {
+                Text(status)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let connectionErrorMessage {
+                Text(connectionErrorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
             Toggle("스트리밍 답변", isOn: Binding(
                 get: { settings.telegramStreamReplies },
                 set: { settings.telegramStreamReplies = $0 }
@@ -190,15 +204,25 @@ struct IntegrationsSettingsView: View {
     }
 
     private func saveBotToken() {
-        let token = botToken.trimmingCharacters(in: .whitespaces)
-        if token.isEmpty {
-            try? keychainService.delete(account: "telegram_bot_token")
-            stopTelegramConnection()
-        } else {
-            try? keychainService.save(account: "telegram_bot_token", value: token)
-            if settings.telegramEnabled {
-                startTelegramConnectionIfPossible()
+        switch KeychainWriteCoordinator.saveTrimmedToken(
+            botToken,
+            account: "telegram_bot_token",
+            keychain: keychainService
+        ) {
+        case .success(let hasToken):
+            botCheckError = nil
+            connectionErrorMessage = nil
+            telegramSaveStatus = hasToken ? "토큰 저장 완료" : "토큰 삭제 완료"
+            if hasToken {
+                if settings.telegramEnabled {
+                    startTelegramConnectionIfPossible()
+                }
+            } else {
+                stopTelegramConnection()
             }
+        case .failure(let error):
+            telegramSaveStatus = nil
+            botCheckError = "토큰 저장 실패: \(error.localizedDescription)"
         }
     }
 
@@ -210,15 +234,20 @@ struct IntegrationsSettingsView: View {
 
         // Reset existing connection before switching transport mode.
         stopTelegramConnection()
+        connectionErrorMessage = nil
 
         let mode = TelegramConnectionMode(rawValue: settings.telegramConnectionMode) ?? .polling
         if mode == .webhook, !settings.telegramWebhookURL.isEmpty {
-            Task {
-                try? await telegramService?.startWebhook(
-                    token: token,
-                    url: settings.telegramWebhookURL,
-                    port: UInt16(settings.telegramWebhookPort)
-                )
+            Task { @MainActor in
+                do {
+                    try await telegramService?.startWebhook(
+                        token: token,
+                        url: settings.telegramWebhookURL,
+                        port: UInt16(settings.telegramWebhookPort)
+                    )
+                } catch {
+                    connectionErrorMessage = "웹훅 시작 실패: \(error.localizedDescription)"
+                }
             }
         } else {
             telegramService?.startPolling(token: token)
@@ -227,7 +256,13 @@ struct IntegrationsSettingsView: View {
 
     private func stopTelegramConnection() {
         telegramService?.stopPolling()
-        Task { try? await telegramService?.stopWebhook() }
+        Task { @MainActor in
+            do {
+                try await telegramService?.stopWebhook()
+            } catch {
+                connectionErrorMessage = "웹훅 중지 실패: \(error.localizedDescription)"
+            }
+        }
     }
 
     private func checkBot() {

--- a/Dochi/Views/Settings/MCPServerEditView.swift
+++ b/Dochi/Views/Settings/MCPServerEditView.swift
@@ -169,6 +169,7 @@ struct MCPServerEditView: View {
         let trimmedName = name.trimmingCharacters(in: .whitespaces)
         let trimmedCommand = command.trimmingCharacters(in: .whitespaces)
         guard !trimmedName.isEmpty, !trimmedCommand.isEmpty else { return }
+        errorMessage = nil
 
         let args = arguments.map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
         var env: [String: String] = [:]
@@ -203,7 +204,12 @@ struct MCPServerEditView: View {
         mcpService?.addServer(config: config)
 
         // Persist to AppStorage
-        persistMCPServers()
+        do {
+            try persistMCPServers()
+        } catch {
+            errorMessage = "MCP 서버 저장 실패: \(error.localizedDescription)"
+            return
+        }
 
         // Auto-connect if enabled
         if isEnabled {
@@ -226,11 +232,16 @@ struct MCPServerEditView: View {
         }
     }
 
-    private func persistMCPServers() {
+    private func persistMCPServers() throws {
         let servers = mcpService?.listServers() ?? []
-        if let data = try? JSONEncoder().encode(servers),
-           let json = String(data: data, encoding: .utf8) {
-            UserDefaults.standard.set(json, forKey: "mcpServersJSON")
+        let data = try JSONEncoder().encode(servers)
+        guard let json = String(data: data, encoding: .utf8) else {
+            throw NSError(
+                domain: "MCPServerEditView",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "MCP 서버 목록 직렬화에 실패했습니다."]
+            )
         }
+        UserDefaults.standard.set(json, forKey: "mcpServersJSON")
     }
 }

--- a/Dochi/Views/SystemStatusSheetView.swift
+++ b/Dochi/Views/SystemStatusSheetView.swift
@@ -322,6 +322,8 @@ private struct CloudSyncTabView: View {
     var syncEngine: SyncEngine?
 
     @State private var showConflictSheet = false
+    @State private var isLegacySyncing = false
+    @State private var legacySyncStatus: String?
 
     var body: some View {
         if let service = supabaseService, service.authState.isSignedIn {
@@ -568,18 +570,39 @@ private struct CloudSyncTabView: View {
                 .buttonStyle(.bordered)
                 .disabled(engine.syncState == .syncing)
             } else {
-                Button {
-                    Task {
-                        try? await service.syncContext()
-                        try? await service.syncConversations()
+                VStack(alignment: .leading, spacing: 4) {
+                    Button {
+                        Task { @MainActor in
+                            isLegacySyncing = true
+                            defer { isLegacySyncing = false }
+                            do {
+                                try await service.syncContext()
+                                try await service.syncConversations()
+                                legacySyncStatus = "동기화 완료"
+                            } catch {
+                                legacySyncStatus = "동기화 실패: \(error.localizedDescription)"
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            if isLegacySyncing {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "arrow.triangle.2.circlepath")
+                            }
+                            Text("수동 동기화")
+                        }
                     }
-                } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "arrow.triangle.2.circlepath")
-                        Text("수동 동기화")
+                    .buttonStyle(.bordered)
+                    .disabled(isLegacySyncing)
+
+                    if let legacySyncStatus {
+                        Text(legacySyncStatus)
+                            .font(.system(size: 11))
+                            .foregroundStyle(legacySyncStatus.contains("실패") ? .red : .secondary)
                     }
                 }
-                .buttonStyle(.bordered)
             }
 
             Spacer()

--- a/DochiTests/KeychainWriteCoordinatorTests.swift
+++ b/DochiTests/KeychainWriteCoordinatorTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class KeychainWriteCoordinatorTests: XCTestCase {
+    func testSaveRequiredValueSuccess() {
+        let keychain = MockKeychainService()
+        let result = KeychainWriteCoordinator.saveRequiredValue(
+            "sk-test",
+            account: "openai_api_key",
+            keychain: keychain
+        )
+
+        switch result {
+        case .success:
+            XCTAssertEqual(keychain.load(account: "openai_api_key"), "sk-test")
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        }
+    }
+
+    func testSaveRequiredValueFailure() {
+        let keychain = FailingKeychainService(failOnSave: true)
+        let result = KeychainWriteCoordinator.saveRequiredValue(
+            "sk-test",
+            account: "openai_api_key",
+            keychain: keychain
+        )
+
+        switch result {
+        case .success:
+            XCTFail("Expected failure")
+        case .failure:
+            XCTAssertTrue(true)
+        }
+    }
+
+    func testSaveTrimmedTokenSavesTrimmedValue() {
+        let keychain = MockKeychainService()
+        let result = KeychainWriteCoordinator.saveTrimmedToken(
+            "  bot-token  ",
+            account: "telegram_bot_token",
+            keychain: keychain
+        )
+
+        switch result {
+        case .success(let hasToken):
+            XCTAssertTrue(hasToken)
+            XCTAssertEqual(keychain.load(account: "telegram_bot_token"), "bot-token")
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        }
+    }
+
+    func testSaveTrimmedTokenDeletesOnEmpty() {
+        let keychain = MockKeychainService()
+        try? keychain.save(account: "telegram_bot_token", value: "existing")
+
+        let result = KeychainWriteCoordinator.saveTrimmedToken(
+            "   ",
+            account: "telegram_bot_token",
+            keychain: keychain
+        )
+
+        switch result {
+        case .success(let hasToken):
+            XCTAssertFalse(hasToken)
+            XCTAssertNil(keychain.load(account: "telegram_bot_token"))
+        case .failure(let error):
+            XCTFail("Unexpected failure: \(error)")
+        }
+    }
+
+    func testSaveTrimmedTokenFailureOnDelete() {
+        let keychain = FailingKeychainService(failOnDelete: true)
+        let result = KeychainWriteCoordinator.saveTrimmedToken(
+            "",
+            account: "telegram_bot_token",
+            keychain: keychain
+        )
+
+        switch result {
+        case .success:
+            XCTFail("Expected failure")
+        case .failure:
+            XCTAssertTrue(true)
+        }
+    }
+}
+
+@MainActor
+private final class FailingKeychainService: KeychainServiceProtocol {
+    let failOnSave: Bool
+    let failOnDelete: Bool
+
+    init(failOnSave: Bool = false, failOnDelete: Bool = false) {
+        self.failOnSave = failOnSave
+        self.failOnDelete = failOnDelete
+    }
+
+    func save(account: String, value: String) throws {
+        if failOnSave {
+            throw NSError(domain: "FailingKeychainService", code: 1, userInfo: [NSLocalizedDescriptionKey: "save failed"])
+        }
+    }
+
+    func load(account: String) -> String? { nil }
+
+    func delete(account: String) throws {
+        if failOnDelete {
+            throw NSError(domain: "FailingKeychainService", code: 2, userInfo: [NSLocalizedDescriptionKey: "delete failed"])
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 설정/온보딩 핵심 액션에서 실패가 묵살되던 경로를 `do/catch` 기반 사용자 피드백으로 전환했습니다.
- `OnboardingView` API 키 저장 실패 시 다음 단계로 진행하지 않도록 차단했습니다.
- `IntegrationsSettingsView`에서 텔레그램 토큰 저장 및 웹훅 시작/중지 실패를 UI에 표시하도록 개선했습니다.
- `AccountSettingsView` 로그아웃 액션에 진행 상태/성공/실패 메시지를 추가했습니다.
- `MCPServerEditView` 직렬화 실패를 에러 메시지로 노출하도록 변경했습니다.
- `SystemStatusSheetView` legacy 동기화 버튼에 진행 상태와 완료/실패 텍스트를 추가했습니다.
- 공통 키체인 쓰기 헬퍼(`KeychainWriteCoordinator`)와 단위 테스트를 추가했습니다.

## UX 반영
- 저장/연결/로그아웃/동기화 액션마다 `진행중 -> 성공/실패` 피드백을 노출
- 실패 시 액션 맥락이 포함된 문구로 사용자에게 즉시 원인 전달

## Test Evidence
- 실행 명령:
  - `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/KeychainWriteCoordinatorTests -only-testing:DochiTests/OnboardingGuideTests`
- 결과:
  - 저장소 기존 컴파일 이슈(`GitRepositoryInsight` 타입 누락, `ResourceOptimizerProtocol`)로 테스트 빌드 단계에서 실패.
  - 본 PR 변경 파일(`OnboardingView`, `IntegrationsSettingsView`, `AccountSettingsView`, `MCPServerEditView`, `SystemStatusSheetView`)은 컴파일 단계에 진입해 오류 없이 진행됨.

## Spec Impact
- 피드백 원칙/갭은 감사 문서 참조:
  - `/Users/hckim/repo/dochi/spec/ui-interaction-feedback-audit.md`

Closes #252
