### PR TITLE
feat: add hook pipeline and audit schema for tool lifecycle (#286)

### DIFF
--- a/Dochi/Models/BridgeSchema.swift
+++ b/Dochi/Models/BridgeSchema.swift
@@ -167,8 +167,10 @@ struct ToolAuditEvent: Sendable {
     let sessionId: String
     let agentId: String?
     let toolName: String
+    let argumentsHash: String
     let riskLevel: String
     let decision: ToolAuditDecision
+    let hookName: String?
     let latencyMs: Int
     let resultCode: Int?
     let timestamp: Date
@@ -181,6 +183,7 @@ enum ToolAuditDecision: String, Sendable {
     case denied        // user denied
     case timeout       // approval timed out
     case policyBlocked // policy rejected
+    case hookBlocked   // PreToolUse hook blocked
 }
 
 // MARK: - Event Envelope

--- a/Dochi/Models/HookRuleset.swift
+++ b/Dochi/Models/HookRuleset.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Declarative ruleset for hook policies.
+/// Loaded from a JSON file or uses built-in defaults.
+struct HookRuleset: Codable, Sendable {
+    let version: String
+    let forbiddenPatterns: [ForbiddenPattern]
+    let piiPatterns: [PIIPattern]
+
+    static var `default`: HookRuleset {
+        HookRuleset(
+            version: "1.0",
+            forbiddenPatterns: ForbiddenPattern.defaults,
+            piiPatterns: PIIPattern.defaults
+        )
+    }
+}
+
+/// A pattern that blocks tool execution when matched.
+struct ForbiddenPattern: Codable, Sendable {
+    /// Pattern to match against (case-insensitive contains).
+    let pattern: String
+    /// Which tool names this applies to (empty = all tools).
+    let tools: [String]
+    /// Why this pattern is forbidden.
+    let reason: String
+
+    static var defaults: [ForbiddenPattern] {
+        [
+            ForbiddenPattern(
+                pattern: "rm -rf /",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "루트 디렉토리 삭제 명령 차단"
+            ),
+            ForbiddenPattern(
+                pattern: "rm -rf /*",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "루트 디렉토리 삭제 명령 차단"
+            ),
+            ForbiddenPattern(
+                pattern: "sudo ",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "관리자 권한 명령 차단"
+            ),
+            ForbiddenPattern(
+                pattern: "mkfs",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "파일시스템 포맷 명령 차단"
+            ),
+            ForbiddenPattern(
+                pattern: "> /dev/sda",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "디스크 직접 쓰기 차단"
+            ),
+            ForbiddenPattern(
+                pattern: ":(){ :|:&};:",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "포크 폭탄 차단"
+            ),
+            ForbiddenPattern(
+                pattern: "chmod -R 777 /",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "광범위 권한 변경 차단"
+            ),
+            ForbiddenPattern(
+                pattern: "shutdown",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "시스템 종료 명령 차단"
+            ),
+            ForbiddenPattern(
+                pattern: "reboot",
+                tools: ["shell.execute", "terminal.run"],
+                reason: "시스템 재시작 명령 차단"
+            ),
+        ]
+    }
+}
+
+/// A PII pattern for argument masking.
+struct PIIPattern: Codable, Sendable {
+    /// Human-readable name of the PII type.
+    let name: String
+    /// Regex pattern to detect PII.
+    let regex: String
+    /// Replacement string (e.g., "[EMAIL]", "[PHONE]").
+    let replacement: String
+
+    static var defaults: [PIIPattern] {
+        [
+            PIIPattern(
+                name: "email",
+                regex: "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+                replacement: "[EMAIL]"
+            ),
+            PIIPattern(
+                name: "phone_kr",
+                regex: "01[0-9]-?\\d{3,4}-?\\d{4}",
+                replacement: "[PHONE]"
+            ),
+            PIIPattern(
+                name: "resident_id",
+                regex: "\\d{6}-?[1-4]\\d{6}",
+                replacement: "[주민번호]"
+            ),
+            PIIPattern(
+                name: "credit_card",
+                regex: "\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}",
+                replacement: "[카드번호]"
+            ),
+            PIIPattern(
+                name: "api_key",
+                regex: "sk-[a-zA-Z0-9]{20,}",
+                replacement: "[API_KEY]"
+            ),
+        ]
+    }
+}

--- a/Dochi/Services/Runtime/Hooks/HookPipeline.swift
+++ b/Dochi/Services/Runtime/Hooks/HookPipeline.swift
@@ -1,0 +1,263 @@
+import Foundation
+import os
+import CryptoKit
+
+/// Orchestrates pre-tool, post-tool, and session lifecycle hooks.
+@MainActor
+final class HookPipeline {
+    private(set) var preHooks: [any PreToolUseHook] = []
+    private(set) var postHooks: [any PostToolUseHook] = []
+    private(set) var lifecycleHooks: [any SessionLifecycleHook] = []
+
+    private let ruleset: HookRuleset
+
+    init(ruleset: HookRuleset = .default) {
+        self.ruleset = ruleset
+        registerDefaultHooks()
+    }
+
+    private func registerDefaultHooks() {
+        preHooks.append(ForbiddenPatternHook(patterns: ruleset.forbiddenPatterns))
+        preHooks.append(PIIMaskingHook(patterns: ruleset.piiPatterns))
+        postHooks.append(MetricsRecordingHook())
+        postHooks.append(MemoryCandidateHook())
+        lifecycleHooks.append(AuditFlushHook())
+    }
+
+    // MARK: - Pre-Tool Hooks
+
+    /// Run all pre-tool hooks in order. First blocking decision wins.
+    func runPreHooks(context: ToolHookContext) -> PreHookResult {
+        for hook in preHooks {
+            let decision = hook.evaluate(context: context)
+            switch decision {
+            case .block:
+                Log.runtime.info("PreToolUse hook '\(hook.name)' blocked \(context.toolName)")
+                return PreHookResult(decision: decision, hookName: hook.name)
+            case .mask:
+                Log.runtime.info("PreToolUse hook '\(hook.name)' masked arguments for \(context.toolName)")
+                return PreHookResult(decision: decision, hookName: hook.name)
+            case .allow:
+                continue
+            }
+        }
+        return PreHookResult(decision: .allow, hookName: nil)
+    }
+
+    // MARK: - Post-Tool Hooks
+
+    /// Run all post-tool hooks and aggregate outputs.
+    func runPostHooks(context: ToolHookContext, result: ToolResult, latencyMs: Int) -> [PostHookOutput] {
+        var outputs: [PostHookOutput] = []
+        for hook in postHooks {
+            if let output = hook.process(context: context, result: result, latencyMs: latencyMs) {
+                outputs.append(output)
+            }
+        }
+        return outputs
+    }
+
+    // MARK: - Session Lifecycle Hooks
+
+    /// Run hooks on session close.
+    func runSessionCloseHooks(sessionId: String, auditLog: [ToolAuditEvent]) {
+        for hook in lifecycleHooks {
+            hook.onSessionClose(sessionId: sessionId, auditLog: auditLog)
+        }
+    }
+
+    /// Run hooks on app stop / runtime shutdown.
+    func runStopHooks(auditLog: [ToolAuditEvent]) {
+        for hook in lifecycleHooks {
+            hook.onStop(auditLog: auditLog)
+        }
+    }
+
+    // MARK: - Utility
+
+    /// Compute SHA-256 hash of tool arguments for audit logging.
+    static func argumentsHash(_ arguments: [String: AnyCodableValue]) -> String {
+        guard !arguments.isEmpty else { return "" }
+        let sortedKeys = arguments.keys.sorted()
+        let parts = sortedKeys.map { key in
+            "\(key)=\(arguments[key].map(String.init(describing:)) ?? "nil")"
+        }
+        let joined = parts.joined(separator: "&")
+        let data = Data(joined.utf8)
+        let digest = SHA256.hash(data: data)
+        return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - ForbiddenPatternHook
+
+/// PreToolUse hook that blocks tool execution when arguments match forbidden patterns.
+@MainActor
+final class ForbiddenPatternHook: PreToolUseHook {
+    let name = "ForbiddenPattern"
+    private let patterns: [ForbiddenPattern]
+
+    init(patterns: [ForbiddenPattern]) {
+        self.patterns = patterns
+    }
+
+    func evaluate(context: ToolHookContext) -> PreHookDecision {
+        for pattern in patterns {
+            // Check if this pattern applies to this tool
+            if !pattern.tools.isEmpty && !pattern.tools.contains(context.toolName) {
+                continue
+            }
+
+            // Check arguments for the forbidden pattern
+            for (_, value) in context.arguments {
+                let stringValue: String
+                switch value {
+                case .string(let s): stringValue = s
+                default: continue
+                }
+
+                if stringValue.lowercased().contains(pattern.pattern.lowercased()) {
+                    return .block(reason: pattern.reason)
+                }
+            }
+        }
+        return .allow
+    }
+}
+
+// MARK: - PIIMaskingHook
+
+/// PreToolUse hook that masks PII in tool arguments.
+@MainActor
+final class PIIMaskingHook: PreToolUseHook {
+    let name = "PIIMasking"
+    private let patterns: [PIIPattern]
+    private let compiledPatterns: [(PIIPattern, NSRegularExpression)]
+
+    init(patterns: [PIIPattern]) {
+        self.patterns = patterns
+        self.compiledPatterns = patterns.compactMap { p in
+            guard let regex = try? NSRegularExpression(pattern: p.regex, options: []) else {
+                return nil
+            }
+            return (p, regex)
+        }
+    }
+
+    func evaluate(context: ToolHookContext) -> PreHookDecision {
+        var masked = context.arguments
+        var didMask = false
+
+        for (key, value) in context.arguments {
+            guard case .string(let s) = value else { continue }
+
+            var result = s
+            for (pattern, regex) in compiledPatterns {
+                let range = NSRange(result.startIndex..., in: result)
+                let newResult = regex.stringByReplacingMatches(
+                    in: result,
+                    options: [],
+                    range: range,
+                    withTemplate: pattern.replacement
+                )
+                if newResult != result {
+                    result = newResult
+                    didMask = true
+                }
+            }
+
+            if didMask {
+                masked[key] = .string(result)
+            }
+        }
+
+        return didMask ? .mask(maskedArguments: masked) : .allow
+    }
+}
+
+// MARK: - MetricsRecordingHook
+
+/// PostToolUse hook that logs execution metrics.
+@MainActor
+final class MetricsRecordingHook: PostToolUseHook {
+    let name = "MetricsRecording"
+
+    /// Aggregated tool execution counts per tool name for the session.
+    private(set) var toolCallCounts: [String: Int] = [:]
+    /// Aggregated latencies per tool name.
+    private(set) var toolLatencies: [String: [Int]] = [:]
+
+    func process(context: ToolHookContext, result: ToolResult, latencyMs: Int) -> PostHookOutput? {
+        toolCallCounts[context.toolName, default: 0] += 1
+        toolLatencies[context.toolName, default: []].append(latencyMs)
+
+        Log.runtime.debug(
+            "PostToolUse metrics: \(context.toolName) — \(latencyMs)ms, success=\(!result.isError), count=\(self.toolCallCounts[context.toolName] ?? 0)"
+        )
+        return nil
+    }
+}
+
+// MARK: - MemoryCandidateHook
+
+/// PostToolUse hook that extracts memory-worthy content from tool results.
+@MainActor
+final class MemoryCandidateHook: PostToolUseHook {
+    let name = "MemoryCandidate"
+
+    /// Tools whose results may contain memory-worthy information.
+    private let memoryToolNames: Set<String> = [
+        "calendar.today", "calendar.list", "reminders.list",
+        "contacts.search", "web.search",
+    ]
+
+    func process(context: ToolHookContext, result: ToolResult, latencyMs: Int) -> PostHookOutput? {
+        guard !result.isError,
+              memoryToolNames.contains(context.toolName),
+              result.content.count > 20 else {
+            return nil
+        }
+
+        // Extract first meaningful line as summary
+        let summary = String(result.content.prefix(200))
+        return PostHookOutput(
+            resultSummary: summary,
+            memoryCandidates: ["\(context.toolName): \(summary)"]
+        )
+    }
+}
+
+// MARK: - AuditFlushHook
+
+/// Session lifecycle hook that flushes audit log entries via os.Logger.
+@MainActor
+final class AuditFlushHook: SessionLifecycleHook {
+    let name = "AuditFlush"
+
+    func onSessionClose(sessionId: String, auditLog: [ToolAuditEvent]) {
+        let sessionEvents = auditLog.filter { $0.sessionId == sessionId }
+        guard !sessionEvents.isEmpty else { return }
+
+        let allowed = sessionEvents.filter { $0.decision == .allowed }.count
+        let approved = sessionEvents.filter { $0.decision == .approved }.count
+        let denied = sessionEvents.filter { $0.decision == .denied }.count
+        let blocked = sessionEvents.filter { $0.decision == .policyBlocked }.count
+        let avgLatency = sessionEvents.isEmpty ? 0 : sessionEvents.map(\.latencyMs).reduce(0, +) / sessionEvents.count
+
+        Log.runtime.info(
+            "Audit flush [session=\(sessionId)]: \(sessionEvents.count) events — allowed=\(allowed), approved=\(approved), denied=\(denied), blocked=\(blocked), avgLatency=\(avgLatency)ms"
+        )
+    }
+
+    func onStop(auditLog: [ToolAuditEvent]) {
+        guard !auditLog.isEmpty else { return }
+
+        let sessions = Set(auditLog.map(\.sessionId))
+        let totalTools = auditLog.count
+        let errorCount = auditLog.filter { $0.resultCode != nil }.count
+
+        Log.runtime.info(
+            "Audit flush [stop]: \(totalTools) events across \(sessions.count) sessions, \(errorCount) errors"
+        )
+    }
+}

--- a/Dochi/Services/Runtime/Hooks/HookProtocols.swift
+++ b/Dochi/Services/Runtime/Hooks/HookProtocols.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+// MARK: - Hook Context
+
+/// Context passed to all tool hooks for decision making.
+struct ToolHookContext: Sendable {
+    let toolCallId: String
+    let sessionId: String
+    let agentId: String?
+    let toolName: String
+    let arguments: [String: AnyCodableValue]
+    let riskLevel: String
+}
+
+// MARK: - Hook Decisions
+
+/// Decision from a PreToolUse hook.
+enum PreHookDecision: Sendable {
+    /// Allow the tool to proceed.
+    case allow
+    /// Block the tool with a reason.
+    case block(reason: String)
+    /// Allow but with masked arguments (PII redaction).
+    case mask(maskedArguments: [String: AnyCodableValue])
+}
+
+/// Result from running all pre-hooks.
+struct PreHookResult: Sendable {
+    let decision: PreHookDecision
+    /// Which hook produced the decision (for audit).
+    let hookName: String?
+}
+
+/// Data extracted by PostToolUse hooks.
+struct PostHookOutput: Sendable {
+    /// Short summary of the tool result.
+    let resultSummary: String?
+    /// Memory candidates extracted from the result.
+    let memoryCandidates: [String]
+}
+
+// MARK: - Hook Protocols
+
+/// Evaluates tool arguments before execution.
+/// Runs synchronously — must be fast (no I/O).
+@MainActor
+protocol PreToolUseHook {
+    var name: String { get }
+    func evaluate(context: ToolHookContext) -> PreHookDecision
+}
+
+/// Processes tool results after execution.
+@MainActor
+protocol PostToolUseHook {
+    var name: String { get }
+    func process(context: ToolHookContext, result: ToolResult, latencyMs: Int) -> PostHookOutput?
+}
+
+/// Handles session lifecycle events (close, stop).
+@MainActor
+protocol SessionLifecycleHook {
+    var name: String { get }
+    func onSessionClose(sessionId: String, auditLog: [ToolAuditEvent])
+    func onStop(auditLog: [ToolAuditEvent])
+}

--- a/Dochi/Services/Runtime/RuntimeBridgeService.swift
+++ b/Dochi/Services/Runtime/RuntimeBridgeService.swift
@@ -77,6 +77,9 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
         healthPollTask?.cancel()
         healthPollTask = nil
 
+        // Run stop hooks (audit log flush, resource cleanup)
+        toolDispatchHandler?.runStopHooks()
+
         // Try graceful shutdown via RPC
         if let conn = connection {
             do {

--- a/Dochi/Services/Runtime/ToolDispatchHandler.swift
+++ b/Dochi/Services/Runtime/ToolDispatchHandler.swift
@@ -23,8 +23,12 @@ final class ToolDispatchHandler {
     /// Audit log entries for the current session.
     private(set) var auditLog: [ToolAuditEvent] = []
 
-    init(toolService: any BuiltInToolServiceProtocol) {
+    /// Hook pipeline for pre/post tool hooks and session lifecycle.
+    let hookPipeline: HookPipeline
+
+    init(toolService: any BuiltInToolServiceProtocol, hookPipeline: HookPipeline = HookPipeline()) {
         self.toolService = toolService
+        self.hookPipeline = hookPipeline
     }
 
     /// Attach the UDS connection for sending RPCs.
@@ -32,15 +36,22 @@ final class ToolDispatchHandler {
         self.connection = connection
     }
 
-    /// Clear session-scoped approvals (e.g., on session close).
+    /// Clear session-scoped approvals and run session close hooks.
     func clearSessionApprovals(sessionId: String) {
         sessionApprovals.removeValue(forKey: sessionId)
+        hookPipeline.runSessionCloseHooks(sessionId: sessionId, auditLog: auditLog)
+    }
+
+    /// Run stop hooks and flush audit log.
+    func runStopHooks() {
+        hookPipeline.runStopHooks(auditLog: auditLog)
     }
 
     // MARK: - Tool Dispatch
 
     /// Handle a `tool.dispatch` bridge event.
-    /// Checks permission, requests approval if needed, executes the tool, and sends back `tool.result`.
+    /// Runs PreToolUse hooks, checks permission, executes the tool, runs PostToolUse hooks,
+    /// and sends back `tool.result`.
     func handleDispatch(event: BridgeEvent) {
         guard let payload = event.payload,
               case .object(let dict) = payload,
@@ -51,11 +62,11 @@ final class ToolDispatchHandler {
             return
         }
 
-        let arguments: [String: Any]
+        let codableArguments: [String: AnyCodableValue]
         if case .object(let argsDict) = dict["arguments"] {
-            arguments = argsDict.toNativeDict()
+            codableArguments = argsDict
         } else {
-            arguments = [:]
+            codableArguments = [:]
         }
 
         let riskLevel: String
@@ -66,11 +77,45 @@ final class ToolDispatchHandler {
         }
 
         let timeout = Self.timeout(for: riskLevel)
+        let argsHash = HookPipeline.argumentsHash(codableArguments)
 
         Log.runtime.info("Tool dispatch: \(toolName) (\(toolCallId)), risk=\(riskLevel), timeout=\(timeout)s")
 
         Task { @MainActor in
             let startTime = Date()
+
+            // Build hook context
+            let hookContext = ToolHookContext(
+                toolCallId: toolCallId,
+                sessionId: sessionId,
+                agentId: event.agentId,
+                toolName: toolName,
+                arguments: codableArguments,
+                riskLevel: riskLevel
+            )
+
+            // Run PreToolUse hooks (forbidden pattern check, PII masking)
+            let preResult = hookPipeline.runPreHooks(context: hookContext)
+
+            // Determine effective arguments after hooks
+            let effectiveArguments: [String: Any]
+            switch preResult.decision {
+            case .block(let reason):
+                let blockedResult = ToolResult(
+                    toolCallId: toolCallId,
+                    content: "도구 '\(toolName)' 실행이 정책에 의해 차단되었습니다: \(reason)",
+                    isError: true
+                )
+                await sendToolResult(toolCallId: toolCallId, sessionId: sessionId, result: blockedResult, errorCode: BridgeErrorCode.toolPermissionDenied.rawValue)
+                recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, argumentsHash: argsHash, riskLevel: riskLevel, decision: .hookBlocked, hookName: preResult.hookName, startTime: startTime, resultCode: BridgeErrorCode.toolPermissionDenied.rawValue)
+                return
+
+            case .mask(let maskedArgs):
+                effectiveArguments = maskedArgs.toNativeDict()
+
+            case .allow:
+                effectiveArguments = codableArguments.toNativeDict()
+            }
 
             // Permission check for sensitive/restricted tools
             if riskLevel != "safe" {
@@ -79,7 +124,7 @@ final class ToolDispatchHandler {
                     sessionId: sessionId,
                     toolName: toolName,
                     riskLevel: riskLevel,
-                    arguments: arguments
+                    arguments: effectiveArguments
                 )
 
                 if !approved {
@@ -89,22 +134,28 @@ final class ToolDispatchHandler {
                         isError: true
                     )
                     await sendToolResult(toolCallId: toolCallId, sessionId: sessionId, result: deniedResult, errorCode: BridgeErrorCode.toolPermissionDenied.rawValue)
-                    recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: .denied, startTime: startTime, resultCode: BridgeErrorCode.toolPermissionDenied.rawValue)
+                    recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, argumentsHash: argsHash, riskLevel: riskLevel, decision: .denied, hookName: nil, startTime: startTime, resultCode: BridgeErrorCode.toolPermissionDenied.rawValue)
                     return
                 }
             }
 
+            // Execute tool
             let result = await executeWithTimeout(
                 toolName: toolName,
                 toolCallId: toolCallId,
-                arguments: arguments,
+                arguments: effectiveArguments,
                 timeout: timeout
             )
 
             await sendToolResult(toolCallId: toolCallId, sessionId: sessionId, result: result)
 
+            let latencyMs = Int(Date().timeIntervalSince(startTime) * 1000)
+
+            // Run PostToolUse hooks (metrics, memory candidates)
+            let _ = hookPipeline.runPostHooks(context: hookContext, result: result, latencyMs: latencyMs)
+
             let decision: ToolAuditDecision = riskLevel == "safe" ? .allowed : .approved
-            recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: result.isError ? .policyBlocked : decision, startTime: startTime, resultCode: result.isError ? BridgeErrorCode.toolExecutionFailed.rawValue : nil)
+            recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, argumentsHash: argsHash, riskLevel: riskLevel, decision: result.isError ? .policyBlocked : decision, hookName: nil, startTime: startTime, resultCode: result.isError ? BridgeErrorCode.toolExecutionFailed.rawValue : nil)
 
             Log.runtime.info("Tool result sent: \(toolName) (\(toolCallId)), success=\(!result.isError)")
         }
@@ -147,7 +198,7 @@ final class ToolDispatchHandler {
             guard let handler = approvalHandler else {
                 Log.runtime.warning("No approval handler — auto-denying \(toolName)")
                 await sendApprovalResolve(approvalId: approvalId, toolCallId: toolCallId, sessionId: sessionId, approved: false, scope: .once, note: "No approval handler available")
-                recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: .denied, startTime: startTime, resultCode: nil)
+                recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, argumentsHash: "", riskLevel: riskLevel, decision: .denied, hookName: nil, startTime: startTime, resultCode: nil)
                 return
             }
 
@@ -155,7 +206,7 @@ final class ToolDispatchHandler {
             if let approved = sessionApprovals[sessionId], approved.contains(toolName) {
                 Log.runtime.info("Session-scoped approval for \(toolName)")
                 await sendApprovalResolve(approvalId: approvalId, toolCallId: toolCallId, sessionId: sessionId, approved: true, scope: .session, note: nil)
-                recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: .approved, startTime: startTime, resultCode: nil)
+                recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, argumentsHash: "", riskLevel: riskLevel, decision: .approved, hookName: nil, startTime: startTime, resultCode: nil)
                 return
             }
 
@@ -172,7 +223,7 @@ final class ToolDispatchHandler {
             await sendApprovalResolve(approvalId: approvalId, toolCallId: toolCallId, sessionId: sessionId, approved: approved, scope: scope, note: nil)
 
             let decision: ToolAuditDecision = approved ? .approved : .denied
-            recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, riskLevel: riskLevel, decision: decision, startTime: startTime, resultCode: nil)
+            recordAudit(toolCallId: toolCallId, sessionId: sessionId, agentId: event.agentId, toolName: toolName, argumentsHash: "", riskLevel: riskLevel, decision: decision, hookName: nil, startTime: startTime, resultCode: nil)
 
             Log.runtime.info("Approval resolved: \(toolName) → \(approved ? "approved" : "denied") (scope=\(scope.rawValue))")
         }
@@ -331,8 +382,10 @@ final class ToolDispatchHandler {
         sessionId: String,
         agentId: String?,
         toolName: String,
+        argumentsHash: String,
         riskLevel: String,
         decision: ToolAuditDecision,
+        hookName: String?,
         startTime: Date,
         resultCode: Int?
     ) {
@@ -342,8 +395,10 @@ final class ToolDispatchHandler {
             sessionId: sessionId,
             agentId: agentId,
             toolName: toolName,
+            argumentsHash: argumentsHash,
             riskLevel: riskLevel,
             decision: decision,
+            hookName: hookName,
             latencyMs: latencyMs,
             resultCode: resultCode,
             timestamp: Date()

--- a/DochiTests/HookPipelineTests.swift
+++ b/DochiTests/HookPipelineTests.swift
@@ -1,0 +1,601 @@
+import XCTest
+@testable import Dochi
+
+final class HookPipelineTests: XCTestCase {
+
+    // MARK: - HookRuleset
+
+    func testDefaultRulesetVersion() {
+        let ruleset = HookRuleset.default
+        XCTAssertEqual(ruleset.version, "1.0")
+        XCTAssertFalse(ruleset.forbiddenPatterns.isEmpty)
+        XCTAssertFalse(ruleset.piiPatterns.isEmpty)
+    }
+
+    func testRulesetEncodeDecode() throws {
+        let ruleset = HookRuleset.default
+        let data = try JSONEncoder().encode(ruleset)
+        let decoded = try JSONDecoder().decode(HookRuleset.self, from: data)
+
+        XCTAssertEqual(decoded.version, "1.0")
+        XCTAssertEqual(decoded.forbiddenPatterns.count, ruleset.forbiddenPatterns.count)
+        XCTAssertEqual(decoded.piiPatterns.count, ruleset.piiPatterns.count)
+    }
+
+    func testForbiddenPatternDefaults() {
+        let patterns = ForbiddenPattern.defaults
+        XCTAssertTrue(patterns.contains(where: { $0.pattern == "rm -rf /" }))
+        XCTAssertTrue(patterns.contains(where: { $0.pattern == "sudo " }))
+        XCTAssertTrue(patterns.contains(where: { $0.pattern == "mkfs" }))
+    }
+
+    func testPIIPatternDefaults() {
+        let patterns = PIIPattern.defaults
+        XCTAssertTrue(patterns.contains(where: { $0.name == "email" }))
+        XCTAssertTrue(patterns.contains(where: { $0.name == "phone_kr" }))
+        XCTAssertTrue(patterns.contains(where: { $0.name == "api_key" }))
+    }
+
+    // MARK: - ForbiddenPatternHook
+
+    @MainActor
+    func testForbiddenPatternBlocksDestructiveCommand() {
+        let hook = ForbiddenPatternHook(patterns: ForbiddenPattern.defaults)
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "shell.execute",
+            arguments: ["command": .string("rm -rf /")],
+            riskLevel: "restricted"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .block(let reason) = decision {
+            XCTAssertTrue(reason.contains("삭제"))
+        } else {
+            XCTFail("Expected .block decision")
+        }
+    }
+
+    @MainActor
+    func testForbiddenPatternBlocksSudo() {
+        let hook = ForbiddenPatternHook(patterns: ForbiddenPattern.defaults)
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "shell.execute",
+            arguments: ["command": .string("sudo apt-get install something")],
+            riskLevel: "restricted"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .block = decision {
+            // Expected
+        } else {
+            XCTFail("Expected .block decision for sudo command")
+        }
+    }
+
+    @MainActor
+    func testForbiddenPatternAllowsSafeCommand() {
+        let hook = ForbiddenPatternHook(patterns: ForbiddenPattern.defaults)
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "shell.execute",
+            arguments: ["command": .string("ls -la /tmp")],
+            riskLevel: "safe"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .allow = decision {
+            // Expected
+        } else {
+            XCTFail("Expected .allow decision for safe command")
+        }
+    }
+
+    @MainActor
+    func testForbiddenPatternSkipsNonMatchingTools() {
+        let hook = ForbiddenPatternHook(patterns: ForbiddenPattern.defaults)
+        // The forbidden patterns target shell.execute/terminal.run, not calendar
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "calendar.create",
+            arguments: ["command": .string("sudo create event")],
+            riskLevel: "sensitive"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .allow = decision {
+            // Expected — "sudo" pattern only applies to shell tools
+        } else {
+            XCTFail("Expected .allow decision for non-shell tool")
+        }
+    }
+
+    @MainActor
+    func testForbiddenPatternCaseInsensitive() {
+        let hook = ForbiddenPatternHook(patterns: ForbiddenPattern.defaults)
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "shell.execute",
+            arguments: ["command": .string("SUDO apt-get install foo")],
+            riskLevel: "restricted"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .block = decision {
+            // Expected
+        } else {
+            XCTFail("Expected .block decision for case-insensitive sudo match")
+        }
+    }
+
+    // MARK: - PIIMaskingHook
+
+    @MainActor
+    func testPIIMaskingEmailRedaction() {
+        let hook = PIIMaskingHook(patterns: PIIPattern.defaults)
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "memory.save",
+            arguments: ["content": .string("연락처: test@example.com")],
+            riskLevel: "safe"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .mask(let masked) = decision {
+            if case .string(let value) = masked["content"] {
+                XCTAssertTrue(value.contains("[EMAIL]"))
+                XCTAssertFalse(value.contains("test@example.com"))
+            } else {
+                XCTFail("Expected string value in masked arguments")
+            }
+        } else {
+            XCTFail("Expected .mask decision for email PII")
+        }
+    }
+
+    @MainActor
+    func testPIIMaskingPhoneRedaction() {
+        let hook = PIIMaskingHook(patterns: PIIPattern.defaults)
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "memory.save",
+            arguments: ["content": .string("전화: 010-1234-5678")],
+            riskLevel: "safe"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .mask(let masked) = decision {
+            if case .string(let value) = masked["content"] {
+                XCTAssertTrue(value.contains("[PHONE]"))
+                XCTAssertFalse(value.contains("010-1234-5678"))
+            } else {
+                XCTFail("Expected string value in masked arguments")
+            }
+        } else {
+            XCTFail("Expected .mask decision for phone PII")
+        }
+    }
+
+    @MainActor
+    func testPIIMaskingAPIKeyRedaction() {
+        let hook = PIIMaskingHook(patterns: PIIPattern.defaults)
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "settings.set",
+            arguments: ["value": .string("sk-abcdef1234567890abcdef1234567890")],
+            riskLevel: "sensitive"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .mask(let masked) = decision {
+            if case .string(let value) = masked["value"] {
+                XCTAssertTrue(value.contains("[API_KEY]"))
+            } else {
+                XCTFail("Expected string value in masked arguments")
+            }
+        } else {
+            XCTFail("Expected .mask decision for API key PII")
+        }
+    }
+
+    @MainActor
+    func testPIIMaskingNoPIINoMask() {
+        let hook = PIIMaskingHook(patterns: PIIPattern.defaults)
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "calendar.today",
+            arguments: ["count": .int(5)],
+            riskLevel: "safe"
+        )
+
+        let decision = hook.evaluate(context: context)
+        if case .allow = decision {
+            // Expected — no string arguments contain PII
+        } else {
+            XCTFail("Expected .allow decision when no PII present")
+        }
+    }
+
+    // MARK: - HookPipeline Integration
+
+    @MainActor
+    func testPipelineBlocksBeforeExecution() {
+        let pipeline = HookPipeline()
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "shell.execute",
+            arguments: ["command": .string("rm -rf /")],
+            riskLevel: "restricted"
+        )
+
+        let result = pipeline.runPreHooks(context: context)
+        if case .block = result.decision {
+            XCTAssertEqual(result.hookName, "ForbiddenPattern")
+        } else {
+            XCTFail("Expected pipeline to block destructive command")
+        }
+    }
+
+    @MainActor
+    func testPipelineAllowsSafeCommands() {
+        let pipeline = HookPipeline()
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "calendar.today",
+            arguments: ["count": .int(5)],
+            riskLevel: "safe"
+        )
+
+        let result = pipeline.runPreHooks(context: context)
+        if case .allow = result.decision {
+            XCTAssertNil(result.hookName)
+        } else {
+            XCTFail("Expected pipeline to allow safe command")
+        }
+    }
+
+    @MainActor
+    func testPipelineMasksPII() {
+        let pipeline = HookPipeline()
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "memory.save",
+            arguments: ["content": .string("Email: user@domain.com")],
+            riskLevel: "safe"
+        )
+
+        let result = pipeline.runPreHooks(context: context)
+        if case .mask(let masked) = result.decision {
+            XCTAssertEqual(result.hookName, "PIIMasking")
+            if case .string(let value) = masked["content"] {
+                XCTAssertTrue(value.contains("[EMAIL]"))
+            }
+        } else {
+            XCTFail("Expected pipeline to mask PII")
+        }
+    }
+
+    @MainActor
+    func testPipelineBlockTakesPrecedenceOverMask() {
+        // ForbiddenPattern runs before PIIMasking
+        let pipeline = HookPipeline()
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "shell.execute",
+            arguments: ["command": .string("sudo send user@domain.com")],
+            riskLevel: "restricted"
+        )
+
+        let result = pipeline.runPreHooks(context: context)
+        if case .block = result.decision {
+            XCTAssertEqual(result.hookName, "ForbiddenPattern")
+        } else {
+            XCTFail("Expected block to take precedence over mask")
+        }
+    }
+
+    // MARK: - PostToolUse Hooks
+
+    @MainActor
+    func testMetricsRecordingHook() {
+        let hook = MetricsRecordingHook()
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "calendar.today",
+            arguments: [:],
+            riskLevel: "safe"
+        )
+        let result = ToolResult(toolCallId: "tc-1", content: "2 meetings")
+
+        let _ = hook.process(context: context, result: result, latencyMs: 42)
+
+        XCTAssertEqual(hook.toolCallCounts["calendar.today"], 1)
+        XCTAssertEqual(hook.toolLatencies["calendar.today"]?.first, 42)
+
+        // Record another
+        let _ = hook.process(context: context, result: result, latencyMs: 55)
+        XCTAssertEqual(hook.toolCallCounts["calendar.today"], 2)
+        XCTAssertEqual(hook.toolLatencies["calendar.today"]?.count, 2)
+    }
+
+    @MainActor
+    func testMemoryCandidateHookExtractsFromRelevantTools() {
+        let hook = MemoryCandidateHook()
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "calendar.today",
+            arguments: [:],
+            riskLevel: "safe"
+        )
+        let result = ToolResult(toolCallId: "tc-1", content: "Today: 10am Team meeting, 2pm Design review, 4pm Planning")
+
+        let output = hook.process(context: context, result: result, latencyMs: 30)
+        XCTAssertNotNil(output)
+        XCTAssertFalse(output!.memoryCandidates.isEmpty)
+        XCTAssertNotNil(output!.resultSummary)
+    }
+
+    @MainActor
+    func testMemoryCandidateHookSkipsIrrelevantTools() {
+        let hook = MemoryCandidateHook()
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "shell.execute",
+            arguments: [:],
+            riskLevel: "restricted"
+        )
+        let result = ToolResult(toolCallId: "tc-1", content: "Some shell output that is long enough to consider")
+
+        let output = hook.process(context: context, result: result, latencyMs: 100)
+        XCTAssertNil(output)
+    }
+
+    @MainActor
+    func testMemoryCandidateHookSkipsErrors() {
+        let hook = MemoryCandidateHook()
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "calendar.today",
+            arguments: [:],
+            riskLevel: "safe"
+        )
+        let result = ToolResult(toolCallId: "tc-1", content: "Error fetching calendar", isError: true)
+
+        let output = hook.process(context: context, result: result, latencyMs: 30)
+        XCTAssertNil(output)
+    }
+
+    // MARK: - Session Lifecycle Hooks
+
+    @MainActor
+    func testAuditFlushHookSessionClose() {
+        let hook = AuditFlushHook()
+        let auditLog = [
+            ToolAuditEvent(toolCallId: "tc-1", sessionId: "s-1", agentId: nil, toolName: "calendar.today", argumentsHash: "abc", riskLevel: "safe", decision: .allowed, hookName: nil, latencyMs: 10, resultCode: nil, timestamp: Date()),
+            ToolAuditEvent(toolCallId: "tc-2", sessionId: "s-1", agentId: nil, toolName: "shell.exec", argumentsHash: "def", riskLevel: "sensitive", decision: .approved, hookName: nil, latencyMs: 50, resultCode: nil, timestamp: Date()),
+            ToolAuditEvent(toolCallId: "tc-3", sessionId: "s-2", agentId: nil, toolName: "test", argumentsHash: "", riskLevel: "safe", decision: .allowed, hookName: nil, latencyMs: 5, resultCode: nil, timestamp: Date()),
+        ]
+
+        // Should not crash and should log summary
+        hook.onSessionClose(sessionId: "s-1", auditLog: auditLog)
+    }
+
+    @MainActor
+    func testAuditFlushHookStop() {
+        let hook = AuditFlushHook()
+        let auditLog = [
+            ToolAuditEvent(toolCallId: "tc-1", sessionId: "s-1", agentId: nil, toolName: "test", argumentsHash: "", riskLevel: "safe", decision: .allowed, hookName: nil, latencyMs: 10, resultCode: nil, timestamp: Date()),
+        ]
+
+        hook.onStop(auditLog: auditLog)
+    }
+
+    // MARK: - Arguments Hash
+
+    @MainActor
+    func testArgumentsHashConsistency() {
+        let args1: [String: AnyCodableValue] = ["key": .string("value"), "count": .int(5)]
+        let args2: [String: AnyCodableValue] = ["count": .int(5), "key": .string("value")]
+
+        // Order shouldn't matter — keys are sorted
+        let hash1 = HookPipeline.argumentsHash(args1)
+        let hash2 = HookPipeline.argumentsHash(args2)
+        XCTAssertEqual(hash1, hash2)
+        XCTAssertFalse(hash1.isEmpty)
+    }
+
+    @MainActor
+    func testArgumentsHashEmpty() {
+        let hash = HookPipeline.argumentsHash([:])
+        XCTAssertEqual(hash, "")
+    }
+
+    @MainActor
+    func testArgumentsHashDifferentArgs() {
+        let hash1 = HookPipeline.argumentsHash(["key": .string("value1")])
+        let hash2 = HookPipeline.argumentsHash(["key": .string("value2")])
+        XCTAssertNotEqual(hash1, hash2)
+    }
+
+    // MARK: - Audit Schema Enhancement
+
+    func testToolAuditEventHasArgumentsHash() {
+        let event = ToolAuditEvent(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: "agent-1",
+            toolName: "shell.execute",
+            argumentsHash: "a1b2c3d4",
+            riskLevel: "restricted",
+            decision: .hookBlocked,
+            hookName: "ForbiddenPattern",
+            latencyMs: 5,
+            resultCode: BridgeErrorCode.toolPermissionDenied.rawValue,
+            timestamp: Date()
+        )
+
+        XCTAssertEqual(event.argumentsHash, "a1b2c3d4")
+        XCTAssertEqual(event.hookName, "ForbiddenPattern")
+        XCTAssertEqual(event.decision, .hookBlocked)
+    }
+
+    func testToolAuditDecisionHookBlocked() {
+        XCTAssertEqual(ToolAuditDecision.hookBlocked.rawValue, "hookBlocked")
+    }
+
+    // MARK: - Hook Integration with ToolDispatchHandler
+
+    @MainActor
+    func testToolDispatchHandlerBlocksForbiddenCommand() async throws {
+        let mockToolService = MockBuiltInToolService()
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("shell.execute"),
+                "arguments": .object(["command": .string("rm -rf /")]),
+                "riskLevel": .string("restricted"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        // Tool should NOT have been executed (blocked by hook before approval check)
+        XCTAssertEqual(mockToolService.executeCallCount, 0)
+
+        // Audit log should record hookBlocked
+        XCTAssertEqual(handler.auditLog.count, 1)
+        XCTAssertEqual(handler.auditLog.first?.decision, .hookBlocked)
+        XCTAssertEqual(handler.auditLog.first?.hookName, "ForbiddenPattern")
+        XCTAssertFalse(handler.auditLog.first?.argumentsHash.isEmpty ?? true)
+    }
+
+    @MainActor
+    func testToolDispatchHandlerRecordsArgumentsHash() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "OK")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("calendar.today"),
+                "arguments": .object(["count": .int(5)]),
+                "riskLevel": .string("safe"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(handler.auditLog.count, 1)
+        XCTAssertFalse(handler.auditLog.first?.argumentsHash.isEmpty ?? true)
+    }
+
+    @MainActor
+    func testToolDispatchRunsPostHooks() async throws {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-1", content: "Today: Team meeting at 10am, Design review at 2pm")
+
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        let event = BridgeEvent(
+            eventId: "e-1",
+            timestamp: "2024-01-01T00:00:00Z",
+            sessionId: "s-1",
+            workspaceId: nil,
+            agentId: nil,
+            eventType: .toolDispatch,
+            payload: .object([
+                "toolCallId": .string("tc-1"),
+                "toolName": .string("calendar.today"),
+                "arguments": .object([:]),
+                "riskLevel": .string("safe"),
+            ])
+        )
+
+        handler.handleDispatch(event: event)
+        try await Task.sleep(for: .milliseconds(200))
+
+        // Should have executed and recorded metrics via post hook
+        XCTAssertEqual(mockToolService.executeCallCount, 1)
+
+        // Check metrics hook recorded the call
+        if let metricsHook = handler.hookPipeline.postHooks.first(where: { $0.name == "MetricsRecording" }) as? MetricsRecordingHook {
+            XCTAssertEqual(metricsHook.toolCallCounts["calendar.today"], 1)
+        } else {
+            XCTFail("MetricsRecordingHook not found in pipeline")
+        }
+    }
+
+    @MainActor
+    func testClearSessionApprovalsRunsLifecycleHooks() {
+        let mockToolService = MockBuiltInToolService()
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        // Add some audit events
+        // Use the internal mechanism by dispatching and recording
+        // For this test, just verify that clearSessionApprovals doesn't crash
+        handler.clearSessionApprovals(sessionId: "s-1")
+        // Lifecycle hooks should have been called (AuditFlushHook)
+    }
+
+    @MainActor
+    func testRunStopHooks() {
+        let mockToolService = MockBuiltInToolService()
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+
+        // Should not crash
+        handler.runStopHooks()
+    }
+}

--- a/dochi-agent-runtime/src/handlers/hooks.ts
+++ b/dochi-agent-runtime/src/handlers/hooks.ts
@@ -1,0 +1,122 @@
+import * as crypto from "crypto";
+import type { PreHookResult, ToolAuditEvent } from "./types";
+
+// MARK: - Forbidden Patterns
+
+interface ForbiddenPattern {
+  pattern: string;
+  tools: string[];
+  reason: string;
+}
+
+const DEFAULT_FORBIDDEN_PATTERNS: ForbiddenPattern[] = [
+  { pattern: "rm -rf /", tools: ["shell.execute", "terminal.run"], reason: "Root directory deletion blocked" },
+  { pattern: "rm -rf /*", tools: ["shell.execute", "terminal.run"], reason: "Root directory deletion blocked" },
+  { pattern: "sudo ", tools: ["shell.execute", "terminal.run"], reason: "Privileged command blocked" },
+  { pattern: "mkfs", tools: ["shell.execute", "terminal.run"], reason: "Filesystem format blocked" },
+  { pattern: "> /dev/sda", tools: ["shell.execute", "terminal.run"], reason: "Direct disk write blocked" },
+  { pattern: ":(){ :|:&};:", tools: ["shell.execute", "terminal.run"], reason: "Fork bomb blocked" },
+  { pattern: "chmod -R 777 /", tools: ["shell.execute", "terminal.run"], reason: "Broad permission change blocked" },
+  { pattern: "shutdown", tools: ["shell.execute", "terminal.run"], reason: "System shutdown blocked" },
+  { pattern: "reboot", tools: ["shell.execute", "terminal.run"], reason: "System reboot blocked" },
+];
+
+// MARK: - Audit Log
+
+const auditLog: ToolAuditEvent[] = [];
+
+/**
+ * Record a tool execution event in the audit log.
+ */
+export function recordAudit(event: ToolAuditEvent): void {
+  auditLog.push(event);
+  console.error(
+    `[audit] ${event.toolName} → ${event.decision} (${event.latencyMs}ms)${event.hookName ? ` hook=${event.hookName}` : ""}`,
+  );
+}
+
+/**
+ * Get audit log entries for a session.
+ */
+export function getSessionAuditLog(sessionId: string): ToolAuditEvent[] {
+  return auditLog.filter((e) => e.sessionId === sessionId);
+}
+
+/**
+ * Flush audit log for a session (logs summary then clears entries).
+ */
+export function flushSessionAudit(sessionId: string): void {
+  const events = auditLog.filter((e) => e.sessionId === sessionId);
+  if (events.length === 0) return;
+
+  const allowed = events.filter((e) => e.decision === "allowed").length;
+  const approved = events.filter((e) => e.decision === "approved").length;
+  const denied = events.filter((e) => e.decision === "denied").length;
+  const blocked = events.filter((e) => e.decision === "hookBlocked" || e.decision === "policyBlocked").length;
+  const avgLatency = Math.round(events.reduce((sum, e) => sum + e.latencyMs, 0) / events.length);
+
+  console.error(
+    `[audit] flush session=${sessionId}: ${events.length} events — ` +
+      `allowed=${allowed}, approved=${approved}, denied=${denied}, blocked=${blocked}, avgLatency=${avgLatency}ms`,
+  );
+
+  // Remove flushed entries
+  const remaining = auditLog.filter((e) => e.sessionId !== sessionId);
+  auditLog.length = 0;
+  auditLog.push(...remaining);
+}
+
+/**
+ * Flush all audit log entries (on runtime stop).
+ */
+export function flushAllAudit(): void {
+  if (auditLog.length === 0) return;
+
+  const sessions = new Set(auditLog.map((e) => e.sessionId));
+  const errors = auditLog.filter((e) => e.resultCode != null).length;
+
+  console.error(
+    `[audit] flush all: ${auditLog.length} events across ${sessions.size} sessions, ${errors} errors`,
+  );
+  auditLog.length = 0;
+}
+
+// MARK: - PreToolUse Hook
+
+/**
+ * Run pre-tool-use hooks: forbidden pattern check.
+ */
+export function runPreToolHooks(
+  toolName: string,
+  args: Record<string, unknown>,
+): PreHookResult {
+  // Check forbidden patterns
+  for (const fp of DEFAULT_FORBIDDEN_PATTERNS) {
+    if (fp.tools.length > 0 && !fp.tools.includes(toolName)) continue;
+
+    for (const val of Object.values(args)) {
+      if (typeof val === "string" && val.toLowerCase().includes(fp.pattern.toLowerCase())) {
+        return {
+          decision: "block",
+          hookName: "ForbiddenPattern",
+          reason: fp.reason,
+        };
+      }
+    }
+  }
+
+  return { decision: "allow" };
+}
+
+// MARK: - Arguments Hash
+
+/**
+ * Compute a short SHA-256 hash of tool arguments for audit logging.
+ */
+export function argumentsHash(args: Record<string, unknown>): string {
+  const keys = Object.keys(args).sort();
+  if (keys.length === 0) return "";
+  const parts = keys.map((k) => `${k}=${String(args[k])}`);
+  const joined = parts.join("&");
+  return crypto.createHash("sha256").update(joined).digest("hex").slice(0, 16);
+}

--- a/dochi-agent-runtime/src/handlers/runtime.ts
+++ b/dochi-agent-runtime/src/handlers/runtime.ts
@@ -6,6 +6,7 @@ import {
   type ShutdownResult,
 } from "./types";
 import { getActiveSessionCount } from "./session";
+import { flushAllAudit } from "./hooks";
 
 const startTime = Date.now();
 let lastError: string | null = null;
@@ -33,6 +34,8 @@ export function handleHealth(): HealthResult {
 
 export function handleShutdown(): ShutdownResult {
   console.error("[runtime] shutdown requested");
+  // Flush all audit log entries before exit
+  flushAllAudit();
   // Schedule process exit after response is sent
   setTimeout(() => process.exit(0), 100);
   return { success: true };

--- a/dochi-agent-runtime/src/handlers/types.ts
+++ b/dochi-agent-runtime/src/handlers/types.ts
@@ -195,3 +195,29 @@ export const TOOL_NOT_FOUND = -32010;
 export const TOOL_EXECUTION_FAILED = -32011;
 export const TOOL_TIMEOUT = -32012;
 export const TOOL_PERMISSION_DENIED = -32013;
+export const TOOL_HOOK_BLOCKED = -32014;
+
+// Hook types
+
+export type PreHookDecision = "allow" | "block" | "mask";
+
+export interface PreHookResult {
+  decision: PreHookDecision;
+  hookName?: string;
+  reason?: string;
+  maskedArguments?: Record<string, unknown>;
+}
+
+export interface ToolAuditEvent {
+  toolCallId: string;
+  sessionId: string;
+  agentId?: string;
+  toolName: string;
+  argumentsHash: string;
+  riskLevel: string;
+  decision: "allowed" | "approved" | "denied" | "timeout" | "policyBlocked" | "hookBlocked";
+  hookName?: string;
+  latencyMs: number;
+  resultCode?: number;
+  timestamp: string;
+}

--- a/dochi-agent-runtime/src/rpc-server.ts
+++ b/dochi-agent-runtime/src/rpc-server.ts
@@ -31,6 +31,16 @@ import {
   requestApproval,
   cancelPendingApprovals,
 } from "./handlers/approval";
+import {
+  runPreToolHooks,
+  recordAudit,
+  argumentsHash,
+  flushSessionAudit,
+  flushAllAudit,
+} from "./handlers/hooks";
+import {
+  TOOL_HOOK_BLOCKED,
+} from "./handlers/types";
 import type {
   SessionOpenParams,
   SessionRunParams,
@@ -211,6 +221,54 @@ async function emitToolDispatchFlow(
       ? "restricted"
       : "safe";
 
+  const startTime = Date.now();
+  const argsHash = argumentsHash(args);
+
+  // 1.5. Run PreToolUse hooks (forbidden pattern check)
+  const preResult = runPreToolHooks(toolName, args);
+  if (preResult.decision === "block") {
+    if (conn.destroyed) return;
+    const reason = preResult.reason ?? "Blocked by hook";
+    recordAudit({
+      toolCallId,
+      sessionId,
+      toolName,
+      argumentsHash: argsHash,
+      riskLevel,
+      decision: "hookBlocked",
+      hookName: preResult.hookName,
+      latencyMs: Date.now() - startTime,
+      timestamp: new Date().toISOString(),
+    });
+    conn.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "bridge.event",
+        params: {
+          eventId: crypto.randomUUID(),
+          timestamp: new Date().toISOString(),
+          sessionId,
+          eventType: "session.tool_result",
+          payload: { toolCallId, content: `Tool '${toolName}' blocked: ${reason}`, success: false },
+        },
+      }) + "\n",
+    );
+    conn.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "bridge.event",
+        params: {
+          eventId: crypto.randomUUID(),
+          timestamp: new Date().toISOString(),
+          sessionId,
+          eventType: "session.completed",
+          payload: { text: `Tool '${toolName}' was blocked by policy: ${reason}` },
+        },
+      }) + "\n",
+    );
+    return;
+  }
+
   // 2. For sensitive/restricted tools, request approval first
   if (riskLevel !== "safe") {
     const approval = await requestApproval(conn, {
@@ -285,7 +343,21 @@ async function emitToolDispatchFlow(
     }) + "\n",
   );
 
-  // 5. Emit session.completed with tool result as final text
+  // 5. Record audit event
+  const decision = riskLevel === "safe" ? "allowed" : "approved";
+  recordAudit({
+    toolCallId,
+    sessionId,
+    toolName,
+    argumentsHash: argsHash,
+    riskLevel,
+    decision: result.success ? decision : "policyBlocked",
+    latencyMs: Date.now() - startTime,
+    resultCode: result.errorCode,
+    timestamp: new Date().toISOString(),
+  });
+
+  // 6. Emit session.completed with tool result as final text
   conn.write(
     JSON.stringify({
       jsonrpc: "2.0",
@@ -364,6 +436,8 @@ export function createRpcServer(socketPath: string): net.Server {
                 `[rpc-server] cancelled ${cancelledTools} tool dispatches, ${cancelledApprovals} approvals for ${sid}`,
               );
             }
+            // Flush audit log for this session
+            flushSessionAudit(sid);
           }
         }
       }


### PR DESCRIPTION
## Summary
- Implement PreToolUse/PostToolUse/SessionLifecycle hook pipeline with declarative forbidden pattern and PII masking rulesets
- Enhance audit schema with `argumentsHash` (SHA-256 truncated) and `hookName` fields per spec §9
- 5 built-in hooks: ForbiddenPattern, PIIMasking, MetricsRecording, MemoryCandidate, AuditFlush
- TypeScript mirror: pre-hook evaluation, audit recording, session/stop flush

## Changes
| File | Description |
|------|-------------|
| `Hooks/HookProtocols.swift` | `PreToolUseHook`, `PostToolUseHook`, `SessionLifecycleHook` protocols |
| `Hooks/HookPipeline.swift` | Pipeline orchestrator + 5 built-in hook implementations |
| `HookRuleset.swift` | Codable ruleset model with `ForbiddenPattern`/`PIIPattern` defaults |
| `BridgeSchema.swift` | `argumentsHash`, `hookName` in `ToolAuditEvent`; `hookBlocked` decision |
| `ToolDispatchHandler.swift` | Pre-hooks before exec, post-hooks after, lifecycle hooks on close/stop |
| `RuntimeBridgeService.swift` | Run stop hooks on `stopRuntime()` |
| `handlers/hooks.ts` | TS pre-hooks, audit recording, session/stop flush |
| `handlers/types.ts` | TS `PreHookResult`, `ToolAuditEvent`, `TOOL_HOOK_BLOCKED` |
| `rpc-server.ts` | Integrate pre-hooks in tool dispatch, flush audit on session close |
| `handlers/runtime.ts` | Flush all audit on shutdown |
| `HookPipelineTests.swift` | 33 tests |

## Observability Coverage (수용 기준)
- [x] **Session lifecycle**: AuditFlushHook logs summary on close/stop
- [x] **Tool decision**: audit records allowed/approved/denied/hookBlocked with argumentsHash
- [x] **Approval**: hookName field traces which hook blocked execution
- [x] **Error code**: resultCode propagated through audit events

## Test plan
- [x] 33 new tests pass (HookPipelineTests)
- [x] 25 existing PermissionApprovalTests pass
- [x] 22 existing ToolDispatchTests pass
- [x] TypeScript `tsc --noEmit` clean
- [x] Build succeeds
- [ ] Smoke test: `tool:shell.execute command=rm -rf /` blocked by ForbiddenPatternHook

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)