### PR TITLE
feat: add SDK session streaming integration (#283)

### DIFF
--- a/Dochi/Services/Protocols/RuntimeBridgeProtocol.swift
+++ b/Dochi/Services/Protocols/RuntimeBridgeProtocol.swift
@@ -17,4 +17,19 @@ protocol RuntimeBridgeProtocol {
 
     /// Query the runtime health status.
     func health() async throws -> RuntimeHealthResponse
+
+    // MARK: - Session Management
+
+    /// Open or reuse a session for the given parameters.
+    func openSession(params: SessionOpenParams) async throws -> SessionOpenResult
+
+    /// Start a session run and return a stream of bridge events.
+    /// The stream yields partial text, tool calls, and completes on `session.completed` or `session.failed`.
+    func runSession(params: SessionRunParams) -> AsyncThrowingStream<BridgeEvent, Error>
+
+    /// Interrupt an active session run.
+    func interruptSession(sessionId: String) async throws -> SessionInterruptResult
+
+    /// Close a session.
+    func closeSession(sessionId: String) async throws -> SessionCloseResult
 }

--- a/Dochi/Services/Runtime/RuntimeBridgeService.swift
+++ b/Dochi/Services/Runtime/RuntimeBridgeService.swift
@@ -30,6 +30,9 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
     private var retryCount = 0
     private var nextRequestId = 1
 
+    /// Active session event stream continuations, keyed by sessionId.
+    private var sessionContinuations: [String: AsyncThrowingStream<BridgeEvent, Error>.Continuation] = [:]
+
     // MARK: - Init
 
     init(
@@ -91,6 +94,12 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
             }
         }
 
+        // Finish all active session streams
+        for (_, continuation) in sessionContinuations {
+            continuation.finish(throwing: RuntimeBridgeError.connectionClosed)
+        }
+        sessionContinuations.removeAll()
+
         connection?.close()
         connection = nil
         process = nil
@@ -115,6 +124,77 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
 
         let data = try JSONEncoder().encode(result)
         return try JSONDecoder().decode(RuntimeHealthResponse.self, from: data)
+    }
+
+    // MARK: - Session Management
+
+    func openSession(params: SessionOpenParams) async throws -> SessionOpenResult {
+        let rpcParams: [String: AnyCodableValue] = [
+            "workspaceId": .string(params.workspaceId),
+            "agentId": .string(params.agentId),
+            "conversationId": .string(params.conversationId),
+            "userId": .string(params.userId),
+            "deviceId": .string(params.deviceId ?? ""),
+            "sdkSessionId": params.sdkSessionId.map { .string($0) } ?? .null,
+        ]
+        return try await sendRpc(method: "session.open", params: rpcParams)
+    }
+
+    func runSession(params: SessionRunParams) -> AsyncThrowingStream<BridgeEvent, Error> {
+        let sessionId = params.sessionId
+        return AsyncThrowingStream { continuation in
+            Task { @MainActor [weak self] in
+                guard let self else {
+                    continuation.finish()
+                    return
+                }
+
+                self.sessionContinuations[sessionId] = continuation
+                continuation.onTermination = { @Sendable _ in
+                    Task { @MainActor [weak self] in
+                        self?.sessionContinuations.removeValue(forKey: sessionId)
+                    }
+                }
+
+                do {
+                    let rpcParams: [String: AnyCodableValue] = [
+                        "sessionId": .string(params.sessionId),
+                        "input": .string(params.input),
+                        "contextSnapshotRef": params.contextSnapshotRef.map { .string($0) } ?? .null,
+                        "permissionMode": params.permissionMode.map { .string($0) } ?? .null,
+                    ]
+                    let _: SessionRunResult = try await self.sendRpc(method: "session.run", params: rpcParams)
+                    // Ack received — events will arrive via UDS notifications
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    func interruptSession(sessionId: String) async throws -> SessionInterruptResult {
+        let rpcParams: [String: AnyCodableValue] = [
+            "sessionId": .string(sessionId),
+        ]
+        let result: SessionInterruptResult = try await sendRpc(method: "session.interrupt", params: rpcParams)
+
+        // Finish any active stream for this session
+        if let continuation = sessionContinuations.removeValue(forKey: sessionId) {
+            continuation.finish()
+        }
+        return result
+    }
+
+    func closeSession(sessionId: String) async throws -> SessionCloseResult {
+        let rpcParams: [String: AnyCodableValue] = [
+            "sessionId": .string(sessionId),
+        ]
+        let result: SessionCloseResult = try await sendRpc(method: "session.close", params: rpcParams)
+
+        if let continuation = sessionContinuations.removeValue(forKey: sessionId) {
+            continuation.finish()
+        }
+        return result
     }
 
     // MARK: - Process Management
@@ -187,6 +267,13 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
         let conn = RuntimeUDSConnection(socketPath: socketPath)
         try await conn.connect()
         self.connection = conn
+
+        // Route incoming notifications to session event streams
+        conn.notificationHandler = { [weak self] notification in
+            Task { @MainActor [weak self] in
+                self?.handleNotification(notification)
+            }
+        }
 
         // Send initialize
         let initParams: [String: AnyCodableValue] = [
@@ -300,6 +387,38 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
         }
     }
 
+    // MARK: - Notification Handling
+
+    private func handleNotification(_ notification: JsonRpcNotification) {
+        guard notification.method == "bridge.event",
+              let params = notification.params else { return }
+
+        // Decode BridgeEvent from notification params
+        guard let event = decodeBridgeEvent(from: params) else { return }
+        guard let sessionId = event.sessionId,
+              let continuation = sessionContinuations[sessionId] else {
+            Log.runtime.debug("Received event for unknown session: \(event.sessionId ?? "nil")")
+            return
+        }
+
+        continuation.yield(event)
+
+        if event.eventType == .sessionCompleted || event.eventType == .sessionFailed {
+            continuation.finish()
+            sessionContinuations.removeValue(forKey: sessionId)
+        }
+    }
+
+    private func decodeBridgeEvent(from params: [String: AnyCodableValue]) -> BridgeEvent? {
+        do {
+            let data = try JSONEncoder().encode(AnyCodableValue.object(params))
+            return try JSONDecoder().decode(BridgeEvent.self, from: data)
+        } catch {
+            Log.runtime.error("Failed to decode bridge event: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
     // MARK: - Helpers
 
     func backoffDelay(attempt: Int) -> Double {
@@ -310,6 +429,25 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
         let id = nextRequestId
         nextRequestId += 1
         return JsonRpcRequest(id: id, method: method, params: params)
+    }
+
+    /// Generic RPC call: send request, decode result as T.
+    private func sendRpc<T: Decodable>(method: String, params: [String: AnyCodableValue]? = nil) async throws -> T {
+        guard let conn = connection else {
+            throw RuntimeBridgeError.notConnected
+        }
+        let request = makeRequest(method: method, params: params)
+        let response = try await conn.send(request)
+
+        guard let result = response.result else {
+            if let err = response.error {
+                throw RuntimeBridgeError.rpcError(code: err.code, message: err.message)
+            }
+            throw RuntimeBridgeError.invalidResponse
+        }
+
+        let data = try JSONEncoder().encode(result)
+        return try JSONDecoder().decode(T.self, from: data)
     }
 }
 
@@ -328,6 +466,9 @@ final class RuntimeUDSConnection: @unchecked Sendable {
     private var fileHandle: FileHandle?
     private var pendingRequests: [Int: CheckedContinuation<JsonRpcResponse, Error>] = [:]
     private let lock = NSLock()
+
+    /// Called when a JSON-RPC notification (no `id`) arrives from the runtime.
+    var notificationHandler: (@Sendable (JsonRpcNotification) -> Void)?
 
     init(socketPath: String) {
         self.socketPath = socketPath
@@ -412,15 +553,22 @@ final class RuntimeUDSConnection: @unchecked Sendable {
             guard let text = String(data: data, encoding: .utf8) else { return }
             for line in text.components(separatedBy: "\n") {
                 guard !line.isEmpty,
-                      let lineData = line.data(using: .utf8),
-                      let response = try? JSONDecoder().decode(JsonRpcResponse.self, from: lineData)
+                      let lineData = line.data(using: .utf8)
                 else { continue }
 
-                self?.lock.lock()
-                let continuation = self?.pendingRequests.removeValue(forKey: response.id)
-                self?.lock.unlock()
+                // Try decoding as a response (has `id` field)
+                if let response = try? JSONDecoder().decode(JsonRpcResponse.self, from: lineData) {
+                    self?.lock.lock()
+                    let continuation = self?.pendingRequests.removeValue(forKey: response.id)
+                    self?.lock.unlock()
+                    continuation?.resume(returning: response)
+                    continue
+                }
 
-                continuation?.resume(returning: response)
+                // Try decoding as a notification (has `method`, no `id`)
+                if let notification = try? JSONDecoder().decode(JsonRpcNotification.self, from: lineData) {
+                    self?.notificationHandler?(notification)
+                }
             }
         }
     }

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -222,6 +222,13 @@ final class DochiViewModel {
     let sessionContext: SessionContext
     let metricsCollector: MetricsCollector
 
+    /// Optional runtime bridge for SDK session path.
+    /// When available and in `.ready` state, input is routed through the SDK session.
+    private var runtimeBridge: (any RuntimeBridgeProtocol)?
+
+    /// Active SDK session ID for the current conversation (nil = use legacy LLM path).
+    private(set) var activeSDKSessionId: String?
+
     // MARK: - Internal
 
     private var processingTask: Task<Void, Never>?
@@ -282,7 +289,8 @@ final class DochiViewModel {
         soundService: SoundServiceProtocol,
         settings: AppSettings,
         sessionContext: SessionContext,
-        metricsCollector: MetricsCollector = MetricsCollector()
+        metricsCollector: MetricsCollector = MetricsCollector(),
+        runtimeBridge: (any RuntimeBridgeProtocol)? = nil
     ) {
         self.llmService = llmService
         self.toolService = toolService
@@ -295,6 +303,7 @@ final class DochiViewModel {
         self.settings = settings
         self.sessionContext = sessionContext
         self.metricsCollector = metricsCollector
+        self.runtimeBridge = runtimeBridge
 
         // Wire TTS completion callback
         self.ttsService.onComplete = { [weak self] in
@@ -991,9 +1000,17 @@ final class DochiViewModel {
             appendUserMessage(finalText, imageData: nil)
             transition(to: .processing)
             processingSubState = .streaming
-            llmStreamActive = true
-            processingTask = Task {
-                await processLLMLoop()
+
+            // Route through SDK session if runtime is ready; otherwise use legacy LLM path
+            if isSDKSessionAvailable {
+                processingTask = Task {
+                    await processSDKSession(input: finalText)
+                }
+            } else {
+                llmStreamActive = true
+                processingTask = Task {
+                    await processLLMLoop()
+                }
             }
         } else {
             // Process images off main thread, then send
@@ -1224,6 +1241,7 @@ final class DochiViewModel {
         llmStreamActive = false
         ttsService.stopAndClear()
         sentenceChunker = SentenceChunker()
+        interruptSDKSession()
 
         // Preserve partial streaming text as assistant message
         if !streamingText.isEmpty {
@@ -1237,11 +1255,150 @@ final class DochiViewModel {
         Log.app.info("Request cancelled by user")
     }
 
+    // MARK: - SDK Session Path
+
+    /// Whether the SDK session path is available and should be used.
+    var isSDKSessionAvailable: Bool {
+        runtimeBridge?.runtimeState == .ready
+    }
+
+    /// Configures the runtime bridge for SDK session support.
+    func configureRuntimeBridge(_ bridge: any RuntimeBridgeProtocol) {
+        self.runtimeBridge = bridge
+    }
+
+    /// Process user input through the SDK runtime session.
+    /// Opens a session if needed, sends input via `session.run`, and maps
+    /// streaming events to UI state updates.
+    private func processSDKSession(input: String) async {
+        guard let bridge = runtimeBridge else {
+            Log.runtime.error("SDK session requested but no runtime bridge available")
+            errorMessage = "런타임이 연결되지 않았습니다."
+            transition(to: .idle)
+            return
+        }
+
+        do {
+            // Open or reuse session
+            if activeSDKSessionId == nil {
+                let conversationId = currentConversation?.id.uuidString ?? UUID().uuidString
+                let openResult = try await bridge.openSession(params: SessionOpenParams(
+                    workspaceId: sessionContext.workspaceId.uuidString,
+                    agentId: settings.activeAgentName,
+                    conversationId: conversationId,
+                    userId: sessionContext.currentUserId ?? "anonymous",
+                    deviceId: nil,
+                    sdkSessionId: nil
+                ))
+                activeSDKSessionId = openResult.sessionId
+                Log.runtime.info("SDK session opened: \(openResult.sessionId) (created: \(openResult.created))")
+            }
+
+            guard let sessionId = activeSDKSessionId else { return }
+
+            // Start session run
+            let runParams = SessionRunParams(
+                sessionId: sessionId,
+                input: input,
+                contextSnapshotRef: nil,
+                permissionMode: nil
+            )
+
+            streamingText = ""
+            var accumulatedText = ""
+
+            for try await event in bridge.runSession(params: runParams) {
+                guard !Task.isCancelled else { break }
+
+                switch event.eventType {
+                case .sessionPartial:
+                    processingSubState = .streaming
+                    if let delta = extractPayloadString(event.payload, key: "delta") {
+                        accumulatedText += delta
+                        streamingText = accumulatedText
+                    }
+
+                case .sessionToolCall:
+                    processingSubState = .toolCalling
+                    if let toolName = extractPayloadString(event.payload, key: "toolName") {
+                        currentToolName = toolName
+                    }
+
+                case .sessionToolResult:
+                    // Tool result received — loop continues for more events
+                    processingSubState = .streaming
+                    currentToolName = nil
+
+                case .sessionCompleted:
+                    let finalText = extractPayloadString(event.payload, key: "text") ?? accumulatedText
+                    if !finalText.isEmpty {
+                        appendAssistantMessage(finalText)
+                    }
+                    streamingText = ""
+                    processingSubState = .complete
+                    saveConversation()
+                    Log.runtime.info("SDK session run completed")
+
+                case .sessionFailed:
+                    let reason = extractPayloadString(event.payload, key: "error") ?? "알 수 없는 오류"
+                    errorMessage = "런타임 오류: \(reason)"
+                    streamingText = ""
+                    Log.runtime.error("SDK session run failed: \(reason)")
+
+                default:
+                    Log.runtime.debug("Unhandled event type: \(event.eventType.rawValue)")
+                }
+            }
+        } catch {
+            Log.runtime.error("SDK session error: \(error.localizedDescription)")
+            errorMessage = "런타임 세션 오류: \(error.localizedDescription)"
+        }
+
+        // Clean up
+        if !streamingText.isEmpty {
+            appendAssistantMessage(streamingText)
+            streamingText = ""
+        }
+        processingSubState = nil
+        currentToolName = nil
+        transition(to: .idle)
+    }
+
+    /// Interrupt the active SDK session.
+    func interruptSDKSession() {
+        guard let bridge = runtimeBridge,
+              let sessionId = activeSDKSessionId else { return }
+
+        Task {
+            do {
+                _ = try await bridge.interruptSession(sessionId: sessionId)
+                Log.runtime.info("SDK session interrupted: \(sessionId)")
+            } catch {
+                Log.runtime.error("Failed to interrupt SDK session: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Extract a string value from a BridgeEvent payload.
+    private func extractPayloadString(_ payload: AnyCodableValue?, key: String) -> String? {
+        guard case .object(let dict) = payload,
+              case .string(let value) = dict[key] else { return nil }
+        return value
+    }
+
     func newConversation() {
         recordUserActivity()
 
         // I-2: 이전 대화에 대해 메모리 자동 정리 트리거
         triggerMemoryConsolidation(for: currentConversation)
+
+        // Close SDK session for previous conversation
+        if let bridge = runtimeBridge, let sessionId = activeSDKSessionId {
+            Task {
+                try? await bridge.closeSession(sessionId: sessionId)
+            }
+        }
+        activeSDKSessionId = nil
 
         currentConversation = nil
         streamingText = ""

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -1330,6 +1330,18 @@ final class MockRuntimeBridgeService: RuntimeBridgeProtocol {
     var stopCallCount = 0
     var healthCallCount = 0
 
+    // Session stubs
+    var stubbedOpenResult: SessionOpenResult?
+    var stubbedSessionEvents: [BridgeEvent] = []
+    var stubbedInterruptResult: SessionInterruptResult?
+    var stubbedCloseResult: SessionCloseResult?
+
+    var openCallCount = 0
+    var runCallCount = 0
+    var interruptCallCount = 0
+    var closeCallCount = 0
+    var lastRunParams: SessionRunParams?
+
     func startRuntime() async throws {
         startCallCount += 1
         if let error = stubbedError { throw error }
@@ -1349,6 +1361,51 @@ final class MockRuntimeBridgeService: RuntimeBridgeProtocol {
             uptimeMs: 1000,
             activeSessions: 0,
             lastError: nil
+        )
+    }
+
+    func openSession(params: SessionOpenParams) async throws -> SessionOpenResult {
+        openCallCount += 1
+        if let error = stubbedError { throw error }
+        return stubbedOpenResult ?? SessionOpenResult(
+            sessionId: "mock-session",
+            sdkSessionId: "mock-sdk",
+            created: true
+        )
+    }
+
+    func runSession(params: SessionRunParams) -> AsyncThrowingStream<BridgeEvent, Error> {
+        runCallCount += 1
+        lastRunParams = params
+        let events = stubbedSessionEvents
+        let error = stubbedError
+        return AsyncThrowingStream { continuation in
+            if let error {
+                continuation.finish(throwing: error)
+                return
+            }
+            for event in events {
+                continuation.yield(event)
+            }
+            continuation.finish()
+        }
+    }
+
+    func interruptSession(sessionId: String) async throws -> SessionInterruptResult {
+        interruptCallCount += 1
+        if let error = stubbedError { throw error }
+        return stubbedInterruptResult ?? SessionInterruptResult(
+            interrupted: true,
+            sessionId: sessionId
+        )
+    }
+
+    func closeSession(sessionId: String) async throws -> SessionCloseResult {
+        closeCallCount += 1
+        if let error = stubbedError { throw error }
+        return stubbedCloseResult ?? SessionCloseResult(
+            closed: true,
+            sessionId: sessionId
         )
     }
 }

--- a/DochiTests/SessionStreamingTests.swift
+++ b/DochiTests/SessionStreamingTests.swift
@@ -1,0 +1,405 @@
+import XCTest
+@testable import Dochi
+
+final class SessionStreamingTests: XCTestCase {
+
+    // MARK: - BridgeEvent Parsing
+
+    func testBridgeEventDecodePartial() throws {
+        let json = """
+        {
+            "eventId": "e-1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "sessionId": "s-1",
+            "eventType": "session.partial",
+            "payload": {"delta": "Hello"}
+        }
+        """
+        let event = try JSONDecoder().decode(BridgeEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(event.eventId, "e-1")
+        XCTAssertEqual(event.sessionId, "s-1")
+        XCTAssertEqual(event.eventType, .sessionPartial)
+
+        // Verify payload contains delta
+        if case .object(let dict) = event.payload,
+           case .string(let delta) = dict["delta"] {
+            XCTAssertEqual(delta, "Hello")
+        } else {
+            XCTFail("Expected payload with delta string")
+        }
+    }
+
+    func testBridgeEventDecodeToolCall() throws {
+        let json = """
+        {
+            "eventId": "e-2",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "sessionId": "s-1",
+            "eventType": "session.tool_call",
+            "payload": {"toolName": "web_search", "toolCallId": "tc-1"}
+        }
+        """
+        let event = try JSONDecoder().decode(BridgeEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(event.eventType, .sessionToolCall)
+
+        if case .object(let dict) = event.payload,
+           case .string(let toolName) = dict["toolName"] {
+            XCTAssertEqual(toolName, "web_search")
+        } else {
+            XCTFail("Expected payload with toolName")
+        }
+    }
+
+    func testBridgeEventDecodeCompleted() throws {
+        let json = """
+        {
+            "eventId": "e-3",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "sessionId": "s-1",
+            "eventType": "session.completed",
+            "payload": {"text": "Hello world"}
+        }
+        """
+        let event = try JSONDecoder().decode(BridgeEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(event.eventType, .sessionCompleted)
+
+        if case .object(let dict) = event.payload,
+           case .string(let text) = dict["text"] {
+            XCTAssertEqual(text, "Hello world")
+        } else {
+            XCTFail("Expected payload with text")
+        }
+    }
+
+    func testBridgeEventDecodeFailed() throws {
+        let json = """
+        {
+            "eventId": "e-4",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "sessionId": "s-1",
+            "eventType": "session.failed",
+            "payload": {"error": "Model overloaded"}
+        }
+        """
+        let event = try JSONDecoder().decode(BridgeEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(event.eventType, .sessionFailed)
+
+        if case .object(let dict) = event.payload,
+           case .string(let error) = dict["error"] {
+            XCTAssertEqual(error, "Model overloaded")
+        } else {
+            XCTFail("Expected payload with error string")
+        }
+    }
+
+    func testBridgeEventDecodeWithNullOptionals() throws {
+        let json = """
+        {
+            "eventId": "e-5",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "eventType": "session.partial",
+            "payload": {"delta": "test"}
+        }
+        """
+        let event = try JSONDecoder().decode(BridgeEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertNil(event.sessionId)
+        XCTAssertNil(event.workspaceId)
+        XCTAssertNil(event.agentId)
+    }
+
+    // MARK: - Notification to Event Mapping
+
+    func testJsonRpcNotificationDecode() throws {
+        let json = """
+        {
+            "jsonrpc": "2.0",
+            "method": "bridge.event",
+            "params": {
+                "eventId": "e-1",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "sessionId": "s-1",
+                "eventType": "session.partial",
+                "payload": {"delta": "Hello"}
+            }
+        }
+        """
+        let notification = try JSONDecoder().decode(JsonRpcNotification.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(notification.method, "bridge.event")
+        XCTAssertNotNil(notification.params)
+
+        // Verify the params can be re-encoded and decoded as BridgeEvent
+        if let params = notification.params {
+            let encoded = try JSONEncoder().encode(AnyCodableValue.object(params))
+            let event = try JSONDecoder().decode(BridgeEvent.self, from: encoded)
+            XCTAssertEqual(event.eventType, .sessionPartial)
+            XCTAssertEqual(event.sessionId, "s-1")
+        }
+    }
+
+    // MARK: - Mock Bridge Session Lifecycle
+
+    @MainActor
+    func testMockBridgeOpenSession() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+
+        let result = try await bridge.openSession(params: SessionOpenParams(
+            workspaceId: "ws-1",
+            agentId: "a-1",
+            conversationId: "c-1",
+            userId: "u-1",
+            deviceId: nil,
+            sdkSessionId: nil
+        ))
+
+        XCTAssertEqual(result.sessionId, "mock-session")
+        XCTAssertTrue(result.created)
+        XCTAssertEqual(bridge.openCallCount, 1)
+    }
+
+    @MainActor
+    func testMockBridgeRunSessionDeliversEvents() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+        bridge.stubbedSessionEvents = [
+            BridgeEvent(
+                eventId: "e-1", timestamp: "2024-01-01T00:00:00Z",
+                sessionId: "s-1", workspaceId: nil, agentId: nil,
+                eventType: .sessionPartial,
+                payload: .object(["delta": .string("Hello")])
+            ),
+            BridgeEvent(
+                eventId: "e-2", timestamp: "2024-01-01T00:00:01Z",
+                sessionId: "s-1", workspaceId: nil, agentId: nil,
+                eventType: .sessionPartial,
+                payload: .object(["delta": .string(" world")])
+            ),
+            BridgeEvent(
+                eventId: "e-3", timestamp: "2024-01-01T00:00:02Z",
+                sessionId: "s-1", workspaceId: nil, agentId: nil,
+                eventType: .sessionCompleted,
+                payload: .object(["text": .string("Hello world")])
+            ),
+        ]
+
+        let params = SessionRunParams(
+            sessionId: "s-1", input: "Hello",
+            contextSnapshotRef: nil, permissionMode: nil
+        )
+
+        var receivedEvents: [BridgeEvent] = []
+        for try await event in bridge.runSession(params: params) {
+            receivedEvents.append(event)
+        }
+
+        XCTAssertEqual(receivedEvents.count, 3)
+        XCTAssertEqual(receivedEvents[0].eventType, .sessionPartial)
+        XCTAssertEqual(receivedEvents[1].eventType, .sessionPartial)
+        XCTAssertEqual(receivedEvents[2].eventType, .sessionCompleted)
+        XCTAssertEqual(bridge.runCallCount, 1)
+    }
+
+    @MainActor
+    func testMockBridgeRunSessionCompletesOnFailed() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.stubbedSessionEvents = [
+            BridgeEvent(
+                eventId: "e-1", timestamp: "2024-01-01T00:00:00Z",
+                sessionId: "s-1", workspaceId: nil, agentId: nil,
+                eventType: .sessionFailed,
+                payload: .object(["error": .string("Model error")])
+            ),
+        ]
+
+        let params = SessionRunParams(
+            sessionId: "s-1", input: "test",
+            contextSnapshotRef: nil, permissionMode: nil
+        )
+
+        var receivedEvents: [BridgeEvent] = []
+        for try await event in bridge.runSession(params: params) {
+            receivedEvents.append(event)
+        }
+
+        XCTAssertEqual(receivedEvents.count, 1)
+        XCTAssertEqual(receivedEvents[0].eventType, .sessionFailed)
+    }
+
+    @MainActor
+    func testMockBridgeInterruptSession() async throws {
+        let bridge = MockRuntimeBridgeService()
+        let result = try await bridge.interruptSession(sessionId: "s-1")
+        XCTAssertTrue(result.interrupted)
+        XCTAssertEqual(result.sessionId, "s-1")
+        XCTAssertEqual(bridge.interruptCallCount, 1)
+    }
+
+    @MainActor
+    func testMockBridgeCloseSession() async throws {
+        let bridge = MockRuntimeBridgeService()
+        let result = try await bridge.closeSession(sessionId: "s-1")
+        XCTAssertTrue(result.closed)
+        XCTAssertEqual(result.sessionId, "s-1")
+        XCTAssertEqual(bridge.closeCallCount, 1)
+    }
+
+    // MARK: - Event → State Mapping
+
+    @MainActor
+    func testPartialEventAccumulatesText() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+        bridge.stubbedSessionEvents = [
+            makeEvent(type: .sessionPartial, payload: ["delta": .string("Hello")]),
+            makeEvent(type: .sessionPartial, payload: ["delta": .string(" world")]),
+            makeEvent(type: .sessionCompleted, payload: ["text": .string("Hello world")]),
+        ]
+
+        let viewModel = makeViewModel(bridge: bridge)
+        viewModel.configureRuntimeBridge(bridge)
+        // Manually ensure a conversation exists
+        viewModel.inputText = "test"
+        viewModel.sendMessage()
+
+        // Wait for processing to complete
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(viewModel.interactionState, .idle)
+        XCTAssertEqual(viewModel.streamingText, "")
+        // The assistant message should have been appended
+        if let conversation = viewModel.currentConversation {
+            let assistantMessages = conversation.messages.filter { $0.role == .assistant }
+            XCTAssertFalse(assistantMessages.isEmpty, "Expected an assistant message")
+            XCTAssertEqual(assistantMessages.last?.content, "Hello world")
+        }
+    }
+
+    @MainActor
+    func testToolCallEventProcessedInStream() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+        bridge.stubbedSessionEvents = [
+            makeEvent(type: .sessionToolCall, payload: ["toolName": .string("web_search"), "toolCallId": .string("tc-1")]),
+            makeEvent(type: .sessionToolResult, payload: ["toolCallId": .string("tc-1"), "content": .string("result")]),
+            makeEvent(type: .sessionCompleted, payload: ["text": .string("Done")]),
+        ]
+
+        let viewModel = makeViewModel(bridge: bridge)
+        viewModel.configureRuntimeBridge(bridge)
+        viewModel.inputText = "search something"
+        viewModel.sendMessage()
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        // Verify session run was invoked
+        XCTAssertEqual(bridge.runCallCount, 1)
+        XCTAssertEqual(bridge.lastRunParams?.input, "search something")
+
+        // After completion, state should be idle with no active tool
+        XCTAssertEqual(viewModel.interactionState, .idle)
+        XCTAssertNil(viewModel.currentToolName)
+
+        // The completed event's text should be appended as assistant message
+        if let conversation = viewModel.currentConversation {
+            let assistantMessages = conversation.messages.filter { $0.role == .assistant }
+            XCTAssertEqual(assistantMessages.last?.content, "Done")
+        }
+    }
+
+    @MainActor
+    func testFailedEventSetsErrorMessage() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+        bridge.stubbedSessionEvents = [
+            makeEvent(type: .sessionFailed, payload: ["error": .string("Model overloaded")]),
+        ]
+
+        let viewModel = makeViewModel(bridge: bridge)
+        viewModel.configureRuntimeBridge(bridge)
+        viewModel.inputText = "test"
+        viewModel.sendMessage()
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(viewModel.interactionState, .idle)
+        XCTAssertNotNil(viewModel.errorMessage)
+        XCTAssertTrue(viewModel.errorMessage?.contains("Model overloaded") ?? false)
+    }
+
+    @MainActor
+    func testSDKSessionAvailableWhenRuntimeReady() {
+        let bridge = MockRuntimeBridgeService()
+        let viewModel = makeViewModel(bridge: bridge)
+        viewModel.configureRuntimeBridge(bridge)
+
+        bridge.runtimeState = .notStarted
+        XCTAssertFalse(viewModel.isSDKSessionAvailable)
+
+        bridge.runtimeState = .ready
+        XCTAssertTrue(viewModel.isSDKSessionAvailable)
+
+        bridge.runtimeState = .degraded
+        XCTAssertFalse(viewModel.isSDKSessionAvailable)
+    }
+
+    @MainActor
+    func testNewConversationClearsSDKSession() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+        bridge.stubbedSessionEvents = [
+            makeEvent(type: .sessionCompleted, payload: ["text": .string("hi")]),
+        ]
+
+        let viewModel = makeViewModel(bridge: bridge)
+        viewModel.configureRuntimeBridge(bridge)
+        viewModel.inputText = "hello"
+        viewModel.sendMessage()
+        try await Task.sleep(for: .milliseconds(200))
+
+        // Should have an active session
+        XCTAssertNotNil(viewModel.activeSDKSessionId)
+
+        // New conversation should clear it
+        viewModel.newConversation()
+        XCTAssertNil(viewModel.activeSDKSessionId)
+
+        // Allow async close task to execute
+        try await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(bridge.closeCallCount, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func makeEvent(
+        type: BridgeEventType,
+        payload: [String: AnyCodableValue],
+        sessionId: String = "mock-session"
+    ) -> BridgeEvent {
+        BridgeEvent(
+            eventId: UUID().uuidString,
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: sessionId,
+            workspaceId: nil,
+            agentId: nil,
+            eventType: type,
+            payload: .object(payload)
+        )
+    }
+
+    @MainActor
+    private func makeViewModel(bridge: MockRuntimeBridgeService) -> DochiViewModel {
+        DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: AppSettings(),
+            sessionContext: SessionContext(workspaceId: UUID()),
+            runtimeBridge: bridge
+        )
+    }
+}

--- a/dochi-agent-runtime/src/rpc-server.ts
+++ b/dochi-agent-runtime/src/rpc-server.ts
@@ -1,5 +1,6 @@
 import * as net from "net";
 import * as fs from "fs";
+import * as crypto from "crypto";
 import {
   type JsonRpcRequest,
   type JsonRpcResponse,
@@ -78,6 +79,77 @@ function processRequest(request: JsonRpcRequest): JsonRpcResponse {
   }
 }
 
+/**
+ * Emit stub streaming events for session.run (echo mode).
+ * Sends the input text back as partial deltas, then a completed event.
+ */
+function emitSessionRunEvents(conn: net.Socket, params: SessionRunParams): void {
+  const sessionId = params.sessionId;
+  const input = params.input;
+  const words = input.split(/\s+/).filter((w) => w.length > 0);
+
+  if (words.length === 0) {
+    // Empty input: emit completed immediately
+    const notification = {
+      jsonrpc: "2.0",
+      method: "bridge.event",
+      params: {
+        eventId: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+        sessionId,
+        eventType: "session.completed",
+        payload: { text: "" },
+      },
+    };
+    conn.write(JSON.stringify(notification) + "\n");
+    return;
+  }
+
+  let accumulated = "";
+  let delay = 0;
+
+  for (const word of words) {
+    delay += 50; // 50ms per word
+    const delta = (accumulated ? " " : "") + word;
+    accumulated += delta;
+    const capturedDelta = delta;
+
+    setTimeout(() => {
+      if (conn.destroyed) return;
+      const notification = {
+        jsonrpc: "2.0",
+        method: "bridge.event",
+        params: {
+          eventId: crypto.randomUUID(),
+          timestamp: new Date().toISOString(),
+          sessionId,
+          eventType: "session.partial",
+          payload: { delta: capturedDelta },
+        },
+      };
+      conn.write(JSON.stringify(notification) + "\n");
+    }, delay);
+  }
+
+  // Completed event after all partials
+  const finalText = accumulated;
+  setTimeout(() => {
+    if (conn.destroyed) return;
+    const notification = {
+      jsonrpc: "2.0",
+      method: "bridge.event",
+      params: {
+        eventId: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+        sessionId,
+        eventType: "session.completed",
+        payload: { text: finalText },
+      },
+    };
+    conn.write(JSON.stringify(notification) + "\n");
+  }, delay + 100);
+}
+
 export function createRpcServer(socketPath: string): net.Server {
   // Remove stale socket file
   if (fs.existsSync(socketPath)) {
@@ -113,6 +185,11 @@ export function createRpcServer(socketPath: string): net.Server {
 
         const response = processRequest(request);
         conn.write(JSON.stringify(response) + "\n");
+
+        // After ack for session.run, emit streaming events (stub echo mode)
+        if (request.method === "session.run" && !response.error) {
+          emitSessionRunEvents(conn, request.params as unknown as SessionRunParams);
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

- Extend `RuntimeBridgeProtocol` with `openSession`, `runSession`, `interruptSession`, `closeSession`
- Implement UDS notification handling: distinguish `JsonRpcResponse` (has `id`) from `JsonRpcNotification` (has `method`) in the reader loop
- `runSession` returns `AsyncThrowingStream<BridgeEvent, Error>` with continuations stored per sessionId
- Route `DochiViewModel.sendMessage()` through SDK when `isSDKSessionAvailable` (runtime state is `.ready`), fallback to legacy LLM path otherwise
- Map bridge events to app state: `.sessionPartial` → streaming text, `.sessionToolCall` → tool calling substate, `.sessionCompleted` → assistant message, `.sessionFailed` → error message
- Add interrupt button support via `interruptSDKSession()`
- TypeScript sidecar echo-mode: `emitSessionRunEvents` splits input into words, emits `session.partial` per word (50ms delay), then `session.completed`
- 16 new tests in `SessionStreamingTests.swift`

## Spec Impact

- `RuntimeBridgeProtocol` — 4 new session methods added (spec/interfaces.md sync needed)
- `DochiViewModel` — new SDK session processing path coexists with legacy LLM path
- `rpc-server.ts` — notification emission pattern established for future real agent integration

## Out of Scope

- Real LLM agent session (currently echo-mode stub)
- Persistent session recovery across app restart
- Multi-session concurrency (one active session at a time)
- Context snapshot passing to runtime

## Risk

- `Task.sleep`-based test timing may flake on slow CI — mitigated with 200ms tolerance
- Echo-mode `setTimeout` in TypeScript may drift under load — acceptable for stub

## Test plan

- [x] 85 tests pass (`xcodebuild test`)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] BridgeEvent parsing (5 tests): partial, toolCall, completed, failed, null optionals
- [x] JsonRpcNotification round-trip decode (1 test)
- [x] Mock bridge lifecycle (5 tests): open, run delivers events, run completes on failed, interrupt, close
- [x] Event→State mapping (4 tests): partial accumulation, tool call processing, failed error, SDK availability
- [x] New conversation clears SDK session (1 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)