### PR TITLE
feat: tools.enable 그룹 활성화와 에이전트 선호 툴 그룹 지원

### DIFF
--- a/Dochi/Models/AgentConfig.swift
+++ b/Dochi/Models/AgentConfig.swift
@@ -6,11 +6,27 @@ struct AgentConfig: Codable, Sendable {
     var description: String?
     var defaultModel: String?
     var permissions: [String]?
+    var preferredToolGroups: [String]?
     var shellPermissions: ShellPermissionConfig?
     var delegationPolicy: DelegationPolicy?
 
     var effectivePermissions: [String] {
         permissions ?? ["safe", "sensitive", "restricted"]
+    }
+
+    var effectivePreferredToolGroups: [String] {
+        guard let preferredToolGroups else { return [] }
+
+        var result: [String] = []
+        var seen: Set<String> = []
+        for raw in preferredToolGroups {
+            let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty else { continue }
+            if seen.insert(normalized).inserted {
+                result.append(normalized)
+            }
+        }
+        return result
     }
 
     var effectiveShellPermissions: ShellPermissionConfig {
@@ -29,6 +45,7 @@ struct AgentConfig: Codable, Sendable {
         description = try container.decodeIfPresent(String.self, forKey: .description)
         defaultModel = try container.decodeIfPresent(String.self, forKey: .defaultModel)
         permissions = try container.decodeIfPresent([String].self, forKey: .permissions)
+        preferredToolGroups = try container.decodeIfPresent([String].self, forKey: .preferredToolGroups)
         shellPermissions = try container.decodeIfPresent(ShellPermissionConfig.self, forKey: .shellPermissions)
         delegationPolicy = try container.decodeIfPresent(DelegationPolicy.self, forKey: .delegationPolicy)
     }
@@ -39,6 +56,7 @@ struct AgentConfig: Codable, Sendable {
         description: String? = nil,
         defaultModel: String? = nil,
         permissions: [String]? = nil,
+        preferredToolGroups: [String]? = nil,
         shellPermissions: ShellPermissionConfig? = nil,
         delegationPolicy: DelegationPolicy? = nil
     ) {
@@ -47,6 +65,7 @@ struct AgentConfig: Codable, Sendable {
         self.description = description
         self.defaultModel = defaultModel
         self.permissions = permissions
+        self.preferredToolGroups = preferredToolGroups
         self.shellPermissions = shellPermissions
         self.delegationPolicy = delegationPolicy
     }

--- a/Dochi/Services/Protocols/BuiltInToolServiceProtocol.swift
+++ b/Dochi/Services/Protocols/BuiltInToolServiceProtocol.swift
@@ -20,6 +20,7 @@ protocol BuiltInToolServiceProtocol {
     var allToolInfos: [ToolInfo] { get }
 
     func availableToolSchemas(for permissions: [String]) -> [[String: Any]]
+    func availableToolSchemas(for permissions: [String], preferredToolGroups: [String]) -> [[String: Any]]
     func execute(name: String, arguments: [String: Any]) async -> ToolResult
     func enableTools(names: [String])
     func enableToolsTTL(minutes: Int)
@@ -31,6 +32,10 @@ protocol BuiltInToolServiceProtocol {
 
 extension BuiltInToolServiceProtocol {
     var selectedCapabilityLabel: String? { nil }
+
+    func availableToolSchemas(for permissions: [String], preferredToolGroups _: [String]) -> [[String: Any]] {
+        availableToolSchemas(for: permissions)
+    }
 
     func toolInfo(named name: String) -> ToolInfo? {
         allToolInfos.first { $0.name == name }

--- a/Dochi/Services/Tools/AgentEditorTool.swift
+++ b/Dochi/Services/Tools/AgentEditorTool.swift
@@ -584,7 +584,8 @@ final class AgentConfigGetTool: BuiltInToolProtocol {
                 "호출어: \(config.wakeWord ?? "(없음)")",
                 "설명: \(config.description ?? "(없음)")",
                 "기본 모델: \(config.defaultModel ?? "(없음)")",
-                "권한: \(config.effectivePermissions.joined(separator: ", "))"
+                "권한: \(config.effectivePermissions.joined(separator: ", "))",
+                "선호 도구 그룹: \(config.effectivePreferredToolGroups.isEmpty ? "(없음)" : config.effectivePreferredToolGroups.joined(separator: ", "))"
             ]
 
             Log.tool.info("Loaded config for agent: \(agentName)")
@@ -623,6 +624,11 @@ final class AgentConfigUpdateTool: BuiltInToolProtocol {
                     "items": ["type": "string", "enum": ["safe", "sensitive", "restricted"]],
                     "description": "에이전트 권한 목록"
                 ],
+                "preferred_tool_groups": [
+                    "type": "array",
+                    "items": ["type": "string"],
+                    "description": "선호 도구 그룹 목록 (예: coding, git, calendar, external_tool)"
+                ],
                 "name": ["type": "string", "description": "에이전트 이름 (미지정 시 활성 에이전트)"]
             ]
         ]
@@ -632,9 +638,14 @@ final class AgentConfigUpdateTool: BuiltInToolProtocol {
         let newWakeWord = arguments["wake_word"] as? String
         let newDescription = arguments["description"] as? String
         let newPermissions = arguments["permissions"] as? [String]
+        let newPreferredToolGroups = arguments["preferred_tool_groups"] as? [String]
 
-        if newWakeWord == nil && newDescription == nil && newPermissions == nil {
-            return ToolResult(toolCallId: "", content: "오류: 수정할 필드가 없습니다. wake_word, description, 또는 permissions를 지정해주세요.", isError: true)
+        if newWakeWord == nil && newDescription == nil && newPermissions == nil && newPreferredToolGroups == nil {
+            return ToolResult(
+                toolCallId: "",
+                content: "오류: 수정할 필드가 없습니다. wake_word, description, permissions, preferred_tool_groups 중 하나를 지정해주세요.",
+                isError: true
+            )
         }
 
         switch resolveAgentName(arguments: arguments, settings: settings, contextService: contextService, sessionContext: sessionContext) {
@@ -660,6 +671,20 @@ final class AgentConfigUpdateTool: BuiltInToolProtocol {
                 let validated = permissions.filter { validValues.contains($0) }
                 config.permissions = validated
                 changes.append("권한: \(validated.joined(separator: ", "))")
+            }
+            if let preferredToolGroups = newPreferredToolGroups {
+                var normalized: [String] = []
+                var seen: Set<String> = []
+                for raw in preferredToolGroups {
+                    let group = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                    guard !group.isEmpty else { continue }
+                    if seen.insert(group).inserted {
+                        normalized.append(group)
+                    }
+                }
+                config.preferredToolGroups = normalized.isEmpty ? nil : normalized
+                let label = normalized.isEmpty ? "(없음)" : normalized.joined(separator: ", ")
+                changes.append("선호 도구 그룹: \(label)")
             }
 
             contextService.saveAgentConfig(workspaceId: sessionContext.workspaceId, config: config)

--- a/Dochi/Services/Tools/BuiltInToolService.swift
+++ b/Dochi/Services/Tools/BuiltInToolService.swift
@@ -284,6 +284,10 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
     }
 
     func availableToolSchemas(for permissions: [String]) -> [[String: Any]] {
+        availableToolSchemas(for: permissions, preferredToolGroups: [])
+    }
+
+    func availableToolSchemas(for permissions: [String], preferredToolGroups: [String]) -> [[String: Any]] {
         var schemas: [[String: Any]] = []
         selectedCapabilityLabel = nil
 
@@ -302,7 +306,8 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
             tools = availableTools
         }
 
-        for tool in tools {
+        let orderedTools = orderedToolsByPreference(tools, preferredToolGroups: preferredToolGroups)
+        for tool in orderedTools {
             // OpenAI requires tool names to match ^[a-zA-Z0-9_-]+$
             let sanitizedName = Self.sanitizeToolName(tool.name)
             schemas.append([
@@ -330,6 +335,31 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
         }
 
         return schemas
+    }
+
+    private func orderedToolsByPreference(
+        _ tools: [any BuiltInToolProtocol],
+        preferredToolGroups: [String]
+    ) -> [any BuiltInToolProtocol] {
+        var orderedGroups: [String] = []
+        var seen: Set<String> = []
+        for raw in preferredToolGroups {
+            let normalized = ToolGroupResolver.normalizeGroupName(raw)
+            guard !normalized.isEmpty else { continue }
+            if seen.insert(normalized).inserted {
+                orderedGroups.append(normalized)
+            }
+        }
+        guard !orderedGroups.isEmpty else { return tools.sorted { $0.name < $1.name } }
+
+        let priorities = Dictionary(uniqueKeysWithValues: orderedGroups.enumerated().map { ($0.element, $0.offset) })
+
+        return tools.sorted { lhs, rhs in
+            let lhsPriority = priorities[ToolGroupResolver.group(forToolName: lhs.name)] ?? Int.max
+            let rhsPriority = priorities[ToolGroupResolver.group(forToolName: rhs.name)] ?? Int.max
+            if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
+            return lhs.name < rhs.name
+        }
     }
 
     func execute(name: String, arguments: [String: Any]) async -> ToolResult {

--- a/Dochi/Services/Tools/ToolRegistry.swift
+++ b/Dochi/Services/Tools/ToolRegistry.swift
@@ -31,6 +31,23 @@ final class ToolRegistry {
         }
     }
 
+    /// Returns tool names that belong to one of the requested logical groups.
+    /// Group names are normalized (trimmed, lowercased) before matching.
+    func toolNames(inGroups groups: [String]) -> [String] {
+        let normalized = Set(groups.map(ToolGroupResolver.normalizeGroupName).filter { !$0.isEmpty })
+        guard !normalized.isEmpty else { return [] }
+
+        return allTools.keys
+            .filter { normalized.contains(ToolGroupResolver.group(forToolName: $0)) }
+            .sorted()
+    }
+
+    /// Returns all currently known logical group names.
+    var allToolGroups: [String] {
+        let groups = allTools.keys.map { ToolGroupResolver.group(forToolName: $0) }
+        return Array(Set(groups)).sorted()
+    }
+
     func enable(names: [String]) {
         for name in names {
             if allTools[name] != nil {
@@ -127,7 +144,18 @@ struct ToolInfo: Identifiable, Sendable {
     let parameters: [ToolParamInfo]
 
     var group: String {
-        let base = String(name.split(separator: ".").first ?? Substring(name))
+        ToolGroupResolver.group(forToolName: name)
+    }
+}
+
+enum ToolGroupResolver {
+    static func normalizeGroupName(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    static func group(forToolName name: String) -> String {
+        let base = String(name.split(separator: ".").first ?? Substring(name)).lowercased()
+
         // 레거시 도구명을 논리적 그룹으로 정규화
         switch base {
         case "create_reminder", "list_reminders", "complete_reminder": return "reminders"

--- a/Dochi/Services/Tools/ToolsRegistryTool.swift
+++ b/Dochi/Services/Tools/ToolsRegistryTool.swift
@@ -48,7 +48,7 @@ final class ToolsListTool: BuiltInToolProtocol {
 final class ToolsEnableTool: BuiltInToolProtocol {
     let name = "tools.enable"
     let category: ToolCategory = .safe
-    let description = "도구를 이름으로 활성화합니다."
+    let description = "도구를 이름(names) 또는 그룹(groups)으로 활성화합니다."
     let isBaseline = true
 
     private let registry: ToolRegistry
@@ -65,18 +65,30 @@ final class ToolsEnableTool: BuiltInToolProtocol {
                     "type": "array",
                     "items": ["type": "string"],
                     "description": "활성화할 도구 이름 목록"
-                ]
+                ],
+                "groups": [
+                    "type": "array",
+                    "items": ["type": "string"],
+                    "description": "활성화할 도구 그룹 목록 (예: coding, git, external_tool, dochi)"
+                ],
             ],
-            "required": ["names"]
         ]
     }
 
     func execute(arguments: [String: Any]) async -> ToolResult {
-        guard let names = arguments["names"] as? [String], !names.isEmpty else {
-            return ToolResult(toolCallId: "", content: "오류: names는 필수입니다 (문자열 배열).", isError: true)
+        let names = arguments["names"] as? [String] ?? []
+        let groups = parseGroups(from: arguments["groups"])
+
+        guard !names.isEmpty || !groups.isEmpty else {
+            return ToolResult(
+                toolCallId: "",
+                content: "오류: names 또는 groups 중 하나 이상이 필요합니다.",
+                isError: true
+            )
         }
 
-        let normalizedNames = normalizeRequestedNames(names)
+        let namesFromGroups = registry.toolNames(inGroups: groups)
+        let normalizedNames = normalizeRequestedNames(names + namesFromGroups)
         let previouslyEnabled = registry.enabledToolNames
         registry.enable(names: normalizedNames)
 
@@ -96,10 +108,39 @@ final class ToolsEnableTool: BuiltInToolProtocol {
         if !invalid.isEmpty {
             lines.append("찾을 수 없는 도구: \(invalid.joined(separator: ", "))")
         }
+        if !groups.isEmpty {
+            let knownGroups = Set(registry.allToolGroups)
+            let unknownGroups = groups.filter { !knownGroups.contains($0) }
+            if !unknownGroups.isEmpty {
+                lines.append("찾을 수 없는 그룹: \(unknownGroups.joined(separator: ", "))")
+            }
+        }
         if lines.isEmpty {
             lines.append("활성화 가능한 도구가 없습니다.")
         }
         return ToolResult(toolCallId: "", content: lines.joined(separator: "\n"))
+    }
+
+    private func parseGroups(from rawGroups: Any?) -> [String] {
+        let values: [String]
+        if let groups = rawGroups as? [String] {
+            values = groups
+        } else if let one = rawGroups as? String {
+            values = [one]
+        } else {
+            values = []
+        }
+
+        var result: [String] = []
+        var seen: Set<String> = []
+        for raw in values {
+            let group = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !group.isEmpty else { continue }
+            if seen.insert(group).inserted {
+                result.append(group)
+            }
+        }
+        return result
     }
 
     private func normalizeRequestedNames(_ names: [String]) -> [String] {

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -231,11 +231,18 @@ final class DochiViewModel {
     private var sentenceChunker = SentenceChunker()
     private var llmStreamActive = false
     private static let maxToolLoopIterations = 10
+    private static let maxSameToolSignatureCalls = 2
+    private static let maxToolControlCallsPerTurn = 1
     private static let maxRecentMessages = 30
     private static let sessionEndingTimeout: TimeInterval = 10
     private static let toolConfirmationTimeout: TimeInterval = 30
     private static let compressionModel = "gpt-4o-mini"
     private static let compressionSummaryPrompt = "다음 메모리를 핵심 사실만 보존하여 50% 이하로 요약하세요. 라인 단위(`- ...`) 형식 유지."
+    private static let toolControlNames: Set<String> = [
+        "tools.enable",
+        "tools.enable_ttl",
+        "tools.reset",
+    ]
 
     // MARK: - Computed
 
@@ -2224,7 +2231,7 @@ final class DochiViewModel {
                         let normalizedName = Self.desanitizeToolNameForLLM(call.name)
                         let blockedForTelegram =
                             normalizedName.hasPrefix("mcp_")
-                            || Self.remoteToolControlNames.contains(normalizedName)
+                            || Self.toolControlNames.contains(normalizedName)
                             || (toolInfoForLLMName(call.name)?.category != .safe)
 
                         let result: ToolResult
@@ -2289,12 +2296,6 @@ final class DochiViewModel {
         }
     }
 
-    private static let remoteToolControlNames: Set<String> = [
-        "tools.enable",
-        "tools.enable_ttl",
-        "tools.reset"
-    ]
-
     private static func desanitizeToolNameForLLM(_ name: String) -> String {
         name.replacingOccurrences(of: "-_-", with: ".")
     }
@@ -2314,7 +2315,7 @@ final class DochiViewModel {
             }
 
             if name.hasPrefix("mcp_") { return false }
-            if Self.remoteToolControlNames.contains(Self.desanitizeToolNameForLLM(name)) { return false }
+            if Self.toolControlNames.contains(Self.desanitizeToolNameForLLM(name)) { return false }
             return true
         }
     }
@@ -2445,6 +2446,9 @@ final class DochiViewModel {
 
         // Compose context (after potential compression)
         var systemPrompt = composeSystemPrompt()
+        if let toolUsageHint = buildRecentToolUsageHint(from: conversation) {
+            systemPrompt += "\n\n\(toolUsageHint)"
+        }
 
         // RAG: Search for relevant documents and inject context (I-1)
         ragLastContextInfo = nil
@@ -2485,7 +2489,11 @@ final class DochiViewModel {
 
         // Get available tool schemas
         let agentPermissions = currentAgentPermissions()
-        let tools = toolService.availableToolSchemas(for: agentPermissions)
+        let preferredToolGroups = currentAgentPreferredToolGroups()
+        let tools = toolService.availableToolSchemas(
+            for: agentPermissions,
+            preferredToolGroups: preferredToolGroups
+        )
         selectedCapabilityLabel = toolService.selectedCapabilityLabel
 
         // Reset sentence chunker for TTS streaming
@@ -2495,6 +2503,8 @@ final class DochiViewModel {
         toolExecutions = []
 
         var toolLoopCount = 0
+        var toolSignatureCounts: [String: Int] = [:]
+        var toolControlCallCount = 0
 
         while toolLoopCount <= Self.maxToolLoopIterations + 1 {
             guard !Task.isCancelled else { return }
@@ -2594,14 +2604,26 @@ final class DochiViewModel {
                 processingSubState = .toolCalling
                 for codableCall in toolCalls {
                     guard !Task.isCancelled else { return }
-                    currentToolName = codableCall.name
-                    Log.tool.info("Executing tool: \(codableCall.name) (loop \(toolLoopCount))")
 
                     let call = ToolCall(
                         id: codableCall.id,
                         name: codableCall.name,
                         arguments: codableCall.arguments
                     )
+
+                    if let guardError = evaluateToolLoopGuard(
+                        call: call,
+                        toolSignatureCounts: &toolSignatureCounts,
+                        toolControlCallCount: &toolControlCallCount
+                    ) {
+                        appendToolResultMessage(guardError)
+                        processingSubState = .toolError
+                        Log.tool.warning("Blocked repetitive tool call: \(call.name)")
+                        continue
+                    }
+
+                    currentToolName = codableCall.name
+                    Log.tool.info("Executing tool: \(codableCall.name) (loop \(toolLoopCount))")
 
                     // UX-7: Create live ToolExecution for UI tracking
                     let info = toolService.toolInfo(named: call.name)
@@ -2936,6 +2958,79 @@ final class DochiViewModel {
         }
     }
 
+    private func buildRecentToolUsageHint(from conversation: Conversation) -> String? {
+        var recentNames: [String] = []
+        var seen: Set<String> = []
+
+        for message in conversation.messages.reversed() {
+            guard let toolCalls = message.toolCalls, !toolCalls.isEmpty else { continue }
+            for call in toolCalls.reversed() {
+                let normalizedName = Self.desanitizeToolNameForLLM(call.name)
+                guard seen.insert(normalizedName).inserted else { continue }
+                recentNames.append(normalizedName)
+                if recentNames.count >= 5 {
+                    break
+                }
+            }
+            if recentNames.count >= 5 {
+                break
+            }
+        }
+
+        guard !recentNames.isEmpty else { return nil }
+        let ordered = recentNames.reversed().joined(separator: ", ")
+        return """
+        ## 최근 도구 사용 힌트
+        - 최근 사용 도구: \(ordered)
+        - 같은 도구를 같은 인자로 반복 호출하지 마세요.
+        - 코딩 세션 현황 질의에서는 `coding.sessions`, `external_tool.status`, `dochi.bridge_status`를 우선 사용하세요.
+        """
+    }
+
+    private func evaluateToolLoopGuard(
+        call: ToolCall,
+        toolSignatureCounts: inout [String: Int],
+        toolControlCallCount: inout Int
+    ) -> ToolResult? {
+        let normalizedName = Self.desanitizeToolNameForLLM(call.name)
+        let signature = Self.toolCallSignature(name: normalizedName, arguments: call.arguments)
+        let signatureCount = (toolSignatureCounts[signature] ?? 0) + 1
+        toolSignatureCounts[signature] = signatureCount
+
+        if signatureCount > Self.maxSameToolSignatureCalls {
+            return ToolResult(
+                toolCallId: call.id,
+                content: "반복 호출 차단: 동일 도구/인자 호출이 \(Self.maxSameToolSignatureCalls)회를 초과했습니다. 다른 도구를 사용하거나 최종 응답을 생성하세요.",
+                isError: true
+            )
+        }
+
+        if Self.toolControlNames.contains(normalizedName) {
+            toolControlCallCount += 1
+            if toolControlCallCount > Self.maxToolControlCallsPerTurn {
+                return ToolResult(
+                    toolCallId: call.id,
+                    content: "제어 도구 호출 차단: tools.enable/tools.enable_ttl/tools.reset는 한 턴에 최대 \(Self.maxToolControlCallsPerTurn)회만 호출할 수 있습니다.",
+                    isError: true
+                )
+            }
+        }
+
+        return nil
+    }
+
+    private static func toolCallSignature(name: String, arguments: [String: Any]) -> String {
+        let payload: String
+        if JSONSerialization.isValidJSONObject(arguments),
+           let data = try? JSONSerialization.data(withJSONObject: arguments, options: [.sortedKeys]),
+           let json = String(data: data, encoding: .utf8) {
+            payload = json
+        } else {
+            payload = String(describing: arguments)
+        }
+        return "\(name)|\(payload)"
+    }
+
     // MARK: - Context Composition
 
     private func composeSystemPrompt() -> String {
@@ -3161,12 +3256,18 @@ final class DochiViewModel {
     // MARK: - Agent Permissions
 
     private func currentAgentPermissions() -> [String] {
-        let agentName = settings.activeAgentName
-        let wsId = sessionContext.workspaceId
-        if let config = contextService.loadAgentConfig(workspaceId: wsId, agentName: agentName) {
-            return config.effectivePermissions
-        }
-        return ["safe"]
+        currentAgentConfig()?.effectivePermissions ?? ["safe"]
+    }
+
+    private func currentAgentPreferredToolGroups() -> [String] {
+        currentAgentConfig()?.effectivePreferredToolGroups ?? []
+    }
+
+    private func currentAgentConfig() -> AgentConfig? {
+        contextService.loadAgentConfig(
+            workspaceId: sessionContext.workspaceId,
+            agentName: settings.activeAgentName
+        )
     }
 
     // MARK: - Conversation Management

--- a/DochiTests/AgentManagementTests.swift
+++ b/DochiTests/AgentManagementTests.swift
@@ -99,7 +99,8 @@ final class AgentManagementTests: XCTestCase {
             wakeWord: "테스트야",
             description: "테스트용 봇",
             defaultModel: "gpt-4o",
-            permissions: ["safe", "sensitive"]
+            permissions: ["safe", "sensitive"],
+            preferredToolGroups: ["coding", "git"]
         )
 
         contextService.saveAgentConfig(workspaceId: wsId, config: config)
@@ -111,6 +112,7 @@ final class AgentManagementTests: XCTestCase {
         XCTAssertEqual(loaded?.description, "테스트용 봇")
         XCTAssertEqual(loaded?.defaultModel, "gpt-4o")
         XCTAssertEqual(loaded?.effectivePermissions, ["safe", "sensitive"])
+        XCTAssertEqual(loaded?.effectivePreferredToolGroups, ["coding", "git"])
     }
 
     func testAgentConfigPermissionsUpdate() {
@@ -126,5 +128,25 @@ final class AgentManagementTests: XCTestCase {
 
         let loaded = contextService.loadAgentConfig(workspaceId: wsId, agentName: "봇")
         XCTAssertEqual(loaded?.effectivePermissions, ["safe"])
+    }
+
+    func testSendMessagePassesPreferredToolGroupsToToolService() async {
+        let wsId = sessionContext.workspaceId
+        let agentName = settings.activeAgentName
+        contextService.saveAgentConfig(
+            workspaceId: wsId,
+            config: AgentConfig(
+                name: agentName,
+                permissions: ["safe"],
+                preferredToolGroups: ["coding", "git"]
+            )
+        )
+        toolService.stubbedSchemas = []
+
+        viewModel.inputText = "테스트 메시지"
+        viewModel.sendMessage()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertEqual(toolService.lastPreferredToolGroups ?? [], ["coding", "git"])
     }
 }

--- a/DochiTests/BuiltInToolServiceCapabilityRouterTests.swift
+++ b/DochiTests/BuiltInToolServiceCapabilityRouterTests.swift
@@ -71,6 +71,19 @@ final class BuiltInToolServiceCapabilityRouterTests: XCTestCase {
         XCTAssertEqual(service.selectedCapabilityLabel, "Chat Core + Coding Read")
     }
 
+    func testPreferredToolGroupsPrioritizeSchemaOrder() {
+        let service = makeService(routerEnabled: true)
+        service.enableTools(names: ["open_url"])
+
+        let schemas = service.availableToolSchemas(
+            for: ["safe"],
+            preferredToolGroups: ["url"]
+        )
+        let names = orderedSchemaNames(from: schemas)
+
+        XCTAssertEqual(names.first, "open_url")
+    }
+
     // MARK: - Helpers
 
     private func makeService(routerEnabled: Bool) -> BuiltInToolService {
@@ -99,5 +112,12 @@ final class BuiltInToolServiceCapabilityRouterTests: XCTestCase {
             names.insert(name)
         }
         return names
+    }
+
+    private func orderedSchemaNames(from schemas: [[String: Any]]) -> [String] {
+        schemas.compactMap { schema in
+            guard let function = schema["function"] as? [String: Any] else { return nil }
+            return function["name"] as? String
+        }
     }
 }

--- a/DochiTests/DochiViewModelToolGuardTests.swift
+++ b/DochiTests/DochiViewModelToolGuardTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class DochiViewModelToolGuardTests: XCTestCase {
+    func testRepeatedToolsEnableIsBlocked() async {
+        let llmService = MockLLMService()
+        llmService.stubbedResponses = [
+            .toolCalls([
+                CodableToolCall(
+                    id: "tc1",
+                    name: "tools-_-enable",
+                    argumentsJSON: #"{"names":["open_url"]}"#
+                ),
+            ]),
+            .toolCalls([
+                CodableToolCall(
+                    id: "tc2",
+                    name: "tools-_-enable",
+                    argumentsJSON: #"{"names":["open_url"]}"#
+                ),
+            ]),
+            .text("완료"),
+        ]
+
+        let toolService = MockBuiltInToolService()
+        let viewModel = makeViewModel(llmService: llmService, toolService: toolService)
+
+        viewModel.inputText = "세션 상태 확인해줘"
+        viewModel.sendMessage()
+        await waitUntilIdle(viewModel)
+
+        XCTAssertEqual(toolService.executeCallCount, 1)
+        let blockedMessage = viewModel.currentConversation?.messages.last(where: {
+            $0.role == .tool && $0.content.contains("제어 도구 호출 차단")
+        })
+        XCTAssertNotNil(blockedMessage)
+    }
+
+    func testSameToolSameArgumentsThirdCallIsBlocked() async {
+        let llmService = MockLLMService()
+        llmService.stubbedResponses = [
+            .toolCalls([
+                CodableToolCall(
+                    id: "tc1",
+                    name: "web_search",
+                    argumentsJSON: #"{"query":"swift"}"#
+                ),
+            ]),
+            .toolCalls([
+                CodableToolCall(
+                    id: "tc2",
+                    name: "web_search",
+                    argumentsJSON: #"{"query":"swift"}"#
+                ),
+            ]),
+            .toolCalls([
+                CodableToolCall(
+                    id: "tc3",
+                    name: "web_search",
+                    argumentsJSON: #"{"query":"swift"}"#
+                ),
+            ]),
+            .text("완료"),
+        ]
+
+        let toolService = MockBuiltInToolService()
+        let viewModel = makeViewModel(llmService: llmService, toolService: toolService)
+
+        viewModel.inputText = "swift 검색해줘"
+        viewModel.sendMessage()
+        await waitUntilIdle(viewModel)
+
+        XCTAssertEqual(toolService.executeCallCount, 2)
+        let blockedMessage = viewModel.currentConversation?.messages.last(where: {
+            $0.role == .tool && $0.content.contains("반복 호출 차단")
+        })
+        XCTAssertNotNil(blockedMessage)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel(
+        llmService: MockLLMService,
+        toolService: MockBuiltInToolService
+    ) -> DochiViewModel {
+        let settings = AppSettings()
+        let wsId = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+        let sessionContext = SessionContext(workspaceId: wsId)
+
+        let keychainService = MockKeychainService()
+        keychainService.store["openai_api_key"] = "sk-test"
+
+        return DochiViewModel(
+            llmService: llmService,
+            toolService: toolService,
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: keychainService,
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: sessionContext
+        )
+    }
+
+    private func waitUntilIdle(_ viewModel: DochiViewModel, timeout: TimeInterval = 2.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while viewModel.interactionState != .idle && Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+}

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -270,11 +270,18 @@ final class MockBuiltInToolService: BuiltInToolServiceProtocol {
     var lastArguments: [String: Any]?
     var enabledNames: [String] = []
     var resetCallCount = 0
+    var lastPreferredToolGroups: [String]?
 
     var nonBaselineToolSummaries: [(name: String, description: String, category: ToolCategory)] = []
     var allToolInfos: [ToolInfo] = []
 
     func availableToolSchemas(for permissions: [String]) -> [[String: Any]] {
+        lastPreferredToolGroups = nil
+        stubbedSchemas
+    }
+
+    func availableToolSchemas(for permissions: [String], preferredToolGroups: [String]) -> [[String: Any]] {
+        lastPreferredToolGroups = preferredToolGroups
         stubbedSchemas
     }
 

--- a/DochiTests/ModelTests.swift
+++ b/DochiTests/ModelTests.swift
@@ -139,6 +139,14 @@ final class ModelTests: XCTestCase {
         XCTAssertEqual(config2.effectiveShellPermissions.allowedCommands, ["safe"])
     }
 
+    func testAgentConfigEffectivePreferredToolGroups() {
+        let config = AgentConfig(
+            name: "coder",
+            preferredToolGroups: [" Coding ", "git", "coding", ""]
+        )
+        XCTAssertEqual(config.effectivePreferredToolGroups, ["coding", "git"])
+    }
+
     func testAgentConfigShellPermissionsCodable() throws {
         let custom = ShellPermissionConfig(
             blockedCommands: ["sudo "],
@@ -166,6 +174,16 @@ final class ModelTests: XCTestCase {
         XCTAssertNil(decoded.shellPermissions)
         // effectiveShellPermissions should return default
         XCTAssertFalse(decoded.effectiveShellPermissions.blockedCommands.isEmpty)
+    }
+
+    func testAgentConfigPreferredToolGroupsCodable() throws {
+        let config = AgentConfig(name: "coder", preferredToolGroups: ["coding", "external_tool"])
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(AgentConfig.self, from: data)
+
+        XCTAssertEqual(decoded.preferredToolGroups ?? [], ["coding", "external_tool"])
+        XCTAssertEqual(decoded.effectivePreferredToolGroups, ["coding", "external_tool"])
     }
 
     // MARK: - ShellPermissionConfig

--- a/DochiTests/ToolRegistryTests.swift
+++ b/DochiTests/ToolRegistryTests.swift
@@ -203,6 +203,18 @@ final class ToolRegistryTests: XCTestCase {
         XCTAssertTrue(registry.enabledToolNames.contains("tool.c"))
     }
 
+    func testToolNamesInGroupsNormalizesLegacyGroups() {
+        registry.register(StubTool(name: "set_timer", category: .safe, isBaseline: true))
+        registry.register(StubTool(name: "dochi.bridge_status", category: .safe, isBaseline: false))
+        registry.register(StubTool(name: "external_tool.status", category: .safe, isBaseline: false))
+
+        let names = registry.toolNames(inGroups: [" TIMER ", "dochi", "external_tool"])
+        XCTAssertEqual(
+            Set(names),
+            Set(["set_timer", "dochi.bridge_status", "external_tool.status"])
+        )
+    }
+
     // MARK: - ToolsEnableTool
 
     func testToolsEnableToolActivatesNewTools() async {
@@ -260,5 +272,42 @@ final class ToolRegistryTests: XCTestCase {
         XCTAssertTrue(result.content.contains("도구 활성화 완료"))
         XCTAssertTrue(result.content.contains("dochi.bridge_open"))
         XCTAssertTrue(registry.enabledToolNames.contains("dochi.bridge_open"))
+    }
+
+    func testToolsEnableToolActivatesByGroups() async {
+        registry.register(StubTool(name: "dochi.bridge_status"))
+        registry.register(StubTool(name: "dochi.bridge_read"))
+        registry.register(StubTool(name: "external_tool.status"))
+        let tool = ToolsEnableTool(registry: registry)
+
+        let result = await tool.execute(arguments: [
+            "groups": ["dochi", "external_tool"]
+        ])
+
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(registry.enabledToolNames.contains("dochi.bridge_status"))
+        XCTAssertTrue(registry.enabledToolNames.contains("dochi.bridge_read"))
+        XCTAssertTrue(registry.enabledToolNames.contains("external_tool.status"))
+    }
+
+    func testToolsEnableToolUnknownGroupReturnsHint() async {
+        registry.register(StubTool(name: "dochi.bridge_status"))
+        let tool = ToolsEnableTool(registry: registry)
+
+        let result = await tool.execute(arguments: [
+            "groups": ["unknown_group"]
+        ])
+
+        XCTAssertFalse(result.isError)
+        XCTAssertTrue(result.content.contains("찾을 수 없는 그룹"))
+        XCTAssertFalse(registry.enabledToolNames.contains("dochi.bridge_status"))
+    }
+
+    func testToolsEnableToolRequiresNamesOrGroups() async {
+        let tool = ToolsEnableTool(registry: registry)
+        let result = await tool.execute(arguments: [:])
+
+        XCTAssertTrue(result.isError)
+        XCTAssertTrue(result.content.contains("names 또는 groups"))
     }
 }


### PR DESCRIPTION
## Summary
- `tools.enable`에 `groups` 입력을 추가해 이름/카테고리 기반 활성화를 모두 지원합니다.
- 에이전트 설정에 `preferredToolGroups`를 추가하고, 툴 스키마 정렬 시 선호 카테고리를 우선 반영합니다.
- 모델 루프에 동일 툴/인자 반복 호출 가드와 제어 툴 호출 횟수 가드를 추가하고, 최근 툴 사용 힌트를 시스템 컨텍스트에 주입합니다.
- 관련 단위 테스트를 추가/확장했습니다.

## Changes
- Tool 그룹 기능
  - `tools.enable` 스키마/동작 확장 (`names`, `groups`)
  - `ToolRegistry`에 그룹 조회 API 및 그룹 정규화 resolver 추가
- 에이전트 설정 기능
  - `AgentConfig.preferredToolGroups` + 정규화/역직렬화
  - `agent.config_get`/`agent.config_update`에 선호 그룹 노출/갱신
- 툴 선택 우선순위
  - `BuiltInToolServiceProtocol`에 선호 그룹 기반 스키마 API 추가
  - `BuiltInToolService`에서 선호 그룹 우선 정렬 적용
- 안정성 보강
  - 툴 루프 가드(동일 signature 반복 제한, 제어 툴 호출 제한)
  - 최근 툴 사용 힌트 컨텍스트 추가
- 테스트
  - `ToolRegistryTests`, `ModelTests`, `AgentManagementTests`, `BuiltInToolServiceCapabilityRouterTests` 확장
  - `DochiViewModelToolGuardTests` 신규 추가

## CLI Validation
- `swiftc DochiCLI/main.swift Dochi/CLIShared/*.swift -o /tmp/dochi-cli`
- `/tmp/dochi-cli --help` 정상
- `/tmp/dochi-cli ask ...`, `/tmp/dochi-cli dev tool ...` 실행 시 Control Plane 미연결 환경에서 예상된 에러 확인
- `/tmp/dochi-cli doctor`로 소켓/토큰 부재 상태 확인

## Test Evidence
- 실행:
  - `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ToolRegistryTests -only-testing:DochiTests/DochiViewModelToolGuardTests`
- 결과:
  - 현재 main 기준의 기존 컴파일 이슈로 빌드 실패 (본 PR 변경 외 영역)
  - 예: `TaskOpportunity`, `ProjectContext`, `GitRepositoryInsight`, `KeychainWriteCoordinator` 타입 미해결

## Spec Impact
- 없음 (동작 확장 중심; 필요 시 후속 문서화 가능)

Closes #278
