### PR TITLE
feat: add orchestrator session selector and execution guard

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -906,6 +906,15 @@ struct DochiApp: App {
         case "bridge.session_history.search":
             return await handleBridgeSessionHistorySearch(params: params, externalToolManager: externalToolManager)
 
+        case "bridge.orchestrator.select_session":
+            return await handleBridgeOrchestratorSelectSession(params: params, externalToolManager: externalToolManager)
+
+        case "bridge.orchestrator.guard_command":
+            return await handleBridgeOrchestratorGuardCommand(params: params, externalToolManager: externalToolManager)
+
+        case "bridge.orchestrator.execute":
+            return await handleBridgeOrchestratorExecute(params: params, externalToolManager: externalToolManager)
+
         case "bridge.repo.list":
             return await handleBridgeRepositoryList(externalToolManager: externalToolManager)
 
@@ -1486,6 +1495,113 @@ struct DochiApp: App {
         ])
     }
 
+    nonisolated private static func handleBridgeOrchestratorSelectSession(
+        params: [String: Any],
+        externalToolManager: ExternalToolSessionManagerProtocol
+    ) async -> LocalControlPlaneMethodResult {
+        let repositoryRoot = nonEmptyString(params["repository_root"])
+        let selection = await externalToolManager.selectSessionForOrchestration(repositoryRoot: repositoryRoot)
+        return .ok(serializeOrchestrationSelection(selection))
+    }
+
+    nonisolated private static func handleBridgeOrchestratorGuardCommand(
+        params: [String: Any],
+        externalToolManager: ExternalToolSessionManagerProtocol
+    ) async -> LocalControlPlaneMethodResult {
+        guard let tierRaw = nonEmptyString(params["tier"]),
+              let tier = CodingSessionControllabilityTier(rawValue: tierRaw) else {
+            return .failure(code: "invalid_tier", message: "유효한 tier가 필요합니다. (t0_full/t1_attach/t2_observe/t3_unknown)")
+        }
+        guard let command = nonEmptyString(params["command"]) else {
+            return .failure(code: "missing_command", message: "command가 필요합니다.")
+        }
+
+        let decision = await MainActor.run {
+            externalToolManager.evaluateOrchestrationExecutionGuard(
+                tier: tier,
+                command: command
+            )
+        }
+
+        if decision.kind == .denied {
+            return .failure(code: "execution_denied", message: decision.reason)
+        }
+        if decision.kind == .confirmationRequired {
+            return .failure(code: "confirmation_required", message: decision.reason)
+        }
+
+        return .ok([
+            "decision": decision.kind.rawValue,
+            "reason": decision.reason,
+            "is_destructive_command": decision.isDestructiveCommand,
+        ])
+    }
+
+    nonisolated private static func handleBridgeOrchestratorExecute(
+        params: [String: Any],
+        externalToolManager: ExternalToolSessionManagerProtocol
+    ) async -> LocalControlPlaneMethodResult {
+        guard let command = nonEmptyString(params["command"]) else {
+            return .failure(code: "missing_command", message: "command가 필요합니다.")
+        }
+        let repositoryRoot = nonEmptyString(params["repository_root"])
+        let confirmed = boolValue(params["confirmed"]) ?? false
+        let selection = await externalToolManager.selectSessionForOrchestration(repositoryRoot: repositoryRoot)
+
+        switch selection.action {
+        case .reuseT0Active, .attachT1:
+            guard let session = selection.selectedSession else {
+                return .failure(code: "session_not_found", message: "선택된 세션을 찾을 수 없습니다.")
+            }
+            let decision = await MainActor.run {
+                externalToolManager.evaluateOrchestrationExecutionGuard(
+                    tier: session.controllabilityTier,
+                    command: command
+                )
+            }
+
+            if decision.kind == .denied {
+                return .failure(code: "execution_denied", message: decision.reason)
+            }
+            if decision.kind == .confirmationRequired, !confirmed {
+                return .failure(code: "confirmation_required", message: decision.reason)
+            }
+
+            guard let runtimeSessionId = session.runtimeSessionId,
+                  let runtimeUUID = UUID(uuidString: runtimeSessionId) else {
+                return .failure(code: "runtime_session_missing", message: "실행 가능한 runtime_session_id를 찾을 수 없습니다.")
+            }
+
+            do {
+                try await externalToolManager.sendCommand(sessionId: runtimeUUID, command: command)
+                return .ok([
+                    "status": "sent",
+                    "command": command,
+                    "selection": serializeOrchestrationSelection(selection),
+                    "guard": [
+                        "decision": decision.kind.rawValue,
+                        "reason": decision.reason,
+                        "is_destructive_command": decision.isDestructiveCommand,
+                    ],
+                ])
+            } catch {
+                return .failure(code: "bridge_send_failed", message: error.localizedDescription)
+            }
+        case .createT0:
+            return .failure(
+                code: "session_creation_required",
+                message: "실행 가능한 세션이 없어 새 T0 세션 생성이 필요합니다."
+            )
+        case .analyzeOnly:
+            return .failure(
+                code: "analyze_only_fallback",
+                message: "현재는 분석 전용(T2/T3) 세션만 존재하여 실행이 차단되었습니다."
+            )
+        case .none:
+            return .failure(code: "session_not_found", message: selection.reason)
+        }
+    }
+
     nonisolated private static func handleBridgeRepositoryList(
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
@@ -1629,6 +1745,35 @@ struct DochiApp: App {
             "started_at": session.startedAt.map(isoTimestamp(_:)) ?? NSNull(),
             "last_activity": session.lastActivityText ?? NSNull(),
         ]
+    }
+
+    nonisolated private static func serializeOrchestrationSelection(
+        _ selection: OrchestrationSessionSelection
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "action": selection.action.rawValue,
+            "reason": selection.reason,
+            "repository_root": selection.repositoryRoot ?? NSNull(),
+        ]
+        if let selected = selection.selectedSession {
+            payload["selected_session"] = [
+                "source": selected.source,
+                "runtime_type": selected.runtimeType.rawValue,
+                "controllability_tier": selected.controllabilityTier.rawValue,
+                "provider": selected.provider,
+                "native_session_id": selected.nativeSessionId,
+                "runtime_session_id": selected.runtimeSessionId ?? NSNull(),
+                "working_directory": selected.workingDirectory ?? NSNull(),
+                "repository_root": selected.repositoryRoot ?? NSNull(),
+                "activity_state": selected.activityState.rawValue,
+                "activity_score": selected.activityScore,
+                "path": selected.path,
+                "updated_at": isoTimestamp(selected.updatedAt),
+            ] as [String: Any]
+        } else {
+            payload["selected_session"] = NSNull()
+        }
+        return payload
     }
 
     @MainActor

--- a/Dochi/Models/ExternalToolModels.swift
+++ b/Dochi/Models/ExternalToolModels.swift
@@ -253,6 +253,42 @@ struct SessionHistorySearchResult: Identifiable, Sendable, Equatable {
     let tags: [String]
 }
 
+enum OrchestrationSessionSelectionAction: String, Codable, Sendable {
+    case reuseT0Active = "reuse_t0_active"
+    case attachT1 = "attach_t1"
+    case createT0 = "create_t0"
+    case analyzeOnly = "analyze_only"
+    case none = "none"
+}
+
+struct OrchestrationSessionSelection: Sendable, Equatable {
+    let action: OrchestrationSessionSelectionAction
+    let reason: String
+    let repositoryRoot: String?
+    let selectedSession: UnifiedCodingSession?
+}
+
+enum OrchestrationExecutionDecisionKind: String, Codable, Sendable {
+    case allowed
+    case confirmationRequired = "confirmation_required"
+    case denied
+}
+
+struct OrchestrationExecutionDecision: Sendable, Equatable {
+    let kind: OrchestrationExecutionDecisionKind
+    let reason: String
+    let isDestructiveCommand: Bool
+}
+
+enum OrchestrationRunState: String, Codable, Sendable {
+    case planned
+    case resolvingSession = "resolving_session"
+    case executing
+    case verifying
+    case completed
+    case failed
+}
+
 enum ExternalTerminalApp: String, CaseIterable, Codable, Sendable {
     case auto
     case terminal

--- a/Dochi/Services/ExternalToolSessionManager.swift
+++ b/Dochi/Services/ExternalToolSessionManager.swift
@@ -54,6 +54,13 @@ protocol ExternalToolSessionManagerProtocol: AnyObject, Sendable {
     func discoverLocalCodingSessions(limit: Int) async -> [DiscoveredCodingSession]
     func listUnifiedCodingSessions(limit: Int) async -> [UnifiedCodingSession]
 
+    // Orchestrator selection/guard
+    func selectSessionForOrchestration(repositoryRoot: String?) async -> OrchestrationSessionSelection
+    func evaluateOrchestrationExecutionGuard(
+        tier: CodingSessionControllabilityTier,
+        command: String
+    ) -> OrchestrationExecutionDecision
+
     // Session history RAG
     func rebuildSessionHistoryIndex(limit: Int) async -> Int
     func searchSessionHistory(query: SessionHistorySearchQuery) async -> [SessionHistorySearchResult]
@@ -91,6 +98,27 @@ extension ExternalToolSessionManagerProtocol {
 
     func listUnifiedCodingSessions(limit _: Int) async -> [UnifiedCodingSession] {
         []
+    }
+
+    func selectSessionForOrchestration(repositoryRoot: String?) async -> OrchestrationSessionSelection {
+        OrchestrationSessionSelection(
+            action: .none,
+            reason: "세션 선택을 지원하지 않습니다.",
+            repositoryRoot: repositoryRoot,
+            selectedSession: nil
+        )
+    }
+
+    func evaluateOrchestrationExecutionGuard(
+        tier: CodingSessionControllabilityTier,
+        command: String
+    ) -> OrchestrationExecutionDecision {
+        _ = (tier, command)
+        return OrchestrationExecutionDecision(
+            kind: .denied,
+            reason: "실행 가드를 지원하지 않습니다.",
+            isDestructiveCommand: false
+        )
     }
 
     func rebuildSessionHistoryIndex(limit _: Int) async -> Int {
@@ -755,6 +783,23 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         }.value
     }
 
+    func selectSessionForOrchestration(repositoryRoot: String?) async -> OrchestrationSessionSelection {
+        let unified = await listUnifiedCodingSessions(limit: 240)
+        return await Task.detached(priority: .utility) {
+            Self.selectSessionForOrchestration(
+                sessions: unified,
+                repositoryRoot: repositoryRoot
+            )
+        }.value
+    }
+
+    func evaluateOrchestrationExecutionGuard(
+        tier: CodingSessionControllabilityTier,
+        command: String
+    ) -> OrchestrationExecutionDecision {
+        Self.evaluateOrchestrationExecutionGuard(tier: tier, command: command)
+    }
+
     func rebuildSessionHistoryIndex(limit: Int) async -> Int {
         let effectiveLimit = max(10, min(2_000, limit))
         let home = FileManager.default.homeDirectoryForCurrentUser
@@ -800,6 +845,138 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                 now: Date()
             )
         }.value
+    }
+
+    nonisolated static func selectSessionForOrchestration(
+        sessions: [UnifiedCodingSession],
+        repositoryRoot: String?
+    ) -> OrchestrationSessionSelection {
+        let normalizedRepositoryRoot = repositoryRoot.map {
+            URL(fileURLWithPath: expandedPath($0)).standardizedFileURL.path
+        }
+        let sorted = sessions
+            .sorted(by: isPreferredUnifiedSessionOrder(_:_:))
+            .filter { $0.activityState != .dead }
+
+        let scoped: [UnifiedCodingSession]
+        if let normalizedRepositoryRoot {
+            scoped = sorted.filter { session in
+                guard let root = session.repositoryRoot else { return false }
+                return URL(fileURLWithPath: root).standardizedFileURL.path == normalizedRepositoryRoot
+            }
+        } else {
+            scoped = sorted
+        }
+
+        if let t0Active = scoped.first(where: { $0.controllabilityTier == .t0Full && $0.activityState == .active }) {
+            return OrchestrationSessionSelection(
+                action: .reuseT0Active,
+                reason: "동일 repo의 T0 active 세션을 재사용합니다.",
+                repositoryRoot: normalizedRepositoryRoot ?? t0Active.repositoryRoot,
+                selectedSession: t0Active
+            )
+        }
+
+        if let t1Attach = scoped.first(where: {
+            $0.controllabilityTier == .t1Attach &&
+                ($0.activityState == .active || $0.activityState == .idle)
+        }) {
+            return OrchestrationSessionSelection(
+                action: .attachT1,
+                reason: "T0 active가 없어 T1(active/idle) 세션으로 attach합니다.",
+                repositoryRoot: normalizedRepositoryRoot ?? t1Attach.repositoryRoot,
+                selectedSession: t1Attach
+            )
+        }
+
+        if let normalizedRepositoryRoot {
+            return OrchestrationSessionSelection(
+                action: .createT0,
+                reason: "실행 가능한 세션이 없어 새 T0 세션 생성이 필요합니다.",
+                repositoryRoot: normalizedRepositoryRoot,
+                selectedSession: nil
+            )
+        }
+
+        if let t2Fallback = sorted.first(where: {
+            $0.controllabilityTier == .t2Observe || $0.controllabilityTier == .t3Unknown
+        }) {
+            return OrchestrationSessionSelection(
+                action: .analyzeOnly,
+                reason: "실행 세션이 없어 T2/T3 분석 전용 모드로 폴백합니다.",
+                repositoryRoot: t2Fallback.repositoryRoot,
+                selectedSession: t2Fallback
+            )
+        }
+
+        return OrchestrationSessionSelection(
+            action: .none,
+            reason: "선택 가능한 세션이 없습니다.",
+            repositoryRoot: normalizedRepositoryRoot,
+            selectedSession: nil
+        )
+    }
+
+    nonisolated static func evaluateOrchestrationExecutionGuard(
+        tier: CodingSessionControllabilityTier,
+        command: String
+    ) -> OrchestrationExecutionDecision {
+        let destructive = isDestructiveCommand(command)
+        switch tier {
+        case .t0Full:
+            return OrchestrationExecutionDecision(
+                kind: .allowed,
+                reason: "T0 세션은 자동 실행이 허용됩니다.",
+                isDestructiveCommand: destructive
+            )
+        case .t1Attach:
+            if destructive {
+                return OrchestrationExecutionDecision(
+                    kind: .confirmationRequired,
+                    reason: "T1 세션의 파괴적 명령은 사용자 확인이 필요합니다.",
+                    isDestructiveCommand: true
+                )
+            }
+            return OrchestrationExecutionDecision(
+                kind: .allowed,
+                reason: "T1 세션의 비파괴 명령은 실행 가능합니다.",
+                isDestructiveCommand: false
+            )
+        case .t2Observe, .t3Unknown:
+            return OrchestrationExecutionDecision(
+                kind: .denied,
+                reason: "T2/T3 세션은 실행 금지이며 제안 전용입니다.",
+                isDestructiveCommand: destructive
+            )
+        }
+    }
+
+    nonisolated static func isDestructiveCommand(_ command: String) -> Bool {
+        let normalized = command.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalized.isEmpty else { return false }
+
+        let destructiveMarkers = [
+            "rm -rf",
+            "rm -fr",
+            "git reset --hard",
+            "git clean -fd",
+            "git clean -xdf",
+            "git push --force",
+            "git push -f",
+            "docker system prune -a",
+            "drop table",
+            "truncate table",
+            "shutdown -h",
+        ]
+        if destructiveMarkers.contains(where: { normalized.contains($0) }) {
+            return true
+        }
+
+        if normalized.hasPrefix("rm "),
+           normalized.contains(" -rf") || normalized.contains(" -fr") {
+            return true
+        }
+        return false
     }
 
     nonisolated static func buildSessionHistoryChunks(

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -1000,6 +1000,8 @@ final class MockExternalToolSessionManager: ExternalToolSessionManagerProtocol {
     var cloneRepositoryCallCount = 0
     var attachRepositoryCallCount = 0
     var removeManagedRepositoryCallCount = 0
+    var selectSessionForOrchestrationCallCount = 0
+    var evaluateOrchestrationExecutionGuardCallCount = 0
     var rebuildSessionHistoryIndexCallCount = 0
     var searchSessionHistoryCallCount = 0
 
@@ -1007,6 +1009,17 @@ final class MockExternalToolSessionManager: ExternalToolSessionManagerProtocol {
     var lastSentCommand: String?
     var mockOutputLines: [String] = ["line1", "line2"]
     var mockGitRepositoryInsights: [GitRepositoryInsight] = []
+    var mockOrchestrationSelection = OrchestrationSessionSelection(
+        action: .none,
+        reason: "mock",
+        repositoryRoot: nil,
+        selectedSession: nil
+    )
+    var mockOrchestrationDecision = OrchestrationExecutionDecision(
+        kind: .allowed,
+        reason: "mock",
+        isDestructiveCommand: false
+    )
     var mockSessionHistoryResults: [SessionHistorySearchResult] = []
 
     func loadProfiles() {
@@ -1157,6 +1170,21 @@ final class MockExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         repository.isArchived = true
         repository.updatedAt = Date()
         managedRepositories[index] = repository
+    }
+
+    func selectSessionForOrchestration(repositoryRoot: String?) async -> OrchestrationSessionSelection {
+        _ = repositoryRoot
+        selectSessionForOrchestrationCallCount += 1
+        return mockOrchestrationSelection
+    }
+
+    func evaluateOrchestrationExecutionGuard(
+        tier: CodingSessionControllabilityTier,
+        command: String
+    ) -> OrchestrationExecutionDecision {
+        _ = (tier, command)
+        evaluateOrchestrationExecutionGuardCallCount += 1
+        return mockOrchestrationDecision
     }
 
     func rebuildSessionHistoryIndex(limit: Int) async -> Int {

--- a/DochiTests/OrchestratorSessionSelectorTests.swift
+++ b/DochiTests/OrchestratorSessionSelectorTests.swift
@@ -1,0 +1,175 @@
+import XCTest
+@testable import Dochi
+
+final class OrchestratorSessionSelectorTests: XCTestCase {
+
+    func testSelectorPrefersT0ActiveWithinRepository() {
+        let repo = "/tmp/repo-a"
+        let sessions = [
+            makeSession(
+                provider: "codex",
+                nativeId: "t1",
+                runtimeId: "11111111-1111-1111-1111-111111111111",
+                tier: .t1Attach,
+                state: .active,
+                repo: repo,
+                score: 84
+            ),
+            makeSession(
+                provider: "codex",
+                nativeId: "t0",
+                runtimeId: "22222222-2222-2222-2222-222222222222",
+                tier: .t0Full,
+                state: .active,
+                repo: repo,
+                score: 78
+            ),
+        ]
+
+        let selected = ExternalToolSessionManager.selectSessionForOrchestration(
+            sessions: sessions,
+            repositoryRoot: repo
+        )
+
+        XCTAssertEqual(selected.action, .reuseT0Active)
+        XCTAssertEqual(selected.selectedSession?.nativeSessionId, "t0")
+    }
+
+    func testSelectorFallsBackToT1WhenNoT0Active() {
+        let repo = "/tmp/repo-a"
+        let sessions = [
+            makeSession(
+                provider: "codex",
+                nativeId: "t0-idle",
+                runtimeId: "33333333-3333-3333-3333-333333333333",
+                tier: .t0Full,
+                state: .idle,
+                repo: repo,
+                score: 60
+            ),
+            makeSession(
+                provider: "codex",
+                nativeId: "t1-active",
+                runtimeId: "44444444-4444-4444-4444-444444444444",
+                tier: .t1Attach,
+                state: .active,
+                repo: repo,
+                score: 55
+            ),
+        ]
+
+        let selected = ExternalToolSessionManager.selectSessionForOrchestration(
+            sessions: sessions,
+            repositoryRoot: repo
+        )
+
+        XCTAssertEqual(selected.action, .attachT1)
+        XCTAssertEqual(selected.selectedSession?.nativeSessionId, "t1-active")
+    }
+
+    func testSelectorReturnsCreateT0WhenNoRunnableSessionInRepo() {
+        let repo = "/tmp/repo-a"
+        let sessions = [
+            makeSession(
+                provider: "codex",
+                nativeId: "observe-only",
+                runtimeId: nil,
+                tier: .t2Observe,
+                state: .active,
+                repo: repo,
+                score: 45
+            ),
+        ]
+
+        let selected = ExternalToolSessionManager.selectSessionForOrchestration(
+            sessions: sessions,
+            repositoryRoot: repo
+        )
+
+        XCTAssertEqual(selected.action, .createT0)
+        XCTAssertNil(selected.selectedSession)
+    }
+
+    func testSelectorFallsBackToAnalyzeOnlyWithoutRepoContext() {
+        let sessions = [
+            makeSession(
+                provider: "claude",
+                nativeId: "observe-1",
+                runtimeId: nil,
+                tier: .t2Observe,
+                state: .active,
+                repo: nil,
+                score: 39
+            ),
+        ]
+
+        let selected = ExternalToolSessionManager.selectSessionForOrchestration(
+            sessions: sessions,
+            repositoryRoot: nil
+        )
+
+        XCTAssertEqual(selected.action, .analyzeOnly)
+        XCTAssertEqual(selected.selectedSession?.nativeSessionId, "observe-1")
+    }
+
+    func testExecutionGuardDeniesT2AndT3() {
+        let t2 = ExternalToolSessionManager.evaluateOrchestrationExecutionGuard(
+            tier: .t2Observe,
+            command: "git status"
+        )
+        let t3 = ExternalToolSessionManager.evaluateOrchestrationExecutionGuard(
+            tier: .t3Unknown,
+            command: "make build"
+        )
+
+        XCTAssertEqual(t2.kind, .denied)
+        XCTAssertEqual(t3.kind, .denied)
+    }
+
+    func testExecutionGuardRequiresConfirmationForDestructiveT1Command() {
+        let decision = ExternalToolSessionManager.evaluateOrchestrationExecutionGuard(
+            tier: .t1Attach,
+            command: "git reset --hard HEAD~1"
+        )
+
+        XCTAssertEqual(decision.kind, .confirmationRequired)
+        XCTAssertTrue(decision.isDestructiveCommand)
+    }
+
+    func testExecutionGuardAllowsNonDestructiveT1Command() {
+        let decision = ExternalToolSessionManager.evaluateOrchestrationExecutionGuard(
+            tier: .t1Attach,
+            command: "git status"
+        )
+
+        XCTAssertEqual(decision.kind, .allowed)
+        XCTAssertFalse(decision.isDestructiveCommand)
+    }
+
+    private func makeSession(
+        provider: String,
+        nativeId: String,
+        runtimeId: String?,
+        tier: CodingSessionControllabilityTier,
+        state: CodingSessionActivityState,
+        repo: String?,
+        score: Int
+    ) -> UnifiedCodingSession {
+        UnifiedCodingSession(
+            source: "test",
+            runtimeType: runtimeId == nil ? .file : .tmux,
+            controllabilityTier: tier,
+            provider: provider,
+            nativeSessionId: nativeId,
+            runtimeSessionId: runtimeId,
+            workingDirectory: repo,
+            repositoryRoot: repo,
+            path: "/tmp/\(nativeId).jsonl",
+            updatedAt: Date(),
+            isActive: state == .active || state == .idle,
+            activityScore: score,
+            activityState: state
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- add orchestration domain models for session selection and execution guard decisions
- implement explicit selector priority in ExternalToolSessionManager: T0(active) -> T1(active/idle) -> create T0 -> T2/T3 analyze-only fallback
- implement tier-based guard policy: T0 allow, T1 destructive command confirmation required, T2/T3 denied
- expose control-plane methods bridge.orchestrator.select_session / bridge.orchestrator.guard_command / bridge.orchestrator.execute
- add unit tests for selector fallback and guard enforcement paths

## Test
- xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/OrchestratorSessionSelectorTests -only-testing:DochiTests/GitRepositoryInsightScorerTests -only-testing:DochiTests/SessionHistoryRAGTests

## Spec Impact
- aligns with spec/coding-agent-session-management-strategy.md §11 (session selector + tier guard)

Closes #265