### PR TITLE
fix: 파일/외부앱 인터랙션 실패 피드백 추가

### DIFF
--- a/Dochi/Utilities/UIFeedbackMessageBuilder.swift
+++ b/Dochi/Utilities/UIFeedbackMessageBuilder.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+enum UIFeedbackMessageBuilder {
+    static func imageAttachmentFailure(count: Int) -> String {
+        if count <= 1 {
+            return "이미지 첨부에 실패했습니다."
+        }
+        return "이미지 \(count)개 첨부에 실패했습니다."
+    }
+
+    static func appOpenFailure(appName: String) -> String {
+        "\(appName) 열기에 실패했습니다."
+    }
+}

--- a/Dochi/Views/ContentView.swift
+++ b/Dochi/Views/ContentView.swift
@@ -933,7 +933,9 @@ struct ContentView: View {
                 Task { await manager.checkAllHealth() }
             }
         case .openShortcutsApp:
-            NSWorkspace.shared.open(URL(string: "shortcuts://")!)
+            if !NSWorkspace.shared.open(URL(string: "shortcuts://")!) {
+                viewModel.errorMessage = UIFeedbackMessageBuilder.appOpenFailure(appName: "단축어 앱")
+            }
         case .custom(let id):
             if id.hasPrefix("switchUser-") {
                 let userIdStr = String(id.dropFirst("switchUser-".count))
@@ -1764,11 +1766,18 @@ struct InputBarView: View {
         panel.begin { response in
             guard response == .OK else { return }
             let urls = Array(panel.urls.prefix(remaining))
+            var failedCount = 0
             for url in urls {
-                if let data = try? Data(contentsOf: url) {
+                do {
+                    let data = try Data(contentsOf: url)
                     let fileName = url.lastPathComponent
                     viewModel.addImageFromData(data, fileName: fileName)
+                } catch {
+                    failedCount += 1
                 }
+            }
+            if failedCount > 0 {
+                viewModel.errorMessage = UIFeedbackMessageBuilder.imageAttachmentFailure(count: failedCount)
             }
         }
     }
@@ -1778,6 +1787,7 @@ struct InputBarView: View {
 
         // Check for image data on clipboard
         guard let types = pasteboard.types else { return false }
+        var failedCount = 0
 
         // Try to get image from pasteboard
         let imageTypes: [NSPasteboard.PasteboardType] = [.tiff, .png]
@@ -1787,6 +1797,7 @@ struct InputBarView: View {
                     viewModel.addImage(image, fileName: "clipboard")
                     return true
                 }
+                failedCount += 1
             }
         }
 
@@ -1795,13 +1806,19 @@ struct InputBarView: View {
             for url in urls {
                 let ext = url.pathExtension.lowercased()
                 guard ImageAttachment.supportedExtensions.contains(ext) else { continue }
-                if let data = try? Data(contentsOf: url) {
+                do {
+                    let data = try Data(contentsOf: url)
                     viewModel.addImageFromData(data, fileName: url.lastPathComponent)
                     return true
+                } catch {
+                    failedCount += 1
                 }
             }
         }
 
+        if failedCount > 0 {
+            viewModel.errorMessage = UIFeedbackMessageBuilder.imageAttachmentFailure(count: failedCount)
+        }
         return false
     }
 
@@ -1809,10 +1826,14 @@ struct InputBarView: View {
         for provider in providers {
             // Try loading as NSImage
             if provider.canLoadObject(ofClass: NSImage.self) {
-                _ = provider.loadObject(ofClass: NSImage.self) { image, _ in
+                _ = provider.loadObject(ofClass: NSImage.self) { image, error in
                     if let nsImage = image as? NSImage {
                         Task { @MainActor in
                             viewModel.addImage(nsImage, fileName: "dropped")
+                        }
+                    } else if error != nil {
+                        Task { @MainActor in
+                            viewModel.errorMessage = UIFeedbackMessageBuilder.imageAttachmentFailure(count: 1)
                         }
                     }
                 }
@@ -1824,9 +1845,14 @@ struct InputBarView: View {
                        let url = URL(dataRepresentation: data, relativeTo: nil) {
                         let ext = url.pathExtension.lowercased()
                         guard ImageAttachment.supportedExtensions.contains(ext) else { return }
-                        if let fileData = try? Data(contentsOf: url) {
+                        do {
+                            let fileData = try Data(contentsOf: url)
                             Task { @MainActor in
                                 viewModel.addImageFromData(fileData, fileName: url.lastPathComponent)
+                            }
+                        } catch {
+                            Task { @MainActor in
+                                viewModel.errorMessage = UIFeedbackMessageBuilder.imageAttachmentFailure(count: 1)
                             }
                         }
                     }

--- a/Dochi/Views/RAG/DocumentLibraryView.swift
+++ b/Dochi/Views/RAG/DocumentLibraryView.swift
@@ -116,7 +116,12 @@ struct DocumentLibraryView: View {
                                 refreshDocuments()
                             } onReindex: {
                                 Task {
-                                    try? await documentIndexer.indexFile(at: URL(fileURLWithPath: doc.filePath))
+                                    do {
+                                        try await documentIndexer.indexFile(at: URL(fileURLWithPath: doc.filePath))
+                                        errorMessage = nil
+                                    } catch {
+                                        errorMessage = "재인덱싱 실패: \(error.localizedDescription)"
+                                    }
                                     refreshDocuments()
                                 }
                             }

--- a/Dochi/Views/Settings/PluginSettingsView.swift
+++ b/Dochi/Views/Settings/PluginSettingsView.swift
@@ -5,25 +5,45 @@ struct PluginSettingsView: View {
     var pluginManager: PluginManagerProtocol?
 
     @State private var selectedPlugin: PluginInfo?
+    @State private var launchErrorMessage: String?
 
     var body: some View {
-        if let pluginManager {
-            pluginContent(pluginManager)
-        } else {
-            VStack(spacing: 12) {
-                Spacer()
-                Image(systemName: "exclamationmark.triangle")
-                    .font(.system(size: 28))
-                    .foregroundStyle(.secondary)
-                Text("플러그인")
-                    .font(.headline)
-                Text("플러그인 관리자가 초기화되지 않았습니다.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                Spacer()
+        Group {
+            if let pluginManager {
+                pluginContent(pluginManager)
+            } else {
+                VStack(spacing: 12) {
+                    Spacer()
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 28))
+                        .foregroundStyle(.secondary)
+                    Text("플러그인")
+                        .font(.headline)
+                    Text("플러그인 관리자가 초기화되지 않았습니다.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .alert(
+            "앱 열기 실패",
+            isPresented: Binding(
+                get: { launchErrorMessage != nil },
+                set: { newValue in
+                    if !newValue { launchErrorMessage = nil }
+                }
+            ),
+            actions: {
+                Button("확인", role: .cancel) {
+                    launchErrorMessage = nil
+                }
+            },
+            message: {
+                Text(launchErrorMessage ?? "")
+            }
+        )
     }
 
     @ViewBuilder
@@ -44,7 +64,7 @@ struct PluginSettingsView: View {
                     }
                     Spacer()
                     Button("폴더 열기") {
-                        NSWorkspace.shared.open(manager.pluginDirectory)
+                        openPluginDirectory(manager.pluginDirectory)
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
@@ -70,7 +90,7 @@ struct PluginSettingsView: View {
                             .font(.subheadline)
                             .foregroundStyle(.tertiary)
                         Button("플러그인 폴더 열기") {
-                            NSWorkspace.shared.open(manager.pluginDirectory)
+                            openPluginDirectory(manager.pluginDirectory)
                         }
                         .buttonStyle(.bordered)
                     }
@@ -115,6 +135,12 @@ struct PluginSettingsView: View {
             if let manager = pluginManager {
                 PluginDetailSheet(pluginId: plugin.id, pluginManager: manager)
             }
+        }
+    }
+
+    private func openPluginDirectory(_ url: URL) {
+        if !NSWorkspace.shared.open(url) {
+            launchErrorMessage = UIFeedbackMessageBuilder.appOpenFailure(appName: "플러그인 폴더")
         }
     }
 }

--- a/Dochi/Views/Settings/ShortcutsSettingsView.swift
+++ b/Dochi/Views/Settings/ShortcutsSettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct ShortcutsSettingsView: View {
     @State private var executionLogs: [ShortcutExecutionLog] = []
+    @State private var launchErrorMessage: String?
 
     var body: some View {
         Form {
@@ -16,6 +17,23 @@ struct ShortcutsSettingsView: View {
         .onAppear {
             loadLogs()
         }
+        .alert(
+            "앱 열기 실패",
+            isPresented: Binding(
+                get: { launchErrorMessage != nil },
+                set: { newValue in
+                    if !newValue { launchErrorMessage = nil }
+                }
+            ),
+            actions: {
+                Button("확인", role: .cancel) {
+                    launchErrorMessage = nil
+                }
+            },
+            message: {
+                Text(launchErrorMessage ?? "")
+            }
+        )
     }
 
     // MARK: - Shortcuts Status Section
@@ -161,11 +179,15 @@ struct ShortcutsSettingsView: View {
     // MARK: - Actions
 
     private func openShortcutsApp() {
-        NSWorkspace.shared.open(URL(string: "shortcuts://")!)
+        if !NSWorkspace.shared.open(URL(string: "shortcuts://")!) {
+            launchErrorMessage = UIFeedbackMessageBuilder.appOpenFailure(appName: "단축어 앱")
+        }
     }
 
     private func openSiriSettings() {
-        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.Siri")!)
+        if !NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.Siri")!) {
+            launchErrorMessage = UIFeedbackMessageBuilder.appOpenFailure(appName: "Siri 설정")
+        }
     }
 
     private func loadLogs() {

--- a/DochiTests/UIFeedbackMessageBuilderTests.swift
+++ b/DochiTests/UIFeedbackMessageBuilderTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Dochi
+
+final class UIFeedbackMessageBuilderTests: XCTestCase {
+    func testImageAttachmentFailureSingle() {
+        XCTAssertEqual(
+            UIFeedbackMessageBuilder.imageAttachmentFailure(count: 1),
+            "이미지 첨부에 실패했습니다."
+        )
+    }
+
+    func testImageAttachmentFailureMultiple() {
+        XCTAssertEqual(
+            UIFeedbackMessageBuilder.imageAttachmentFailure(count: 3),
+            "이미지 3개 첨부에 실패했습니다."
+        )
+    }
+
+    func testAppOpenFailureMessage() {
+        XCTAssertEqual(
+            UIFeedbackMessageBuilder.appOpenFailure(appName: "단축어 앱"),
+            "단축어 앱 열기에 실패했습니다."
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- 문서 라이브러리 개별 재인덱싱 경로에서 실패를 조용히 무시하지 않고 에러 메시지를 노출하도록 수정했습니다.
- 이미지 첨부(파일 선택/클립보드/드롭) 실패 시 실패 개수 기반 메시지를 사용자에게 표시하도록 개선했습니다.
- 외부 앱 열기 액션(단축어 앱, Siri 설정, 플러그인 폴더) 실패 시 alert로 안내하도록 변경했습니다.
- 공통 문구 생성을 위해 `UIFeedbackMessageBuilder` 유틸과 테스트를 추가했습니다.

## UX 반영
- 무반응처럼 보이던 실패 경로에 즉시 피드백 제공
- 실패 메시지에 대상/개수 포함 (`이미지 n개 첨부 실패`, `앱 열기 실패`)

## Test Evidence
- 실행 명령:
  - `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/UIFeedbackMessageBuilderTests`
- 결과:
  - 통과 (3 tests, 0 failures)

## Spec Impact
- 피드백 갭 목록 참조:
  - `/Users/hckim/repo/dochi/spec/ui-interaction-feedback-audit.md`

Closes #254
