### PR TITLE
feat: add Dochi CLI conversation/log inspection commands

### DIFF
--- a/Dochi/CLIShared/CLICommandSurface.swift
+++ b/Dochi/CLIShared/CLICommandSurface.swift
@@ -23,6 +23,8 @@ enum CLIContextAction: Equatable, Sendable {
 
 enum CLIConversationAction: Equatable, Sendable {
     case list(limit: Int)
+    case show(id: String, limit: Int)
+    case tail(limit: Int)
 }
 
 enum CLIConfigAction: Equatable, Sendable {
@@ -33,6 +35,10 @@ enum CLIConfigAction: Equatable, Sendable {
 
 enum CLISessionAction: Equatable, Sendable {
     case list
+}
+
+enum CLILogAction: Equatable, Sendable {
+    case recent(minutes: Int, limit: Int, category: String?, level: String?, contains: String?)
 }
 
 enum CLIDevAction: Equatable, Sendable {
@@ -59,6 +65,7 @@ enum CLICommand: Equatable, Sendable {
     case chat
     case context(CLIContextAction)
     case conversation(CLIConversationAction)
+    case log(CLILogAction)
     case config(CLIConfigAction)
     case session(CLISessionAction)
     case dev(CLIDevAction)
@@ -165,6 +172,9 @@ enum CLICommandParser {
         case "conversation", "conversations":
             command = try parseConversation(tail)
 
+        case "log":
+            command = try parseLog(tail)
+
         case "config":
             command = try parseConfig(tail)
 
@@ -197,17 +207,116 @@ enum CLICommandParser {
     }
 
     private static func parseConversation(_ args: [String]) throws -> CLICommand {
-        let sub = args.first ?? "list"
-        guard sub == "list" else {
-            throw CLIParseError.invalidUsage("conversation 하위 명령은 list만 지원합니다.")
+        let sub: String
+        let rest: [String]
+        if let first = args.first, !first.hasPrefix("--") {
+            sub = first
+            rest = Array(args.dropFirst())
+        } else {
+            sub = "list"
+            rest = args
         }
 
-        var limit = 10
-        if args.count >= 3, args[1] == "--limit", let parsed = Int(args[2]) {
-            limit = max(1, parsed)
+        switch sub {
+        case "list":
+            let limit = try parseSingleIntOption(rest, option: "--limit", defaultValue: 10, usage: "conversation list --limit <N>")
+            return .conversation(.list(limit: limit))
+
+        case "show":
+            guard let id = rest.first, !id.hasPrefix("--") else {
+                throw CLIParseError.invalidUsage("conversation show <conversation_id> [--limit N] 형식이 필요합니다.")
+            }
+            let optionArgs = Array(rest.dropFirst())
+            let limit = try parseSingleIntOption(optionArgs, option: "--limit", defaultValue: 20, usage: "conversation show <conversation_id> [--limit N]")
+            return .conversation(.show(id: id, limit: limit))
+
+        case "tail", "latest":
+            let limit = try parseSingleIntOption(rest, option: "--limit", defaultValue: 20, usage: "conversation tail [--limit N]")
+            return .conversation(.tail(limit: limit))
+
+        default:
+            throw CLIParseError.invalidUsage("conversation 하위 명령은 list/show/tail만 지원합니다.")
+        }
+    }
+
+    private static func parseLog(_ args: [String]) throws -> CLICommand {
+        let sub: String
+        let rest: [String]
+        if let first = args.first, !first.hasPrefix("--") {
+            sub = first
+            rest = Array(args.dropFirst())
+        } else {
+            sub = "recent"
+            rest = args
+        }
+        guard sub == "recent" else {
+            throw CLIParseError.invalidUsage("log 하위 명령은 recent만 지원합니다.")
         }
 
-        return .conversation(.list(limit: limit))
+        var minutes = 15
+        var limit = 200
+        var category: String?
+        var level: String?
+        var contains: String?
+
+        var index = 0
+        while index < rest.count {
+            switch rest[index] {
+            case "--minutes":
+                guard index + 1 < rest.count, let parsed = Int(rest[index + 1]) else {
+                    throw CLIParseError.invalidUsage("log recent --minutes <N> 형식이 필요합니다.")
+                }
+                minutes = max(1, parsed)
+                index += 2
+            case "--limit":
+                guard index + 1 < rest.count, let parsed = Int(rest[index + 1]) else {
+                    throw CLIParseError.invalidUsage("log recent --limit <N> 형식이 필요합니다.")
+                }
+                limit = max(1, parsed)
+                index += 2
+            case "--category":
+                guard index + 1 < rest.count else {
+                    throw CLIParseError.invalidUsage("log recent --category <name> 형식이 필요합니다.")
+                }
+                category = rest[index + 1]
+                index += 2
+            case "--level":
+                guard index + 1 < rest.count else {
+                    throw CLIParseError.invalidUsage("log recent --level <name> 형식이 필요합니다.")
+                }
+                level = rest[index + 1]
+                index += 2
+            case "--contains":
+                guard index + 1 < rest.count else {
+                    throw CLIParseError.invalidUsage("log recent --contains <keyword> 형식이 필요합니다.")
+                }
+                contains = rest[index + 1]
+                index += 2
+            default:
+                throw CLIParseError.invalidUsage("알 수 없는 옵션입니다: \(rest[index])")
+            }
+        }
+
+        return .log(.recent(
+            minutes: minutes,
+            limit: limit,
+            category: category,
+            level: level,
+            contains: contains
+        ))
+    }
+
+    private static func parseSingleIntOption(
+        _ args: [String],
+        option: String,
+        defaultValue: Int,
+        usage: String
+    ) throws -> Int {
+        guard !args.isEmpty else { return defaultValue }
+        guard args.count == 2, args[0] == option, let parsed = Int(args[1]) else {
+            throw CLIParseError.invalidUsage("\(usage) 형식이 필요합니다.")
+        }
+        return max(1, parsed)
     }
 
     private static func parseConfig(_ args: [String]) throws -> CLICommand {

--- a/DochiCLI/README.md
+++ b/DochiCLI/README.md
@@ -40,6 +40,10 @@ dochi doctor
 dochi ask "오늘 할 일 정리해줘"
 dochi chat
 dochi conversation list --limit 20
+dochi conversation show 35BBCC9A-EB8F-43E1-9069-D774E46E714D --limit 15
+dochi conversation tail --limit 20
+dochi log recent --minutes 30 --limit 200
+dochi log recent --minutes 60 --category Tool --level error --contains "session"
 dochi context show system
 dochi context edit memory
 dochi config show
@@ -82,15 +86,32 @@ dochi doctor
 dochi ask "회의록 요약해줘" --json
 ```
 
-## 5) 로컬 파일 경로
+## 5) 대화/로그 점검 표준 루틴 (운영 기본)
+
+앞으로 "도치가 이상하게 답했다 / 세션 조회가 꼬였다" 같은 이슈는 아래 순서로 먼저 수집합니다.
+
+```bash
+dochi conversation list --limit 10
+dochi conversation tail --limit 30
+dochi log recent --minutes 20 --limit 300
+dochi log recent --minutes 60 --category Tool --level error
+```
+
+권장 규칙:
+- 최신 대화 본문 확인은 `conversation tail` 또는 `conversation show`를 우선 사용
+- 앱 상태/도구 오류 확인은 `log recent`를 우선 사용
+- 필요하면 이후에만 `dochi dev log tail`로 실시간 추적
+
+## 6) 로컬 파일 경로
 
 - CLI 설정 파일: `~/Library/Application Support/Dochi/cli_config.json`
 - 로컬 소켓: `~/Library/Application Support/Dochi/run/dochi.sock`
 - 로컬 API 토큰: `~/Library/Application Support/Dochi/run/control-plane.token`
+- 대화 파일: `~/Library/Application Support/Dochi/conversations/*.json`
 
 앱 연결 모드에서는 CLI가 `control-plane.token`을 자동으로 읽어 `auth_token`을 요청에 포함합니다.
 
-## 6) `dochi doctor`로 상태 점검
+## 7) `dochi doctor`로 상태 점검
 
 `doctor`는 아래 항목을 점검합니다.
 
@@ -105,7 +126,7 @@ dochi ask "회의록 요약해줘" --json
 
 앱 연결 모드에서 문제를 만났다면 `dochi doctor` 출력부터 확인하세요.
 
-## 7) 자주 발생하는 문제
+## 8) 자주 발생하는 문제
 
 ### "Dochi 앱이 실행 중이 아닙니다" / "Control Plane 연결 실패"
 
@@ -128,7 +149,7 @@ dochi config set model claude-sonnet-4-5-20250929
 dochi --mode standalone --allow-standalone ask "테스트"
 ```
 
-## 8) 종료 코드
+## 9) 종료 코드
 
 - `0`: 성공
 - `1`: 런타임 오류
@@ -137,7 +158,7 @@ dochi --mode standalone --allow-standalone ask "테스트"
 - `4`: 앱 연결 오류
 - `5`: 인증 오류
 
-## 9) 비-UI 기능 검증 표준 절차 (Host 모드)
+## 10) 비-UI 기능 검증 표준 절차 (Host 모드)
 
 비-UI 기능 검증 기본 원칙:
 - 제품 검증은 `--mode app`(또는 `auto`)로 수행

--- a/DochiCLI/main.swift
+++ b/DochiCLI/main.swift
@@ -118,6 +118,9 @@ enum DochiCLI {
         case .conversation(let action):
             return handleConversation(action)
 
+        case .log(let action):
+            return handleLog(action)
+
         case .config(let action):
             return handleConfig(action)
 
@@ -297,42 +300,391 @@ enum DochiCLI {
         }
     }
 
-    // MARK: - Conversation
+    // MARK: - Conversation / Log (Local observability)
+
+    private struct LocalConversationMessage {
+        let role: String
+        let timestamp: String
+        let content: String
+    }
+
+    private struct LocalConversationRecord {
+        let id: String
+        let title: String
+        let source: String
+        let updatedAt: String
+        let messages: [LocalConversationMessage]
+    }
+
+    private struct LocalLogEntry {
+        let timestamp: String
+        let category: String
+        let level: String
+        let message: String
+        let raw: String
+    }
 
     private static func handleConversation(_ action: CLIConversationAction) -> CLIResult {
+        let convDir = CLIConfig.contextDirectory.appendingPathComponent("conversations")
+        let jsonFiles = listConversationFiles(in: convDir)
+
         switch action {
         case .list(let limit):
-            let convDir = CLIConfig.contextDirectory.appendingPathComponent("conversations")
-            guard let files = try? FileManager.default.contentsOfDirectory(
-                at: convDir,
-                includingPropertiesForKeys: [.contentModificationDateKey],
-                options: .skipsHiddenFiles
-            ) else {
-                return CLIResult(exitCode: .success, command: "conversation.list", message: "대화가 없습니다.")
-            }
-
-            let jsonFiles = files.filter { $0.pathExtension == "json" }
-                .sorted {
-                    let d1 = (try? $0.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
-                    let d2 = (try? $1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
-                    return d1 > d2
-                }
-
             guard !jsonFiles.isEmpty else {
                 return CLIResult(exitCode: .success, command: "conversation.list", message: "대화가 없습니다.")
             }
 
-            var lines: [String] = ["최근 대화 (최대 \(limit)개)"]
+            var lines: [String] = ["최근 대화 (최대 \(limit)개 / 전체 \(jsonFiles.count)개)"]
+            var conversationIDs: [String] = []
             for (index, file) in jsonFiles.prefix(limit).enumerated() {
-                lines.append("\(index + 1). \(file.deletingPathExtension().lastPathComponent)")
+                if let record = try? loadConversationRecord(from: file) {
+                    conversationIDs.append(record.id)
+                    lines.append("\(index + 1). \(record.title) (\(record.id)) | messages: \(record.messages.count) | updated: \(record.updatedAt)")
+                } else {
+                    let fallbackID = file.deletingPathExtension().lastPathComponent
+                    conversationIDs.append(fallbackID)
+                    lines.append("\(index + 1). \(fallbackID)")
+                }
             }
 
             return CLIResult(
                 exitCode: .success,
                 command: "conversation.list",
                 message: lines.joined(separator: "\n"),
-                data: ["count": jsonFiles.count]
+                data: [
+                    "count": jsonFiles.count,
+                    "conversation_ids": conversationIDs,
+                ]
             )
+
+        case .show(let id, let limit):
+            guard !jsonFiles.isEmpty else {
+                return CLIResult(exitCode: .configError, command: "conversation.show", message: "대화 파일이 없습니다: \(convDir.path)")
+            }
+
+            let requestedID = id.lowercased().replacingOccurrences(of: ".json", with: "")
+            if let exact = jsonFiles.first(where: { $0.deletingPathExtension().lastPathComponent.lowercased() == requestedID }) {
+                do {
+                    let record = try loadConversationRecord(from: exact)
+                    let rendered = renderConversation(record, limit: limit)
+                    return CLIResult(exitCode: .success, command: "conversation.show", message: rendered.message, data: rendered.data)
+                } catch {
+                    return CLIResult(exitCode: .runtimeError, command: "conversation.show", message: "대화 파싱 실패: \(error.localizedDescription)")
+                }
+            }
+
+            let partialMatches = jsonFiles.filter { file in
+                file.deletingPathExtension().lastPathComponent.lowercased().hasPrefix(requestedID)
+            }
+            if partialMatches.count > 1 {
+                let candidates = partialMatches.map { $0.deletingPathExtension().lastPathComponent }.prefix(10)
+                return CLIResult(
+                    exitCode: .invalidUsage,
+                    command: "conversation.show",
+                    message: "ID prefix가 모호합니다. 더 길게 입력하세요: \(candidates.joined(separator: ", "))"
+                )
+            }
+            guard let matched = partialMatches.first else {
+                return CLIResult(exitCode: .configError, command: "conversation.show", message: "대화를 찾지 못했습니다: \(id)")
+            }
+
+            do {
+                let record = try loadConversationRecord(from: matched)
+                let rendered = renderConversation(record, limit: limit)
+                return CLIResult(exitCode: .success, command: "conversation.show", message: rendered.message, data: rendered.data)
+            } catch {
+                return CLIResult(exitCode: .runtimeError, command: "conversation.show", message: "대화 파싱 실패: \(error.localizedDescription)")
+            }
+
+        case .tail(let limit):
+            guard let latest = jsonFiles.first else {
+                return CLIResult(exitCode: .success, command: "conversation.tail", message: "대화가 없습니다.")
+            }
+            do {
+                let record = try loadConversationRecord(from: latest)
+                let rendered = renderConversation(record, limit: limit)
+                return CLIResult(exitCode: .success, command: "conversation.tail", message: rendered.message, data: rendered.data)
+            } catch {
+                return CLIResult(exitCode: .runtimeError, command: "conversation.tail", message: "대화 파싱 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private static func handleLog(_ action: CLILogAction) -> CLIResult {
+        switch action {
+        case .recent(let minutes, let limit, let category, let level, let contains):
+            if let level, normalizedRequestedLogLevel(level) == nil {
+                return CLIResult(
+                    exitCode: .invalidUsage,
+                    command: "log.recent",
+                    message: "지원하지 않는 로그 레벨입니다: \(level). (debug|info|notice|error|fault)"
+                )
+            }
+
+            do {
+                let entries = try loadLocalDochiLogs(
+                    minutes: minutes,
+                    limit: limit,
+                    category: category,
+                    level: normalizedRequestedLogLevel(level),
+                    contains: contains
+                )
+                guard !entries.isEmpty else {
+                    return CLIResult(exitCode: .success, command: "log.recent", message: "조건에 맞는 로그가 없습니다.")
+                }
+
+                let lines = entries.map { entry in
+                    "[\(entry.timestamp)] [\(entry.category)] [\(entry.level)] \(entry.message)"
+                }
+                let payload = entries.map { entry -> [String: Any] in
+                    [
+                        "timestamp": entry.timestamp,
+                        "category": entry.category,
+                        "level": entry.level,
+                        "message": entry.message,
+                    ]
+                }
+
+                return CLIResult(
+                    exitCode: .success,
+                    command: "log.recent",
+                    message: lines.joined(separator: "\n"),
+                    data: [
+                        "count": entries.count,
+                        "entries": payload,
+                    ]
+                )
+            } catch {
+                return CLIResult(exitCode: .runtimeError, command: "log.recent", message: "로그 조회 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private static func listConversationFiles(in directory: URL) -> [URL] {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: .skipsHiddenFiles
+        ) else {
+            return []
+        }
+
+        return files
+            .filter { $0.pathExtension == "json" }
+            .sorted {
+                let d1 = (try? $0.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+                let d2 = (try? $1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+                return d1 > d2
+            }
+    }
+
+    private static func loadConversationRecord(from file: URL) throws -> LocalConversationRecord {
+        let data = try Data(contentsOf: file)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CLIParseError.invalidUsage("대화 JSON 형식이 올바르지 않습니다.")
+        }
+
+        let id = file.deletingPathExtension().lastPathComponent
+        let title = (root["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? (root["title"] as? String ?? id)
+            : id
+        let source = root["source"] as? String ?? "local"
+        let updatedAt = root["updatedAt"] as? String ?? "-"
+        let rawMessages = root["messages"] as? [[String: Any]] ?? []
+
+        let messages = rawMessages.map { item -> LocalConversationMessage in
+            let role = item["role"] as? String ?? "unknown"
+            let timestamp = item["timestamp"] as? String ?? "-"
+            let content = stringifyJSONValue(item["content"])
+            return LocalConversationMessage(role: role, timestamp: timestamp, content: content)
+        }
+
+        return LocalConversationRecord(
+            id: id,
+            title: title,
+            source: source,
+            updatedAt: updatedAt,
+            messages: messages
+        )
+    }
+
+    private static func renderConversation(_ record: LocalConversationRecord, limit: Int) -> (message: String, data: [String: Any]) {
+        let clippedLimit = max(1, limit)
+        let shown = Array(record.messages.suffix(clippedLimit))
+        let startIndex = max(0, record.messages.count - shown.count)
+
+        var lines: [String] = [
+            "대화: \(record.title)",
+            "id: \(record.id)",
+            "source: \(record.source)",
+            "updated: \(record.updatedAt)",
+            "messages: \(record.messages.count) (최근 \(shown.count)개 표시)",
+        ]
+
+        for (offset, message) in shown.enumerated() {
+            let absoluteIndex = startIndex + offset + 1
+            lines.append("")
+            lines.append("\(absoluteIndex). [\(message.timestamp)] \(message.role)")
+
+            let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                lines.append("   (empty)")
+                continue
+            }
+
+            let clipped = clipMessageContent(trimmed, maxLength: 2000)
+            for line in clipped.components(separatedBy: .newlines) {
+                lines.append("   \(line)")
+            }
+        }
+
+        let payloadMessages = shown.map { message -> [String: Any] in
+            [
+                "role": message.role,
+                "timestamp": message.timestamp,
+                "content": message.content,
+            ]
+        }
+
+        return (
+            lines.joined(separator: "\n"),
+            [
+                "conversation_id": record.id,
+                "title": record.title,
+                "source": record.source,
+                "updated_at": record.updatedAt,
+                "total_messages": record.messages.count,
+                "shown_messages": payloadMessages,
+            ]
+        )
+    }
+
+    private static func stringifyJSONValue(_ value: Any?) -> String {
+        guard let value else { return "" }
+        if let string = value as? String { return string }
+        if let json = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+           let string = String(data: json, encoding: .utf8) {
+            return string
+        }
+        return String(describing: value)
+    }
+
+    private static func clipMessageContent(_ text: String, maxLength: Int) -> String {
+        guard text.count > maxLength else { return text }
+        let prefix = text.prefix(maxLength)
+        return "\(prefix)\n...(truncated)"
+    }
+
+    private static func normalizedRequestedLogLevel(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "debug", "info", "notice", "error", "fault":
+            return normalized
+        default:
+            return nil
+        }
+    }
+
+    private static func loadLocalDochiLogs(
+        minutes: Int,
+        limit: Int,
+        category: String?,
+        level: String?,
+        contains: String?
+    ) throws -> [LocalLogEntry] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        process.arguments = [
+            "show",
+            "--style", "compact",
+            "--last", "\(max(1, minutes))m",
+            "--predicate", "subsystem == \"com.dochi.app\"",
+            "--debug",
+            "--info",
+        ]
+
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        process.standardOutput = outPipe
+        process.standardError = errPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: outData, encoding: .utf8) ?? ""
+        let stderr = String(data: errData, encoding: .utf8) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            let reason = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw CLIParseError.invalidUsage("`log show` 실행 실패 (\(process.terminationStatus)): \(reason)")
+        }
+
+        var entries: [LocalLogEntry] = []
+        for rawLine in output.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty, !line.hasPrefix("Timestamp") else { continue }
+            guard let entry = parseLocalLogLine(line) else { continue }
+
+            if let category, !category.isEmpty, entry.category.caseInsensitiveCompare(category) != .orderedSame {
+                continue
+            }
+            if let level, entry.level != level {
+                continue
+            }
+            if let contains, !contains.isEmpty, !entry.raw.localizedCaseInsensitiveContains(contains) {
+                continue
+            }
+
+            entries.append(entry)
+        }
+
+        let clippedLimit = max(1, limit)
+        if entries.count <= clippedLimit {
+            return entries
+        }
+        return Array(entries.suffix(clippedLimit))
+    }
+
+    private static func parseLocalLogLine(_ line: String) -> LocalLogEntry? {
+        guard let subsystemRange = line.range(of: "[com.dochi.app:") else { return nil }
+        guard let categoryEnd = line[subsystemRange.upperBound...].firstIndex(of: "]") else { return nil }
+
+        let category = String(line[subsystemRange.upperBound..<categoryEnd])
+        let messageStart = line.index(after: categoryEnd)
+        let message = String(line[messageStart...]).trimmingCharacters(in: .whitespaces)
+
+        let prefix = String(line[..<subsystemRange.lowerBound])
+        let tokens = prefix.split(whereSeparator: { $0.isWhitespace })
+        let timestamp: String
+        if tokens.count >= 2 {
+            timestamp = "\(tokens[0]) \(tokens[1])"
+        } else {
+            timestamp = "-"
+        }
+        let typeToken = tokens.count >= 3 ? String(tokens[2]) : "-"
+        let level = normalizeLogLevel(typeToken)
+
+        return LocalLogEntry(
+            timestamp: timestamp,
+            category: category,
+            level: level,
+            message: message,
+            raw: line
+        )
+    }
+
+    private static func normalizeLogLevel(_ token: String) -> String {
+        guard let first = token.uppercased().first else { return "unknown" }
+        switch first {
+        case "D": return "debug"
+        case "I": return "info"
+        case "N": return "notice"
+        case "E": return "error"
+        case "F": return "fault"
+        default: return "unknown"
         }
     }
 
@@ -1076,6 +1428,9 @@ enum DochiCLI {
           dochi ask <질문> [--json]
           dochi chat
           dochi conversation list [--limit N]
+          dochi conversation show <conversation_id|prefix> [--limit N]
+          dochi conversation tail [--limit N]
+          dochi log recent [--minutes N] [--limit N] [--category C] [--level L] [--contains K]
           dochi context show [system|memory]
           dochi context edit [system|memory]
           dochi config show

--- a/DochiTests/CLICommandSurfaceTests.swift
+++ b/DochiTests/CLICommandSurfaceTests.swift
@@ -32,6 +32,61 @@ final class CLICommandSurfaceTests: XCTestCase {
         XCTAssertEqual(invocation.command, .conversation(.list(limit: 25)))
     }
 
+    func testParseConversationShowWithLimit() throws {
+        let invocation = try CLICommandParser.parse([
+            "conversation", "show", "35BBCC9A-EB8F-43E1-9069-D774E46E714D", "--limit", "12",
+        ])
+        XCTAssertEqual(
+            invocation.command,
+            .conversation(.show(id: "35BBCC9A-EB8F-43E1-9069-D774E46E714D", limit: 12))
+        )
+    }
+
+    func testParseConversationTailWithLimit() throws {
+        let invocation = try CLICommandParser.parse(["conversation", "tail", "--limit", "18"])
+        XCTAssertEqual(invocation.command, .conversation(.tail(limit: 18)))
+    }
+
+    func testParseConversationListWithoutExplicitSubcommand() throws {
+        let invocation = try CLICommandParser.parse(["conversation", "--limit", "7"])
+        XCTAssertEqual(invocation.command, .conversation(.list(limit: 7)))
+    }
+
+    func testParseLogRecentWithFilters() throws {
+        let invocation = try CLICommandParser.parse([
+            "log", "recent",
+            "--minutes", "20",
+            "--limit", "100",
+            "--category", "Tool",
+            "--level", "error",
+            "--contains", "session",
+        ])
+        XCTAssertEqual(
+            invocation.command,
+            .log(.recent(
+                minutes: 20,
+                limit: 100,
+                category: "Tool",
+                level: "error",
+                contains: "session"
+            ))
+        )
+    }
+
+    func testParseLogRecentWithoutExplicitSubcommand() throws {
+        let invocation = try CLICommandParser.parse(["log", "--minutes", "5", "--limit", "30"])
+        XCTAssertEqual(
+            invocation.command,
+            .log(.recent(minutes: 5, limit: 30, category: nil, level: nil, contains: nil))
+        )
+    }
+
+    func testParseConversationShowWithoutIDThrows() {
+        XCTAssertThrowsError(try CLICommandParser.parse(["conversation", "show", "--limit", "10"])) { error in
+            XCTAssertTrue(error.localizedDescription.contains("conversation show"))
+        }
+    }
+
     func testParseDevBridgeSend() throws {
         let invocation = try CLICommandParser.parse(["dev", "bridge", "send", "abc-123", "run", "tests"])
         XCTAssertEqual(invocation.command, .dev(.bridgeSend(sessionId: "abc-123", command: "run tests")))


### PR DESCRIPTION
## Summary
- add `dochi conversation show <id|prefix> [--limit N]` to inspect message body of a specific conversation JSON
- add `dochi conversation tail [--limit N]` to inspect the latest conversation quickly
- add `dochi log recent [--minutes N] [--limit N] [--category C] [--level L] [--contains K]` for local unified log inspection (`com.dochi.app`) without control-plane dependency
- extend CLI parser/actions and usage/help text
- document a standard troubleshooting routine in `DochiCLI/README.md` so operators use the new commands first

## Test Evidence
- `xcodebuild -project Dochi.xcodeproj -scheme DochiCLI -configuration Debug build`
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/CLICommandSurfaceTests`

## Spec Impact
- Updated operational CLI guide: `DochiCLI/README.md`
