### PR TITLE
feat: add permission gate and approval UX for tool dispatch (#285)

### DIFF
--- a/Dochi/Models/BridgeSchema.swift
+++ b/Dochi/Models/BridgeSchema.swift
@@ -126,6 +126,63 @@ enum ToolTimeoutPolicy {
     static let restricted: TimeInterval = 120
 }
 
+// MARK: - Approval RPC Types
+
+/// Parameters for `approval.request` (runtime → app notification).
+struct ApprovalRequestParams: Codable, Sendable {
+    let approvalId: String
+    let toolCallId: String
+    let sessionId: String
+    let toolName: String
+    let riskLevel: String     // "sensitive", "restricted"
+    let reason: String        // Why the tool is being called
+    let argumentsSummary: String  // Human-readable arguments summary
+}
+
+/// Parameters for `approval.resolve` (app → runtime RPC).
+struct ApprovalResolveParams: Codable, Sendable {
+    let approvalId: String
+    let toolCallId: String
+    let sessionId: String
+    let approved: Bool
+    let scope: ApprovalScope
+    let note: String?
+}
+
+/// Scope of an approval decision.
+enum ApprovalScope: String, Codable, Sendable {
+    case once = "once"
+    case session = "session"
+}
+
+/// Result from `approval.resolve` ack.
+struct ApprovalResolveAck: Codable, Sendable {
+    let received: Bool
+    let approvalId: String
+}
+
+/// Audit event for tool execution decisions.
+struct ToolAuditEvent: Sendable {
+    let toolCallId: String
+    let sessionId: String
+    let agentId: String?
+    let toolName: String
+    let riskLevel: String
+    let decision: ToolAuditDecision
+    let latencyMs: Int
+    let resultCode: Int?
+    let timestamp: Date
+}
+
+/// Decision recorded in audit log.
+enum ToolAuditDecision: String, Sendable {
+    case allowed       // safe tool, auto-approved
+    case approved      // user approved sensitive/restricted tool
+    case denied        // user denied
+    case timeout       // approval timed out
+    case policyBlocked // policy rejected
+}
+
 // MARK: - Event Envelope
 
 /// Common envelope for all runtime events (spec §5).

--- a/Dochi/Models/ToolConfirmation.swift
+++ b/Dochi/Models/ToolConfirmation.swift
@@ -1,9 +1,17 @@
 import Foundation
 
-/// Represents a pending sensitive tool confirmation request.
+/// Represents a pending sensitive tool confirmation request (local tool path).
 @MainActor
 struct ToolConfirmation {
     let toolName: String
     let toolDescription: String
     let continuation: CheckedContinuation<Bool, Never>
+}
+
+/// Represents a pending SDK tool approval request with scope selection.
+/// Used for the runtime bridge path where tools require approval.required flow.
+@MainActor
+struct SDKToolApproval {
+    let params: ApprovalRequestParams
+    let continuation: CheckedContinuation<(approved: Bool, scope: ApprovalScope), Never>
 }

--- a/Dochi/Services/Protocols/RuntimeBridgeProtocol.swift
+++ b/Dochi/Services/Protocols/RuntimeBridgeProtocol.swift
@@ -23,6 +23,10 @@ protocol RuntimeBridgeProtocol {
     /// Configure tool dispatch with the app's built-in tool service.
     func configureToolDispatch(toolService: any BuiltInToolServiceProtocol)
 
+    /// Set the approval handler for sensitive/restricted tool execution.
+    /// Called when the runtime dispatches a tool that requires user approval.
+    func setApprovalHandler(_ handler: ToolApprovalHandler?)
+
     // MARK: - Session Management
 
     /// Open or reuse a session for the given parameters.

--- a/Dochi/Services/Runtime/RuntimeBridgeService.swift
+++ b/Dochi/Services/Runtime/RuntimeBridgeService.swift
@@ -140,6 +140,11 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
         self.toolDispatchHandler = handler
     }
 
+    /// Set the approval handler for sensitive/restricted tool execution.
+    func setApprovalHandler(_ handler: ToolApprovalHandler?) {
+        toolDispatchHandler?.approvalHandler = handler
+    }
+
     // MARK: - Session Management
 
     func openSession(params: SessionOpenParams) async throws -> SessionOpenResult {
@@ -208,6 +213,7 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
         if let continuation = sessionContinuations.removeValue(forKey: sessionId) {
             continuation.finish()
         }
+        toolDispatchHandler?.clearSessionApprovals(sessionId: sessionId)
         return result
     }
 
@@ -413,9 +419,13 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
         // Decode BridgeEvent from notification params
         guard let event = decodeBridgeEvent(from: params) else { return }
 
-        // Route tool.dispatch to the dispatch handler (does not go through session stream)
+        // Route tool.dispatch and approval.required to the dispatch handler
         if event.eventType == .toolDispatch {
             toolDispatchHandler?.handleDispatch(event: event)
+            return
+        }
+        if event.eventType == .approvalRequired {
+            toolDispatchHandler?.handleApprovalRequest(event: event)
             return
         }
 

--- a/Dochi/Services/Runtime/ToolDispatchHandler.swift
+++ b/Dochi/Services/Runtime/ToolDispatchHandler.swift
@@ -1,26 +1,46 @@
 import Foundation
 import os
 
-/// Handles `tool.dispatch` notifications from the runtime by executing local tools
-/// and sending `tool.result` RPC responses back.
+/// Callback to request user approval for a sensitive/restricted tool.
+/// Returns (approved, scope) where scope is "once" or "session".
+typealias ToolApprovalHandler = @MainActor (ApprovalRequestParams) async -> (approved: Bool, scope: ApprovalScope)
+
+/// Handles `tool.dispatch` and `approval.required` notifications from the runtime
+/// by executing local tools and sending results/decisions back.
 @MainActor
 final class ToolDispatchHandler {
 
     private let toolService: any BuiltInToolServiceProtocol
     private weak var connection: RuntimeUDSConnection?
-    private var requestIdCounter: Int = 10_000  // Offset to avoid collision with session RPCs
+    private var requestIdCounter: Int = 10_000
+
+    /// Callback for requesting user approval (wired to UI confirmation banner).
+    var approvalHandler: ToolApprovalHandler?
+
+    /// Session-scoped approvals: sessionId → Set of approved tool names.
+    private var sessionApprovals: [String: Set<String>] = [:]
+
+    /// Audit log entries for the current session.
+    private(set) var auditLog: [ToolAuditEvent] = []
 
     init(toolService: any BuiltInToolServiceProtocol) {
         self.toolService = toolService
     }
 
-    /// Attach the UDS connection for sending tool.result RPCs.
+    /// Attach the UDS connection for sending RPCs.
     func setConnection(_ connection: RuntimeUDSConnection) {
         self.connection = connection
     }
 
+    /// Clear session-scoped approvals (e.g., on session close).
+    func clearSessionApprovals(sessionId: String) {
+        sessionApprovals.removeValue(forKey: sessionId)
+    }
+
+    // MARK: - Tool Dispatch
+
     /// Handle a `tool.dispatch` bridge event.
-    /// Decodes the payload, executes the tool, and sends back `tool.result`.
+    /// Checks permission, requests approval if needed, executes the tool, and sends back `tool.result`.
     func handleDispatch(event: BridgeEvent) {
         guard let payload = event.payload,
               case .object(let dict) = payload,
@@ -31,7 +51,6 @@ final class ToolDispatchHandler {
             return
         }
 
-        // Extract arguments
         let arguments: [String: Any]
         if case .object(let argsDict) = dict["arguments"] {
             arguments = argsDict.toNativeDict()
@@ -39,7 +58,6 @@ final class ToolDispatchHandler {
             arguments = [:]
         }
 
-        // Extract risk level for timeout
         let riskLevel: String
         if case .string(let risk) = dict["riskLevel"] {
             riskLevel = risk
@@ -52,6 +70,30 @@ final class ToolDispatchHandler {
         Log.runtime.info("Tool dispatch: \(toolName) (\(toolCallId)), risk=\(riskLevel), timeout=\(timeout)s")
 
         Task { @MainActor in
+            let startTime = Date()
+
+            // Permission check for sensitive/restricted tools
+            if riskLevel != "safe" {
+                let approved = await checkPermission(
+                    toolCallId: toolCallId,
+                    sessionId: sessionId,
+                    toolName: toolName,
+                    riskLevel: riskLevel,
+                    arguments: arguments
+                )
+
+                if !approved {
+                    let deniedResult = ToolResult(
+                        toolCallId: toolCallId,
+                        content: "도구 '\(toolName)' 실행이 사용자에 의해 거부되었습니다.",
+                        isError: true
+                    )
+                    await sendToolResult(toolCallId: toolCallId, sessionId: sessionId, result: deniedResult, errorCode: BridgeErrorCode.toolPermissionDenied.rawValue)
+                    recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: .denied, startTime: startTime, resultCode: BridgeErrorCode.toolPermissionDenied.rawValue)
+                    return
+                }
+            }
+
             let result = await executeWithTimeout(
                 toolName: toolName,
                 toolCallId: toolCallId,
@@ -59,17 +101,128 @@ final class ToolDispatchHandler {
                 timeout: timeout
             )
 
-            await sendToolResult(
-                toolCallId: toolCallId,
-                sessionId: sessionId,
-                result: result
-            )
+            await sendToolResult(toolCallId: toolCallId, sessionId: sessionId, result: result)
+
+            let decision: ToolAuditDecision = riskLevel == "safe" ? .allowed : .approved
+            recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: result.isError ? .policyBlocked : decision, startTime: startTime, resultCode: result.isError ? BridgeErrorCode.toolExecutionFailed.rawValue : nil)
 
             Log.runtime.info("Tool result sent: \(toolName) (\(toolCallId)), success=\(!result.isError)")
         }
     }
 
+    // MARK: - Approval Request (from runtime)
+
+    /// Handle an `approval.required` bridge event from the runtime.
+    /// Shows approval UI and sends `approval.resolve` RPC back.
+    func handleApprovalRequest(event: BridgeEvent) {
+        guard let payload = event.payload,
+              case .object(let dict) = payload,
+              case .string(let approvalId) = dict["approvalId"],
+              case .string(let toolCallId) = dict["toolCallId"],
+              case .string(let toolName) = dict["toolName"],
+              case .string(let riskLevel) = dict["riskLevel"],
+              let sessionId = event.sessionId else {
+            Log.runtime.warning("Invalid approval.required payload")
+            return
+        }
+
+        let reason: String
+        if case .string(let r) = dict["reason"] { reason = r } else { reason = "" }
+        let argumentsSummary: String
+        if case .string(let s) = dict["argumentsSummary"] { argumentsSummary = s } else { argumentsSummary = "" }
+
+        let params = ApprovalRequestParams(
+            approvalId: approvalId,
+            toolCallId: toolCallId,
+            sessionId: sessionId,
+            toolName: toolName,
+            riskLevel: riskLevel,
+            reason: reason,
+            argumentsSummary: argumentsSummary
+        )
+
+        Task { @MainActor in
+            let startTime = Date()
+
+            guard let handler = approvalHandler else {
+                Log.runtime.warning("No approval handler — auto-denying \(toolName)")
+                await sendApprovalResolve(approvalId: approvalId, toolCallId: toolCallId, sessionId: sessionId, approved: false, scope: .once, note: "No approval handler available")
+                recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: .denied, startTime: startTime, resultCode: nil)
+                return
+            }
+
+            // Check session-scoped approval
+            if let approved = sessionApprovals[sessionId], approved.contains(toolName) {
+                Log.runtime.info("Session-scoped approval for \(toolName)")
+                await sendApprovalResolve(approvalId: approvalId, toolCallId: toolCallId, sessionId: sessionId, approved: true, scope: .session, note: nil)
+                recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: .approved, startTime: startTime, resultCode: nil)
+                return
+            }
+
+            let (approved, scope) = await handler(params)
+
+            if approved && scope == .session {
+                if sessionApprovals[sessionId] == nil {
+                    sessionApprovals[sessionId] = []
+                }
+                sessionApprovals[sessionId]?.insert(toolName)
+                Log.runtime.info("Session-scoped approval granted for \(toolName)")
+            }
+
+            await sendApprovalResolve(approvalId: approvalId, toolCallId: toolCallId, sessionId: sessionId, approved: approved, scope: scope, note: nil)
+
+            let decision: ToolAuditDecision = approved ? .approved : .denied
+            recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: decision, startTime: startTime, resultCode: nil)
+
+            Log.runtime.info("Approval resolved: \(toolName) → \(approved ? "approved" : "denied") (scope=\(scope.rawValue))")
+        }
+    }
+
     // MARK: - Private
+
+    /// Check if a sensitive/restricted tool is allowed.
+    /// Uses the existing BuiltInToolService confirmation flow.
+    private func checkPermission(
+        toolCallId: String,
+        sessionId: String,
+        toolName: String,
+        riskLevel: String,
+        arguments: [String: Any]
+    ) async -> Bool {
+        // Check session-scoped approval
+        if let approved = sessionApprovals[sessionId], approved.contains(toolName) {
+            Log.runtime.info("Session-scoped approval for \(toolName)")
+            return true
+        }
+
+        // Request user approval via the approval handler
+        guard let handler = approvalHandler else {
+            Log.runtime.warning("No approval handler — denying \(toolName)")
+            return false
+        }
+
+        let argsSummary = arguments.keys.sorted().joined(separator: ", ")
+        let params = ApprovalRequestParams(
+            approvalId: UUID().uuidString,
+            toolCallId: toolCallId,
+            sessionId: sessionId,
+            toolName: toolName,
+            riskLevel: riskLevel,
+            reason: "도구 실행 승인이 필요합니다",
+            argumentsSummary: argsSummary.isEmpty ? "(인자 없음)" : argsSummary
+        )
+
+        let (approved, scope) = await handler(params)
+
+        if approved && scope == .session {
+            if sessionApprovals[sessionId] == nil {
+                sessionApprovals[sessionId] = []
+            }
+            sessionApprovals[sessionId]?.insert(toolName)
+        }
+
+        return approved
+    }
 
     private func executeWithTimeout(
         toolName: String,
@@ -77,7 +230,6 @@ final class ToolDispatchHandler {
         arguments: [String: Any],
         timeout: TimeInterval
     ) async -> ToolResult {
-        // Execute tool on MainActor with a timeout via Task.sleep race
         let executionTask = Task { @MainActor in
             await self.toolService.execute(name: toolName, arguments: arguments)
         }
@@ -92,7 +244,6 @@ final class ToolDispatchHandler {
             )
         }
 
-        // Race: whichever finishes first wins
         let result = await executionTask.value
         timeoutTask.cancel()
         return result
@@ -101,7 +252,8 @@ final class ToolDispatchHandler {
     private func sendToolResult(
         toolCallId: String,
         sessionId: String,
-        result: ToolResult
+        result: ToolResult,
+        errorCode: Int? = nil
     ) async {
         guard let connection else {
             Log.runtime.warning("Cannot send tool.result: no UDS connection")
@@ -109,7 +261,6 @@ final class ToolDispatchHandler {
         }
 
         requestIdCounter += 1
-        let requestId = requestIdCounter
 
         var params: [String: AnyCodableValue] = [
             "toolCallId": .string(toolCallId),
@@ -117,12 +268,12 @@ final class ToolDispatchHandler {
             "success": .bool(!result.isError),
             "content": .string(result.content),
         ]
-        if result.isError {
-            params["errorCode"] = .int(BridgeErrorCode.toolExecutionFailed.rawValue)
+        if let code = errorCode ?? (result.isError ? BridgeErrorCode.toolExecutionFailed.rawValue : nil) {
+            params["errorCode"] = .int(code)
         }
 
         let request = JsonRpcRequest(
-            id: requestId,
+            id: requestIdCounter,
             method: "tool.result",
             params: params
         )
@@ -132,6 +283,73 @@ final class ToolDispatchHandler {
         } catch {
             Log.runtime.error("Failed to send tool.result: \(error.localizedDescription)")
         }
+    }
+
+    private func sendApprovalResolve(
+        approvalId: String,
+        toolCallId: String,
+        sessionId: String,
+        approved: Bool,
+        scope: ApprovalScope,
+        note: String?
+    ) async {
+        guard let connection else {
+            Log.runtime.warning("Cannot send approval.resolve: no UDS connection")
+            return
+        }
+
+        requestIdCounter += 1
+
+        var params: [String: AnyCodableValue] = [
+            "approvalId": .string(approvalId),
+            "toolCallId": .string(toolCallId),
+            "sessionId": .string(sessionId),
+            "approved": .bool(approved),
+            "scope": .string(scope.rawValue),
+        ]
+        if let note {
+            params["note"] = .string(note)
+        }
+
+        let request = JsonRpcRequest(
+            id: requestIdCounter,
+            method: "approval.resolve",
+            params: params
+        )
+
+        do {
+            _ = try await connection.send(request)
+        } catch {
+            Log.runtime.error("Failed to send approval.resolve: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Audit
+
+    private func recordAudit(
+        toolCallId: String,
+        sessionId: String,
+        agentId: String?,
+        toolName: String,
+        riskLevel: String,
+        decision: ToolAuditDecision,
+        startTime: Date,
+        resultCode: Int?
+    ) {
+        let latencyMs = Int(Date().timeIntervalSince(startTime) * 1000)
+        let event = ToolAuditEvent(
+            toolCallId: toolCallId,
+            sessionId: sessionId,
+            agentId: agentId,
+            toolName: toolName,
+            riskLevel: riskLevel,
+            decision: decision,
+            latencyMs: latencyMs,
+            resultCode: resultCode,
+            timestamp: Date()
+        )
+        auditLog.append(event)
+        Log.runtime.info("Audit: \(toolName) → \(decision.rawValue) (\(latencyMs)ms)")
     }
 
     static func timeout(for riskLevel: String) -> TimeInterval {
@@ -146,7 +364,6 @@ final class ToolDispatchHandler {
 // MARK: - AnyCodableValue → Native Dictionary
 
 extension AnyCodableValue {
-    /// Convert AnyCodableValue to native Swift dictionary for tool arguments.
     func toNative() -> Any {
         switch self {
         case .string(let s): return s

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -106,6 +106,7 @@ final class DochiViewModel {
     var currentToolName: String?
     var partialTranscript: String = ""
     var pendingToolConfirmation: ToolConfirmation?
+    var pendingSDKApproval: SDKToolApproval?
     var userProfiles: [UserProfile] = []
     var currentUserName: String = "(사용자 없음)"
     var selectedCapabilityLabel: String?
@@ -234,6 +235,7 @@ final class DochiViewModel {
     private var processingTask: Task<Void, Never>?
     private var sessionTimeoutTask: Task<Void, Never>?
     private var confirmationTimeoutTask: Task<Void, Never>?
+    private var sdkApprovalTimeoutTask: Task<Void, Never>?
     private var localServerMonitorTask: Task<Void, Never>?
     private var sentenceChunker = SentenceChunker()
     private var llmStreamActive = false
@@ -1266,6 +1268,10 @@ final class DochiViewModel {
     func configureRuntimeBridge(_ bridge: any RuntimeBridgeProtocol) {
         self.runtimeBridge = bridge
         bridge.configureToolDispatch(toolService: toolService)
+        bridge.setApprovalHandler { [weak self] params in
+            guard let self else { return (approved: false, scope: .once) }
+            return await self.requestSDKToolApproval(params: params)
+        }
     }
 
     /// Process user input through the SDK runtime session.
@@ -1950,6 +1956,39 @@ final class DochiViewModel {
         pendingToolConfirmation = nil
         confirmation.continuation.resume(returning: approved)
         Log.tool.info("Tool confirmation \(approved ? "approved" : "denied"): \(confirmation.toolName)")
+    }
+
+    // MARK: - SDK Tool Approval
+
+    /// Show approval UI for a runtime-dispatched sensitive/restricted tool
+    /// and wait for user decision with scope selection.
+    private func requestSDKToolApproval(params: ApprovalRequestParams) async -> (approved: Bool, scope: ApprovalScope) {
+        return await withCheckedContinuation { continuation in
+            self.pendingSDKApproval = SDKToolApproval(
+                params: params,
+                continuation: continuation
+            )
+
+            self.sdkApprovalTimeoutTask?.cancel()
+            self.sdkApprovalTimeoutTask = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(Self.toolConfirmationTimeout + 5))
+                guard !Task.isCancelled else { return }
+                if self?.pendingSDKApproval?.params.toolName == params.toolName {
+                    Log.runtime.warning("SDK tool approval safety-net timeout: \(params.toolName)")
+                    self?.respondToSDKApproval(approved: false)
+                }
+            }
+        }
+    }
+
+    /// Called by UI when user responds to an SDK tool approval request.
+    func respondToSDKApproval(approved: Bool, scope: ApprovalScope = .once) {
+        guard let approval = pendingSDKApproval else { return }
+        sdkApprovalTimeoutTask?.cancel()
+        sdkApprovalTimeoutTask = nil
+        pendingSDKApproval = nil
+        approval.continuation.resume(returning: (approved: approved, scope: scope))
+        Log.runtime.info("SDK tool approval \(approved ? "approved(\(scope.rawValue))" : "denied"): \(approval.params.toolName)")
     }
 
     /// End the voice session manually.

--- a/Dochi/Views/ContentView.swift
+++ b/Dochi/Views/ContentView.swift
@@ -289,6 +289,10 @@ struct ContentView: View {
                 viewModel.respondToToolConfirmation(approved: false)
                 return .handled
             }
+            if viewModel.pendingSDKApproval != nil {
+                viewModel.respondToSDKApproval(approved: false)
+                return .handled
+            }
             if selectedSection == .chat, viewModel.interactionState == .processing {
                 viewModel.cancelRequest()
                 return .handled
@@ -299,6 +303,10 @@ struct ContentView: View {
         .onKeyPress(.return) {
             if viewModel.pendingToolConfirmation != nil {
                 viewModel.respondToToolConfirmation(approved: true)
+                return .handled
+            }
+            if viewModel.pendingSDKApproval != nil {
+                viewModel.respondToSDKApproval(approved: true, scope: .once)
                 return .handled
             }
             return .ignored
@@ -469,13 +477,23 @@ struct ContentView: View {
                 )
             }
 
-            // Tool confirmation banner
+            // Tool confirmation banner (local tool path)
             if let confirmation = viewModel.pendingToolConfirmation {
                 ToolConfirmationBannerView(
                     toolName: confirmation.toolName,
                     toolDescription: confirmation.toolDescription,
                     onApprove: { viewModel.respondToToolConfirmation(approved: true) },
                     onDeny: { viewModel.respondToToolConfirmation(approved: false) }
+                )
+            }
+
+            // SDK tool approval banner (runtime bridge path)
+            if let approval = viewModel.pendingSDKApproval {
+                SDKToolApprovalBannerView(
+                    params: approval.params,
+                    onApproveOnce: { viewModel.respondToSDKApproval(approved: true, scope: .once) },
+                    onApproveSession: { viewModel.respondToSDKApproval(approved: true, scope: .session) },
+                    onDeny: { viewModel.respondToSDKApproval(approved: false) }
                 )
             }
 
@@ -1535,6 +1553,162 @@ struct ToolConfirmationBannerView: View {
             try? await Task.sleep(for: .seconds(2))
 
             // Notify ViewModel to auto-deny (also cancels ViewModel's timeout task)
+            onDeny()
+        }
+    }
+}
+
+// MARK: - SDK Tool Approval Banner
+
+struct SDKToolApprovalBannerView: View {
+    let params: ApprovalRequestParams
+    let onApproveOnce: () -> Void
+    let onApproveSession: () -> Void
+    let onDeny: () -> Void
+    let timeoutSeconds: TimeInterval
+
+    @State private var remainingSeconds: Int
+    @State private var timerActive = true
+    @State private var showTimeoutMessage = false
+
+    init(params: ApprovalRequestParams, onApproveOnce: @escaping () -> Void, onApproveSession: @escaping () -> Void, onDeny: @escaping () -> Void, timeoutSeconds: TimeInterval = 30) {
+        self.params = params
+        self.onApproveOnce = onApproveOnce
+        self.onApproveSession = onApproveSession
+        self.onDeny = onDeny
+        self.timeoutSeconds = timeoutSeconds
+        self._remainingSeconds = State(initialValue: Int(timeoutSeconds))
+    }
+
+    private var isUrgent: Bool { remainingSeconds <= 10 }
+    private var progress: Double { Double(remainingSeconds) / timeoutSeconds }
+    private var riskColor: Color { params.riskLevel == "restricted" ? .red : .orange }
+
+    var body: some View {
+        if showTimeoutMessage {
+            timeoutMessageView
+        } else {
+            bannerContent
+        }
+    }
+
+    private var bannerContent: some View {
+        HStack(spacing: 8) {
+            Image(systemName: params.riskLevel == "restricted" ? "shield.slash" : "shield.lefthalf.filled")
+                .foregroundStyle(riskColor)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Text(params.toolName)
+                        .font(.system(size: 12, weight: .semibold))
+                    Text(params.riskLevel)
+                        .font(.system(size: 9, weight: .bold))
+                        .textCase(.uppercase)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(riskColor.opacity(0.2))
+                        .clipShape(Capsule())
+                        .foregroundStyle(riskColor)
+                }
+                if !params.reason.isEmpty {
+                    Text(params.reason)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+
+            // Countdown timer badge
+            ZStack {
+                Circle()
+                    .stroke(Color.secondary.opacity(0.2), lineWidth: 2)
+                    .frame(width: 28, height: 28)
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(isUrgent ? Color.red : riskColor, lineWidth: 2)
+                    .frame(width: 28, height: 28)
+                    .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 1), value: remainingSeconds)
+                Text("\(remainingSeconds)")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(isUrgent ? .red : .secondary)
+            }
+
+            Button {
+                timerActive = false
+                onDeny()
+            } label: {
+                Text("거부")
+                    .font(.system(size: 11, weight: .medium))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+            }
+            .buttonStyle(.bordered)
+
+            Button {
+                timerActive = false
+                onApproveSession()
+            } label: {
+                Text("세션 허용")
+                    .font(.system(size: 11, weight: .medium))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+            }
+            .buttonStyle(.bordered)
+            .tint(.green)
+
+            Button {
+                timerActive = false
+                onApproveOnce()
+            } label: {
+                Text("허용")
+                    .font(.system(size: 11, weight: .medium))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(isUrgent ? Color.red.opacity(0.12) : riskColor.opacity(0.08))
+        .animation(.easeInOut(duration: 0.3), value: isUrgent)
+        .onAppear {
+            startCountdown()
+        }
+    }
+
+    private var timeoutMessageView: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "clock.badge.xmark")
+                .foregroundStyle(.red)
+            Text("시간 초과로 자동 거부됨")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.red)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.red.opacity(0.08))
+        .transition(.opacity)
+    }
+
+    private func startCountdown() {
+        Task { @MainActor in
+            while timerActive && remainingSeconds > 0 {
+                try? await Task.sleep(for: .seconds(1))
+                guard timerActive else { return }
+                remainingSeconds -= 1
+            }
+
+            guard timerActive else { return }
+            timerActive = false
+
+            withAnimation(.easeInOut(duration: 0.3)) {
+                showTimeoutMessage = true
+            }
+
+            try? await Task.sleep(for: .seconds(2))
             onDeny()
         }
     }

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -1334,6 +1334,10 @@ final class MockRuntimeBridgeService: RuntimeBridgeProtocol {
     var configureToolDispatchCallCount = 0
     var lastToolService: (any BuiltInToolServiceProtocol)?
 
+    // Approval handler
+    var setApprovalHandlerCallCount = 0
+    var lastApprovalHandler: ToolApprovalHandler?
+
     // Session stubs
     var stubbedOpenResult: SessionOpenResult?
     var stubbedSessionEvents: [BridgeEvent] = []
@@ -1371,6 +1375,11 @@ final class MockRuntimeBridgeService: RuntimeBridgeProtocol {
     func configureToolDispatch(toolService: any BuiltInToolServiceProtocol) {
         configureToolDispatchCallCount += 1
         lastToolService = toolService
+    }
+
+    func setApprovalHandler(_ handler: ToolApprovalHandler?) {
+        setApprovalHandlerCallCount += 1
+        lastApprovalHandler = handler
     }
 
     func openSession(params: SessionOpenParams) async throws -> SessionOpenResult {

--- a/DochiTests/PermissionApprovalTests.swift
+++ b/DochiTests/PermissionApprovalTests.swift
@@ -1,0 +1,814 @@
+import XCTest
+@testable import Dochi
+
+final class PermissionApprovalTests: XCTestCase {
+
+    // MARK: - Approval Schema Types
+
+    func testApprovalRequestParamsEncodeDecode() throws {
+        let params = ApprovalRequestParams(
+            approvalId: "ap-1",
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            toolName: "shell.exec",
+            riskLevel: "sensitive",
+            reason: "쉘 명령 실행 승인이 필요합니다",
+            argumentsSummary: "command=ls -la"
+        )
+
+        let data = try JSONEncoder().encode(params)
+        let decoded = try JSONDecoder().decode(ApprovalRequestParams.self, from: data)
+
+        XCTAssertEqual(decoded.approvalId, "ap-1")
+        XCTAssertEqual(decoded.toolCallId, "tc-1")
+        XCTAssertEqual(decoded.sessionId, "s-1")
+        XCTAssertEqual(decoded.toolName, "shell.exec")
+        XCTAssertEqual(decoded.riskLevel, "sensitive")
+        XCTAssertEqual(decoded.reason, "쉘 명령 실행 승인이 필요합니다")
+        XCTAssertEqual(decoded.argumentsSummary, "command=ls -la")
+    }
+
+    func testApprovalResolveParamsEncodeDecode() throws {
+        let params = ApprovalResolveParams(
+            approvalId: "ap-1",
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            approved: true,
+            scope: .session,
+            note: nil
+        )
+
+        let data = try JSONEncoder().encode(params)
+        let decoded = try JSONDecoder().decode(ApprovalResolveParams.self, from: data)
+
+        XCTAssertEqual(decoded.approvalId, "ap-1")
+        XCTAssertTrue(decoded.approved)
+        XCTAssertEqual(decoded.scope, .session)
+        XCTAssertNil(decoded.note)
+    }
+
+    func testApprovalResolveParamsWithNote() throws {
+        let params = ApprovalResolveParams(
+            approvalId: "ap-2",
+            toolCallId: "tc-2",
+            sessionId: "s-1",
+            approved: false,
+            scope: .once,
+            note: "사용자가 위험하다고 판단"
+        )
+
+        let data = try JSONEncoder().encode(params)
+        let decoded = try JSONDecoder().decode(ApprovalResolveParams.self, from: data)
+
+        XCTAssertFalse(decoded.approved)
+        XCTAssertEqual(decoded.scope, .once)
+        XCTAssertEqual(decoded.note, "사용자가 위험하다고 판단")
+    }
+
+    func testApprovalResolveAckEncodeDecode() throws {
+        let ack = ApprovalResolveAck(received: true, approvalId: "ap-1")
+
+        let data = try JSONEncoder().encode(ack)
+        let decoded = try JSONDecoder().decode(ApprovalResolveAck.self, from: data)
+
+        XCTAssertTrue(decoded.received)
+        XCTAssertEqual(decoded.approvalId, "ap-1")
+    }
+
+    // MARK: - ApprovalScope
+
+    func testApprovalScopeRawValues() {
+        XCTAssertEqual(ApprovalScope.once.rawValue, "once")
+        XCTAssertEqual(ApprovalScope.session.rawValue, "session")
+    }
+
+    func testApprovalScopeEncodeDecode() throws {
+        let data = try JSONEncoder().encode(ApprovalScope.session)
+        let decoded = try JSONDecoder().decode(ApprovalScope.self, from: data)
+        XCTAssertEqual(decoded, .session)
+    }
+
+    // MARK: - ToolAuditEvent & Decision
+
+    func testToolAuditDecisionRawValues() {
+        XCTAssertEqual(ToolAuditDecision.allowed.rawValue, "allowed")
+        XCTAssertEqual(ToolAuditDecision.approved.rawValue, "approved")
+        XCTAssertEqual(ToolAuditDecision.denied.rawValue, "denied")
+        XCTAssertEqual(ToolAuditDecision.timeout.rawValue, "timeout")
+        XCTAssertEqual(ToolAuditDecision.policyBlocked.rawValue, "policyBlocked")
+    }
+
+    // MARK: - BridgeEventType
+
+    func testApprovalRequiredEventType() throws {
+        let json = """
+        {
+            "eventId": "e-1",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "sessionId": "s-1",
+            "eventType": "approval.required",
+            "payload": {
+                "approvalId": "ap-1",
+                "toolCallId": "tc-1",
+                "toolName": "shell.exec",
+                "riskLevel": "sensitive",
+                "reason": "Test",
+                "argumentsSummary": "cmd=test"
+            }
+        }
+        """
+        let event = try JSONDecoder().decode(BridgeEvent.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(event.eventType, .approvalRequired)
+        XCTAssertEqual(event.sessionId, "s-1")
+    }
+
+    // MARK: - ToolDispatchHandler Approval Flow
+
+    @MainActor
+    func testSensitiveToolRequiresApproval() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "OK")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        // Set approval handler that approves everything
+        handler.approvalHandler = { _ in
+            return (approved: true, scope: .once)
+        }
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        // Tool should have been executed after approval
+        XCTAssertEqual(mockToolService.executeCallCount, 1)
+        XCTAssertEqual(mockToolService.lastExecutedName, "shell.exec")
+
+        // Audit log should record the approval
+        XCTAssertEqual(handler.auditLog.count, 1)
+        XCTAssertEqual(handler.auditLog.first?.decision, .approved)
+        XCTAssertEqual(handler.auditLog.first?.toolName, "shell.exec")
+        XCTAssertEqual(handler.auditLog.first?.riskLevel, "sensitive")
+    }
+
+    @MainActor
+    func testSensitiveToolDenied() async throws {
+        let mockToolService = MockBuiltInToolService()
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        // Set approval handler that denies
+        handler.approvalHandler = { _ in
+            return (approved: false, scope: .once)
+        }
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        // Tool should NOT have been executed
+        XCTAssertEqual(mockToolService.executeCallCount, 0)
+
+        // Audit log should record the denial
+        XCTAssertEqual(handler.auditLog.count, 1)
+        XCTAssertEqual(handler.auditLog.first?.decision, .denied)
+    }
+
+    @MainActor
+    func testSafeToolSkipsApproval() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "OK")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        // Set approval handler (should NOT be called for safe tools)
+        var approvalCalled = false
+        handler.approvalHandler = { _ in
+            approvalCalled = true
+            return (approved: true, scope: .once)
+        }
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("calendar.today"),
+                "arguments": .object([:]),
+                "riskLevel": .string("safe"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(mockToolService.executeCallCount, 1)
+        XCTAssertFalse(approvalCalled)
+
+        // Audit log should show "allowed" (not "approved")
+        XCTAssertEqual(handler.auditLog.count, 1)
+        XCTAssertEqual(handler.auditLog.first?.decision, .allowed)
+    }
+
+    @MainActor
+    func testRestrictedToolRequiresApproval() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "Executed")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        var receivedParams: ApprovalRequestParams?
+        handler.approvalHandler = { params in
+            receivedParams = params
+            return (approved: true, scope: .session)
+        }
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("file.delete"),
+                "arguments": .object(["path": .string("/tmp/test")]),
+                "riskLevel": .string("restricted"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(mockToolService.executeCallCount, 1)
+        XCTAssertNotNil(receivedParams)
+        XCTAssertEqual(receivedParams?.toolName, "file.delete")
+        XCTAssertEqual(receivedParams?.riskLevel, "restricted")
+    }
+
+    // MARK: - Session-Scoped Approvals
+
+    @MainActor
+    func testSessionScopedApprovalCachesDecision() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "OK")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        var approvalCallCount = 0
+        handler.approvalHandler = { _ in
+            approvalCallCount += 1
+            return (approved: true, scope: .session)
+        }
+
+        // First call — approval handler called
+        let event1 = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event1)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(approvalCallCount, 1)
+        XCTAssertEqual(mockToolService.executeCallCount, 1)
+
+        // Second call — should use session-scoped approval, NOT call handler
+        let event2 = BridgeEvent(
+            eventId: "e-2",
+            timestamp: "2024-01-01T00:00:01Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-2"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event2)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(approvalCallCount, 1, "Should NOT call approval handler again — session-scoped")
+        XCTAssertEqual(mockToolService.executeCallCount, 2)
+    }
+
+    @MainActor
+    func testClearSessionApprovalsResetsCache() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "OK")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        var approvalCallCount = 0
+        handler.approvalHandler = { _ in
+            approvalCallCount += 1
+            return (approved: true, scope: .session)
+        }
+
+        // First call — gets session approval
+        let event1 = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event1)
+        try await Task.sleep(for: .milliseconds(200))
+        XCTAssertEqual(approvalCallCount, 1)
+
+        // Clear session approvals
+        handler.clearSessionApprovals(sessionId: "s-1")
+
+        // Third call — should require approval again
+        let event3 = BridgeEvent(
+            eventId: "e-3",
+            timestamp: "2024-01-01T00:00:02Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-3"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event3)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(approvalCallCount, 2, "Should require approval again after clearing session")
+    }
+
+    @MainActor
+    func testNoApprovalHandlerDeniesTool() async throws {
+        let mockToolService = MockBuiltInToolService()
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        // No approval handler set — should auto-deny sensitive tools
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(mockToolService.executeCallCount, 0, "Tool should not execute without approval handler")
+        XCTAssertEqual(handler.auditLog.count, 1)
+        XCTAssertEqual(handler.auditLog.first?.decision, .denied)
+    }
+
+    // MARK: - Audit Log
+
+    @MainActor
+    func testAuditLogRecordsLatency() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "OK")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: "agent-1",
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("calendar.today"),
+                "arguments": .object([:]),
+                "riskLevel": .string("safe"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(handler.auditLog.count, 1)
+        let audit = handler.auditLog.first!
+        XCTAssertEqual(audit.toolCallId, "tc-1")
+        XCTAssertEqual(audit.sessionId, "s-1")
+        XCTAssertEqual(audit.agentId, "agent-1")
+        XCTAssertEqual(audit.toolName, "calendar.today")
+        XCTAssertEqual(audit.riskLevel, "safe")
+        XCTAssertGreaterThanOrEqual(audit.latencyMs, 0)
+        XCTAssertNil(audit.resultCode)
+    }
+
+    @MainActor
+    func testAuditLogRecordsErrorCode() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(
+            toolCallId: "tc-1",
+            content: "Failed",
+            isError: true
+        )
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("calendar.today"),
+                "arguments": .object([:]),
+                "riskLevel": .string("safe"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(handler.auditLog.count, 1)
+        XCTAssertEqual(handler.auditLog.first?.decision, .policyBlocked)
+        XCTAssertEqual(handler.auditLog.first?.resultCode, BridgeErrorCode.toolExecutionFailed.rawValue)
+    }
+
+    // MARK: - Mock Bridge Approval Handler
+
+    @MainActor
+    func testMockBridgeSetApprovalHandler() {
+        let bridge = MockRuntimeBridgeService()
+
+        let approvalHandler: ToolApprovalHandler = { _ in
+            return (approved: true, scope: .once)
+        }
+
+        bridge.setApprovalHandler(approvalHandler)
+
+        XCTAssertEqual(bridge.setApprovalHandlerCallCount, 1)
+        XCTAssertNotNil(bridge.lastApprovalHandler)
+    }
+
+    @MainActor
+    func testConfigureRuntimeBridgeWiresApprovalHandler() {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: AppSettings(),
+            sessionContext: SessionContext(workspaceId: UUID()),
+            runtimeBridge: bridge
+        )
+
+        viewModel.configureRuntimeBridge(bridge)
+
+        // Both tool dispatch and approval handler should be configured
+        XCTAssertEqual(bridge.configureToolDispatchCallCount, 1)
+        XCTAssertEqual(bridge.setApprovalHandlerCallCount, 1)
+        XCTAssertNotNil(bridge.lastApprovalHandler)
+    }
+
+    // MARK: - SDK Approval UI (ViewModel)
+
+    @MainActor
+    func testSDKApprovalRespondApproveOnce() async throws {
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: AppSettings(),
+            sessionContext: SessionContext(workspaceId: UUID())
+        )
+
+        let params = ApprovalRequestParams(
+            approvalId: "ap-1",
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            toolName: "shell.exec",
+            riskLevel: "sensitive",
+            reason: "쉘 명령 실행",
+            argumentsSummary: "command=ls"
+        )
+
+        // Start the approval request in a task
+        let resultTask = Task { @MainActor in
+            await withCheckedContinuation { (cont: CheckedContinuation<(approved: Bool, scope: ApprovalScope), Never>) in
+                viewModel.pendingSDKApproval = SDKToolApproval(
+                    params: params,
+                    continuation: cont
+                )
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Verify the approval is pending
+        XCTAssertNotNil(viewModel.pendingSDKApproval)
+        XCTAssertEqual(viewModel.pendingSDKApproval?.params.toolName, "shell.exec")
+
+        // Respond
+        viewModel.respondToSDKApproval(approved: true, scope: .once)
+
+        let result = await resultTask.value
+        XCTAssertTrue(result.approved)
+        XCTAssertEqual(result.scope, .once)
+        XCTAssertNil(viewModel.pendingSDKApproval)
+    }
+
+    @MainActor
+    func testSDKApprovalRespondApproveSession() async throws {
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: AppSettings(),
+            sessionContext: SessionContext(workspaceId: UUID())
+        )
+
+        let params = ApprovalRequestParams(
+            approvalId: "ap-1",
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            toolName: "shell.exec",
+            riskLevel: "sensitive",
+            reason: "test",
+            argumentsSummary: ""
+        )
+
+        let resultTask = Task { @MainActor in
+            await withCheckedContinuation { (cont: CheckedContinuation<(approved: Bool, scope: ApprovalScope), Never>) in
+                viewModel.pendingSDKApproval = SDKToolApproval(
+                    params: params,
+                    continuation: cont
+                )
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        viewModel.respondToSDKApproval(approved: true, scope: .session)
+
+        let result = await resultTask.value
+        XCTAssertTrue(result.approved)
+        XCTAssertEqual(result.scope, .session)
+    }
+
+    @MainActor
+    func testSDKApprovalRespondDeny() async throws {
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: AppSettings(),
+            sessionContext: SessionContext(workspaceId: UUID())
+        )
+
+        let params = ApprovalRequestParams(
+            approvalId: "ap-1",
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            toolName: "shell.exec",
+            riskLevel: "sensitive",
+            reason: "test",
+            argumentsSummary: ""
+        )
+
+        let resultTask = Task { @MainActor in
+            await withCheckedContinuation { (cont: CheckedContinuation<(approved: Bool, scope: ApprovalScope), Never>) in
+                viewModel.pendingSDKApproval = SDKToolApproval(
+                    params: params,
+                    continuation: cont
+                )
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        viewModel.respondToSDKApproval(approved: false)
+
+        let result = await resultTask.value
+        XCTAssertFalse(result.approved)
+        XCTAssertEqual(result.scope, .once)
+    }
+
+    @MainActor
+    func testSDKApprovalRespondNoPending() {
+        let viewModel = DochiViewModel(
+            llmService: MockLLMService(),
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: MockKeychainService(),
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: AppSettings(),
+            sessionContext: SessionContext(workspaceId: UUID())
+        )
+
+        // Should not crash when no pending approval
+        viewModel.respondToSDKApproval(approved: true)
+        XCTAssertNil(viewModel.pendingSDKApproval)
+    }
+
+    // MARK: - Session Scoped Approval Across Different Sessions
+
+    @MainActor
+    func testSessionScopedApprovalDoesNotLeakAcrossSessions() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "OK")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        var approvalCallCount = 0
+        handler.approvalHandler = { _ in
+            approvalCallCount += 1
+            return (approved: true, scope: .session)
+        }
+
+        // Session s-1 approval
+        let event1 = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event1)
+        try await Task.sleep(for: .milliseconds(200))
+        XCTAssertEqual(approvalCallCount, 1)
+
+        // Same tool in different session s-2 — should require new approval
+        let event2 = BridgeEvent(
+            eventId: "e-2",
+            timestamp: "2024-01-01T00:00:01Z",
+            sessionId: "s-2",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-2"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event2)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(approvalCallCount, 2, "Different session should require separate approval")
+    }
+
+    // MARK: - Once Scope Does Not Cache
+
+    @MainActor
+    func testOnceScopeDoesNotCache() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "OK")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        var approvalCallCount = 0
+        handler.approvalHandler = { _ in
+            approvalCallCount += 1
+            return (approved: true, scope: .once)
+        }
+
+        // First call
+        let event1 = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event1)
+        try await Task.sleep(for: .milliseconds(200))
+        XCTAssertEqual(approvalCallCount, 1)
+
+        // Second call — should require approval again (scope=once)
+        let event2 = BridgeEvent(
+            eventId: "e-2",
+            timestamp: "2024-01-01T00:00:01Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-2"),
+                "toolName": .string("shell.exec"),
+                "arguments": .object([:]),
+                "riskLevel": .string("sensitive"),
+            ])
+        )
+
+        handler.handleDispatch(event: event2)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(approvalCallCount, 2, "Once-scoped approval should not be cached")
+    }
+}

--- a/dochi-agent-runtime/src/handlers/approval.ts
+++ b/dochi-agent-runtime/src/handlers/approval.ts
@@ -1,0 +1,155 @@
+import * as crypto from "crypto";
+import type * as net from "net";
+import type { ApprovalResolveParams, ApprovalResolveAck } from "./types";
+import { TOOL_PERMISSION_DENIED } from "./types";
+
+/** Tracks a pending approval awaiting user decision from the app. */
+interface PendingApproval {
+  approvalId: string;
+  toolCallId: string;
+  sessionId: string;
+  toolName: string;
+  riskLevel: string;
+  requestedAt: number;
+  timeoutMs: number;
+  timer: ReturnType<typeof setTimeout>;
+  resolve: (result: { approved: boolean; scope: string }) => void;
+}
+
+/** Approval timeout: 30 seconds (matches app-side banner timeout). */
+const APPROVAL_TIMEOUT_MS = 30_000;
+
+/** In-memory map of pending approvals keyed by approvalId. */
+const pendingApprovals = new Map<string, PendingApproval>();
+
+/** Session-scoped approvals: toolName → true (approved for rest of session). */
+const sessionApprovals = new Map<string, Set<string>>();
+
+/**
+ * Check if a tool has a session-scoped approval.
+ */
+export function hasSessionApproval(sessionId: string, toolName: string): boolean {
+  return sessionApprovals.get(sessionId)?.has(toolName) ?? false;
+}
+
+/**
+ * Request approval from the app for a sensitive/restricted tool.
+ * Sends an approval.required bridge event and waits for approval.resolve RPC.
+ */
+export function requestApproval(
+  conn: net.Socket,
+  params: {
+    toolCallId: string;
+    sessionId: string;
+    toolName: string;
+    riskLevel: string;
+    reason: string;
+    argumentsSummary: string;
+  },
+): Promise<{ approved: boolean; scope: string }> {
+  // Check session-scoped approval first
+  if (hasSessionApproval(params.sessionId, params.toolName)) {
+    console.error(
+      `[approval] session-scoped approval found for ${params.toolName} in ${params.sessionId}`,
+    );
+    return Promise.resolve({ approved: true, scope: "session" });
+  }
+
+  const approvalId = crypto.randomUUID();
+
+  return new Promise<{ approved: boolean; scope: string }>((resolve) => {
+    const timer = setTimeout(() => {
+      pendingApprovals.delete(approvalId);
+      console.error(`[approval] timeout for ${params.toolName} (${approvalId})`);
+      resolve({ approved: false, scope: "once" });
+    }, APPROVAL_TIMEOUT_MS);
+
+    pendingApprovals.set(approvalId, {
+      approvalId,
+      toolCallId: params.toolCallId,
+      sessionId: params.sessionId,
+      toolName: params.toolName,
+      riskLevel: params.riskLevel,
+      requestedAt: Date.now(),
+      timeoutMs: APPROVAL_TIMEOUT_MS,
+      timer,
+      resolve,
+    });
+
+    // Send approval.required notification to the app
+    const notification = {
+      jsonrpc: "2.0",
+      method: "bridge.event",
+      params: {
+        eventId: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+        sessionId: params.sessionId,
+        eventType: "approval.required",
+        payload: {
+          approvalId,
+          toolCallId: params.toolCallId,
+          toolName: params.toolName,
+          riskLevel: params.riskLevel,
+          reason: params.reason,
+          argumentsSummary: params.argumentsSummary,
+        },
+      },
+    };
+
+    conn.write(JSON.stringify(notification) + "\n");
+    console.error(
+      `[approval] requested approval for ${params.toolName} (${approvalId}), risk=${params.riskLevel}`,
+    );
+  });
+}
+
+/**
+ * Handle `approval.resolve` RPC from the app.
+ */
+export function handleApprovalResolve(params: ApprovalResolveParams): ApprovalResolveAck {
+  const pending = pendingApprovals.get(params.approvalId);
+  if (!pending) {
+    console.error(`[approval] received resolve for unknown approvalId: ${params.approvalId}`);
+    return { received: false, approvalId: params.approvalId };
+  }
+
+  clearTimeout(pending.timer);
+  pendingApprovals.delete(params.approvalId);
+
+  // Record session-scoped approval
+  if (params.approved && params.scope === "session") {
+    if (!sessionApprovals.has(pending.sessionId)) {
+      sessionApprovals.set(pending.sessionId, new Set());
+    }
+    sessionApprovals.get(pending.sessionId)!.add(pending.toolName);
+    console.error(
+      `[approval] session-scoped approval granted for ${pending.toolName} in ${pending.sessionId}`,
+    );
+  }
+
+  pending.resolve({ approved: params.approved, scope: params.scope });
+
+  console.error(
+    `[approval] resolved ${pending.toolName} (${params.approvalId}): approved=${params.approved}, scope=${params.scope}`,
+  );
+
+  return { received: true, approvalId: params.approvalId };
+}
+
+/**
+ * Cancel all pending approvals for a session.
+ */
+export function cancelPendingApprovals(sessionId: string): number {
+  let cancelled = 0;
+  for (const [id, pending] of pendingApprovals) {
+    if (pending.sessionId === sessionId) {
+      clearTimeout(pending.timer);
+      pending.resolve({ approved: false, scope: "once" });
+      pendingApprovals.delete(id);
+      cancelled++;
+    }
+  }
+  // Clear session-scoped approvals
+  sessionApprovals.delete(sessionId);
+  return cancelled;
+}

--- a/dochi-agent-runtime/src/handlers/types.ts
+++ b/dochi-agent-runtime/src/handlers/types.ts
@@ -153,6 +153,32 @@ export interface ToolResultAck {
   toolCallId: string;
 }
 
+// Approval types
+
+export interface ApprovalRequestParams {
+  approvalId: string;
+  toolCallId: string;
+  sessionId: string;
+  toolName: string;
+  riskLevel: "sensitive" | "restricted";
+  reason: string;
+  argumentsSummary: string;
+}
+
+export interface ApprovalResolveParams {
+  approvalId: string;
+  toolCallId: string;
+  sessionId: string;
+  approved: boolean;
+  scope: "once" | "session";
+  note?: string;
+}
+
+export interface ApprovalResolveAck {
+  received: boolean;
+  approvalId: string;
+}
+
 // JSON-RPC error codes (standard)
 export const PARSE_ERROR = -32700;
 export const INVALID_REQUEST = -32600;

--- a/dochi-agent-runtime/src/rpc-server.ts
+++ b/dochi-agent-runtime/src/rpc-server.ts
@@ -26,12 +26,18 @@ import {
   dispatchToolToApp,
   cancelPendingDispatches,
 } from "./handlers/tool";
+import {
+  handleApprovalResolve,
+  requestApproval,
+  cancelPendingApprovals,
+} from "./handlers/approval";
 import type {
   SessionOpenParams,
   SessionRunParams,
   SessionInterruptParams,
   SessionCloseParams,
   ToolResultParams,
+  ApprovalResolveParams,
 } from "./handlers/types";
 
 type Handler = (params?: Record<string, unknown>) => unknown;
@@ -47,6 +53,7 @@ const handlers: Record<string, Handler> = {
   "session.close": (params) => handleSessionClose(params as unknown as SessionCloseParams),
   "session.list": () => handleSessionList(),
   "tool.result": (params) => handleToolResult(params as unknown as ToolResultParams),
+  "approval.resolve": (params) => handleApprovalResolve(params as unknown as ApprovalResolveParams),
 };
 
 function processRequest(request: JsonRpcRequest): JsonRpcResponse {
@@ -197,18 +204,69 @@ async function emitToolDispatchFlow(
     }) + "\n",
   );
 
-  // 2. Dispatch tool to app and wait for result
+  // Determine risk level from tool name (stub: tools containing "sensitive" or "restricted")
+  const riskLevel = toolName.includes("sensitive")
+    ? "sensitive"
+    : toolName.includes("restricted")
+      ? "restricted"
+      : "safe";
+
+  // 2. For sensitive/restricted tools, request approval first
+  if (riskLevel !== "safe") {
+    const approval = await requestApproval(conn, {
+      toolCallId,
+      sessionId,
+      toolName,
+      riskLevel,
+      reason: `Echo mode: executing ${toolName}`,
+      argumentsSummary: argsStr || "(no arguments)",
+    });
+
+    if (!approval.approved) {
+      // Denied: emit tool_result with permission denied and complete
+      if (conn.destroyed) return;
+      conn.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "bridge.event",
+          params: {
+            eventId: crypto.randomUUID(),
+            timestamp: new Date().toISOString(),
+            sessionId,
+            eventType: "session.tool_result",
+            payload: { toolCallId, content: `Tool '${toolName}' denied by user`, success: false },
+          },
+        }) + "\n",
+      );
+      conn.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "bridge.event",
+          params: {
+            eventId: crypto.randomUUID(),
+            timestamp: new Date().toISOString(),
+            sessionId,
+            eventType: "session.completed",
+            payload: { text: `Tool '${toolName}' was denied.` },
+          },
+        }) + "\n",
+      );
+      return;
+    }
+  }
+
+  // 3. Dispatch tool to app and wait for result
   const result = await dispatchToolToApp(conn, {
     toolCallId,
     toolName,
     arguments: args,
     sessionId,
-    riskLevel: "safe",
+    riskLevel: riskLevel as "safe" | "sensitive" | "restricted",
   });
 
   if (conn.destroyed) return;
 
-  // 3. Emit session.tool_result event
+  // 4. Emit session.tool_result event
   conn.write(
     JSON.stringify({
       jsonrpc: "2.0",
@@ -227,7 +285,7 @@ async function emitToolDispatchFlow(
     }) + "\n",
   );
 
-  // 4. Emit session.completed with tool result as final text
+  // 5. Emit session.completed with tool result as final text
   conn.write(
     JSON.stringify({
       jsonrpc: "2.0",
@@ -299,9 +357,12 @@ export function createRpcServer(socketPath: string): net.Server {
         ) {
           const sid = (request.params as { sessionId?: string }).sessionId;
           if (sid) {
-            const cancelled = cancelPendingDispatches(sid);
-            if (cancelled > 0) {
-              console.error(`[rpc-server] cancelled ${cancelled} pending tool dispatches for ${sid}`);
+            const cancelledTools = cancelPendingDispatches(sid);
+            const cancelledApprovals = cancelPendingApprovals(sid);
+            if (cancelledTools + cancelledApprovals > 0) {
+              console.error(
+                `[rpc-server] cancelled ${cancelledTools} tool dispatches, ${cancelledApprovals} approvals for ${sid}`,
+              );
             }
           }
         }


### PR DESCRIPTION
## Summary
- Implement `canUseTool` permission checking in `ToolDispatchHandler` for sensitive/restricted tools dispatched via the runtime bridge
- Add `SDKToolApprovalBannerView` with three-way decision (deny / approve once / approve session) and 30s countdown
- Session-scoped approvals cache decisions per session to avoid repeated prompts for the same tool
- Audit log records all tool execution decisions with latency tracking
- TypeScript `handlers/approval.ts` handles `approval.required` → `approval.resolve` round-trip

## Changes
| File | Description |
|------|-------------|
| `BridgeSchema.swift` | `ApprovalRequestParams`, `ApprovalResolveParams`, `ApprovalScope`, `ToolAuditEvent`, `ToolAuditDecision` |
| `ToolDispatchHandler.swift` | Permission check, session-scoped approvals, `handleApprovalRequest`, audit logging |
| `RuntimeBridgeProtocol.swift` | `setApprovalHandler` method |
| `RuntimeBridgeService.swift` | Forward approval handler to dispatch handler |
| `DochiViewModel.swift` | `requestSDKToolApproval`/`respondToSDKApproval`, safety-net timeout |
| `ToolConfirmation.swift` | `SDKToolApproval` model |
| `ContentView.swift` | `SDKToolApprovalBannerView` (risk badge, 3 buttons), keyboard shortcuts |
| `handlers/approval.ts` | `requestApproval`, `handleApprovalResolve`, `cancelPendingApprovals` |
| `handlers/types.ts` | TS approval types |
| `rpc-server.ts` | `approval.resolve` handler, approval flow in tool dispatch |
| `MockServices.swift` | Mock `setApprovalHandler` |
| `PermissionApprovalTests.swift` | 25 tests |

## Test plan
- [x] 25 new unit tests pass (`PermissionApprovalTests`)
- [x] 22 existing `ToolDispatchTests` still pass
- [x] TypeScript `tsc --noEmit` clean
- [x] Build succeeds
- [ ] Smoke test: SDK path with `tool:sensitive_test` triggers approval banner
- [ ] Smoke test: Approve session → second call skips banner
- [ ] Smoke test: Escape key / timeout → auto-deny

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)