### PR TITLE
fix: log SDK session close failures (#283)

### DIFF
--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -1395,7 +1395,11 @@ final class DochiViewModel {
         // Close SDK session for previous conversation
         if let bridge = runtimeBridge, let sessionId = activeSDKSessionId {
             Task {
-                try? await bridge.closeSession(sessionId: sessionId)
+                do {
+                    _ = try await bridge.closeSession(sessionId: sessionId)
+                } catch {
+                    Log.runtime.warning("Failed to close SDK session \(sessionId): \(error.localizedDescription)")
+                }
             }
         }
         activeSDKSessionId = nil


### PR DESCRIPTION
## Summary

- Replace `try? await bridge.closeSession(...)` with `do/catch` + `Log.runtime.warning` in `DochiViewModel.newConversation()`
- Prevents stale session close failures from going unnoticed

Per PR #300 review feedback. The fix was pushed after the PR had already been merged.

## Test plan

- [x] Existing tests pass (no behavior change, only logging added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)