### PR TITLE
feat: implement memory pipeline with extraction, classification, dedup, and projection (#288)

### DIFF
--- a/Dochi/Models/MemoryAuditEvent.swift
+++ b/Dochi/Models/MemoryAuditEvent.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+// MARK: - MemoryAuditEvent
+
+/// Records an action taken on a memory candidate for audit/traceability.
+struct MemoryAuditEvent: Codable, Sendable {
+    let eventId: String
+    let timestamp: Date
+    let candidateId: String
+    let targetLayer: MemoryTargetLayer
+    let action: MemoryAuditAction
+    let workspaceId: String
+    let agentId: String?
+    let userId: String?
+    let reason: String
+
+    init(
+        eventId: String = UUID().uuidString,
+        timestamp: Date = Date(),
+        candidateId: String,
+        targetLayer: MemoryTargetLayer,
+        action: MemoryAuditAction,
+        workspaceId: String,
+        agentId: String? = nil,
+        userId: String? = nil,
+        reason: String
+    ) {
+        self.eventId = eventId
+        self.timestamp = timestamp
+        self.candidateId = candidateId
+        self.targetLayer = targetLayer
+        self.action = action
+        self.workspaceId = workspaceId
+        self.agentId = agentId
+        self.userId = userId
+        self.reason = reason
+    }
+}
+
+// MARK: - MemoryAuditAction
+
+/// The kind of action recorded in a memory audit event.
+enum MemoryAuditAction: String, Codable, Sendable {
+    case stored
+    case dropped
+    case deduplicated
+    case retryQueued
+    case retryFailed
+    case projectionRefreshed
+    case projectionFailed
+}

--- a/Dochi/Models/MemoryCandidate.swift
+++ b/Dochi/Models/MemoryCandidate.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+// MARK: - MemoryCandidate
+
+/// A candidate memory entry extracted from conversation or tool results,
+/// pending classification and storage.
+struct MemoryCandidate: Codable, Sendable, Identifiable {
+    let id: String
+    let content: String
+    let source: MemoryCandidateSource
+    let timestamp: Date
+    let sessionId: String
+    let workspaceId: String
+    let agentId: String?
+    let userId: String?
+
+    init(
+        id: String = UUID().uuidString,
+        content: String,
+        source: MemoryCandidateSource,
+        timestamp: Date = Date(),
+        sessionId: String,
+        workspaceId: String,
+        agentId: String? = nil,
+        userId: String? = nil
+    ) {
+        self.id = id
+        self.content = content
+        self.source = source
+        self.timestamp = timestamp
+        self.sessionId = sessionId
+        self.workspaceId = workspaceId
+        self.agentId = agentId
+        self.userId = userId
+    }
+}
+
+// MARK: - MemoryCandidateSource
+
+/// Where the memory candidate originated.
+enum MemoryCandidateSource: String, Codable, Sendable {
+    case conversation
+    case toolResult
+    case userExplicit
+}
+
+// MARK: - MemoryTargetLayer
+
+/// Which memory layer a candidate should be stored in.
+enum MemoryTargetLayer: String, Codable, Sendable {
+    case personal
+    case workspace
+    case agent
+    case drop
+}
+
+// MARK: - MemoryClassification
+
+/// Result of classifying a memory candidate into a target layer.
+struct MemoryClassification: Codable, Sendable {
+    let candidateId: String
+    let targetLayer: MemoryTargetLayer
+    let confidence: Double
+    let reason: String
+}
+
+// MARK: - MemoryProjection
+
+/// A compressed representation of memory for a given layer.
+///
+/// Contains a summary of the full memory log and a list of hot facts
+/// (frequently referenced or recently added items).
+struct MemoryProjection: Codable, Sendable {
+    let layer: MemoryTargetLayer
+    let summary: String
+    let hotFacts: [String]
+    let generatedAt: Date
+    let sourceCharCount: Int
+}

--- a/Dochi/Models/MemoryPipelineModels.swift
+++ b/Dochi/Models/MemoryPipelineModels.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// MARK: - DeduplicationResult
+
+/// 중복 검사 결과
+struct DeduplicationResult: Sendable {
+    let classification: MemoryClassification
+    let originalContent: String
+    let isDuplicate: Bool
+    let isConflict: Bool
+    let conflictingContent: String?
+    let similarity: Double
+
+    init(
+        classification: MemoryClassification,
+        originalContent: String,
+        isDuplicate: Bool = false,
+        isConflict: Bool = false,
+        conflictingContent: String? = nil,
+        similarity: Double = 0.0
+    ) {
+        self.classification = classification
+        self.originalContent = originalContent
+        self.isDuplicate = isDuplicate
+        self.isConflict = isConflict
+        self.conflictingContent = conflictingContent
+        self.similarity = similarity
+    }
+}
+
+// MARK: - RetryEntry
+
+/// 재시도 큐 항목
+struct RetryEntry: Codable, Identifiable, Sendable {
+    let id: UUID
+    let content: String
+    let targetLayer: MemoryTargetLayer
+    let workspaceId: String
+    let agentName: String
+    let userId: String?
+    let attemptCount: Int
+    let lastAttemptAt: Date
+    let createdAt: Date
+    let errorMessage: String?
+
+    init(
+        id: UUID = UUID(),
+        content: String,
+        targetLayer: MemoryTargetLayer,
+        workspaceId: String,
+        agentName: String,
+        userId: String?,
+        attemptCount: Int = 0,
+        lastAttemptAt: Date = Date(),
+        createdAt: Date = Date(),
+        errorMessage: String? = nil
+    ) {
+        self.id = id
+        self.content = content
+        self.targetLayer = targetLayer
+        self.workspaceId = workspaceId
+        self.agentName = agentName
+        self.userId = userId
+        self.attemptCount = attemptCount
+        self.lastAttemptAt = lastAttemptAt
+        self.createdAt = createdAt
+        self.errorMessage = errorMessage
+    }
+
+    /// 다음 재시도 시각 (지수 백오프: 2^attempt * 5초, 최대 5분)
+    var nextRetryAt: Date {
+        let delay = min(pow(2.0, Double(attemptCount)) * 5.0, 300.0)
+        return lastAttemptAt.addingTimeInterval(delay)
+    }
+
+    var isExhausted: Bool {
+        attemptCount >= RetryEntry.maxAttempts
+    }
+
+    static let maxAttempts = 5
+}
+
+// MARK: - MemoryPipelineResult
+
+/// 파이프라인 실행 결과
+struct MemoryPipelineResult: Sendable, Equatable {
+    let candidatesExtracted: Int
+    let candidatesClassified: Int
+    let candidatesDropped: Int
+    let duplicatesSkipped: Int
+    let conflictsDetected: Int
+    let candidatesStored: Int
+    let retryQueued: Int
+
+    static let empty = MemoryPipelineResult(
+        candidatesExtracted: 0,
+        candidatesClassified: 0,
+        candidatesDropped: 0,
+        duplicatesSkipped: 0,
+        conflictsDetected: 0,
+        candidatesStored: 0,
+        retryQueued: 0
+    )
+}

--- a/Dochi/Services/Context/LayerClassifier.swift
+++ b/Dochi/Services/Context/LayerClassifier.swift
@@ -1,0 +1,168 @@
+import Foundation
+import os
+
+// MARK: - LayerClassifier
+
+/// 규칙 기반 메모리 후보 분류기.
+/// 후보를 personal / workspace / agent / drop 으로 분류한다.
+@MainActor
+final class LayerClassifier {
+
+    // MARK: - Classification Rules
+
+    private static let personalKeywords: Set<String> = [
+        "선호", "좋아하", "싫어하", "알레르기", "생일", "취미",
+        "나는", "제가", "내가", "저는", "내 ", "제 ",
+        "prefer", "like", "dislike", "birthday", "hobby",
+        "my ", "i am", "i'm", "알려줘", "기억해",
+        "습관", "성격", "이름은", "나이는", "직업은",
+    ]
+
+    private static let workspaceKeywords: Set<String> = [
+        "프로젝트", "팀", "회의", "결정", "일정", "마감",
+        "project", "team", "meeting", "decision", "deadline",
+        "배포", "릴리스", "버전", "스프린트", "칸반",
+        "release", "deploy", "version", "sprint", "kanban",
+        "repository", "repo", "branch", "merge", "코드리뷰",
+        "아키텍처", "설계", "API", "서버", "데이터베이스",
+    ]
+
+    private static let agentKeywords: Set<String> = [
+        "학습", "패턴", "자주", "항상", "보통", "매번",
+        "learn", "pattern", "usually", "always", "often",
+        "이전에", "지난번", "다음에는", "앞으로",
+        "스타일", "방식", "형식", "포맷", "톤",
+        "style", "format", "tone", "approach",
+        "피드백", "개선", "교정", "수정",
+    ]
+
+    private static let dropKeywords: Set<String> = [
+        "안녕", "고마워", "감사", "ㅋㅋ", "ㅎㅎ",
+        "hello", "thanks", "thank you", "bye", "ok",
+        "네", "아니요", "응", "좋아", "알겠",
+    ]
+
+    // MARK: - Classify
+
+    /// 단일 후보를 분류한다.
+    func classify(_ candidate: MemoryCandidate) -> MemoryClassification {
+        let content = candidate.content.lowercased()
+        let words = Set(content.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty })
+
+        // 1. 드롭 체크: 짧은 단순 인사/응답
+        if content.count < 10 && matchCount(words: words, keywords: Self.dropKeywords) > 0 {
+            return MemoryClassification(
+                candidateId: candidate.id,
+                targetLayer: .drop,
+                confidence: 0.9,
+                reason: "짧은 인사/응답으로 드롭"
+            )
+        }
+
+        // 2. 도구 결과에서 온 후보
+        if candidate.source == .toolResult {
+            let wsScore = matchCount(words: words, keywords: Self.workspaceKeywords)
+                + matchCount(content: content, keywords: Self.workspaceKeywords)
+            let agentScore = matchCount(words: words, keywords: Self.agentKeywords)
+                + matchCount(content: content, keywords: Self.agentKeywords)
+            let personalScore = matchCount(words: words, keywords: Self.personalKeywords)
+                + matchCount(content: content, keywords: Self.personalKeywords)
+
+            if personalScore > wsScore && personalScore > agentScore {
+                return MemoryClassification(
+                    candidateId: candidate.id,
+                    targetLayer: .personal,
+                    confidence: normalizedConfidence(personalScore),
+                    reason: "도구 결과, 개인 키워드 매칭 (\(personalScore)건)"
+                )
+            } else if wsScore >= agentScore {
+                return MemoryClassification(
+                    candidateId: candidate.id,
+                    targetLayer: .workspace,
+                    confidence: normalizedConfidence(wsScore),
+                    reason: "도구 결과, 워크스페이스 키워드 매칭 (\(wsScore)건)"
+                )
+            } else {
+                return MemoryClassification(
+                    candidateId: candidate.id,
+                    targetLayer: .agent,
+                    confidence: normalizedConfidence(agentScore),
+                    reason: "도구 결과, 에이전트 키워드 매칭 (\(agentScore)건)"
+                )
+            }
+        }
+
+        // 3. 대화에서 온 후보: 키워드 기반 점수 산정
+        let personalScore = matchCount(words: words, keywords: Self.personalKeywords)
+            + matchCount(content: content, keywords: Self.personalKeywords)
+        let workspaceScore = matchCount(words: words, keywords: Self.workspaceKeywords)
+            + matchCount(content: content, keywords: Self.workspaceKeywords)
+        let agentScore = matchCount(words: words, keywords: Self.agentKeywords)
+            + matchCount(content: content, keywords: Self.agentKeywords)
+        let dropScore = matchCount(words: words, keywords: Self.dropKeywords)
+
+        let maxScore = max(personalScore, workspaceScore, agentScore)
+
+        // 키워드 매칭 없으면 personal 기본
+        if maxScore == 0 {
+            return MemoryClassification(
+                candidateId: candidate.id,
+                targetLayer: .personal,
+                confidence: 0.3,
+                reason: "키워드 매칭 없음, 기본 personal"
+            )
+        }
+
+        // 드롭 점수가 가장 높으면 드롭
+        if dropScore > maxScore {
+            return MemoryClassification(
+                candidateId: candidate.id,
+                targetLayer: .drop,
+                confidence: normalizedConfidence(dropScore),
+                reason: "드롭 키워드 우세 (\(dropScore)건)"
+            )
+        }
+
+        if personalScore >= workspaceScore && personalScore >= agentScore {
+            return MemoryClassification(
+                candidateId: candidate.id,
+                targetLayer: .personal,
+                confidence: normalizedConfidence(personalScore),
+                reason: "개인 키워드 매칭 (\(personalScore)건)"
+            )
+        } else if workspaceScore >= agentScore {
+            return MemoryClassification(
+                candidateId: candidate.id,
+                targetLayer: .workspace,
+                confidence: normalizedConfidence(workspaceScore),
+                reason: "워크스페이스 키워드 매칭 (\(workspaceScore)건)"
+            )
+        } else {
+            return MemoryClassification(
+                candidateId: candidate.id,
+                targetLayer: .agent,
+                confidence: normalizedConfidence(agentScore),
+                reason: "에이전트 키워드 매칭 (\(agentScore)건)"
+            )
+        }
+    }
+
+    /// 여러 후보를 일괄 분류한다.
+    func classifyAll(_ candidates: [MemoryCandidate]) -> [MemoryClassification] {
+        candidates.map { classify($0) }
+    }
+
+    // MARK: - Helpers
+
+    private func matchCount(words: Set<String>, keywords: Set<String>) -> Int {
+        words.intersection(keywords).count
+    }
+
+    private func matchCount(content: String, keywords: Set<String>) -> Int {
+        keywords.filter { content.contains($0) }.count
+    }
+
+    private func normalizedConfidence(_ score: Int) -> Double {
+        min(0.5 + Double(score) * 0.1, 1.0)
+    }
+}

--- a/Dochi/Services/Context/MemoryCandidateExtractor.swift
+++ b/Dochi/Services/Context/MemoryCandidateExtractor.swift
@@ -1,0 +1,188 @@
+import Foundation
+import os
+
+// MARK: - MemoryCandidateExtractor
+
+/// 대화 종료 시 및 PostToolUse 이벤트에서 메모리 후보를 추출한다.
+@MainActor
+final class MemoryCandidateExtractor {
+
+    static let minMessageCount = 3
+    static let maxCandidates = 15
+    static let minToolResultLength = 20
+
+    // MARK: - Extract from Conversation
+
+    /// 대화에서 메모리 후보를 추출한다.
+    func extractFromConversation(
+        messages: [Message],
+        sessionId: String,
+        workspaceId: String,
+        agentId: String?,
+        userId: String?
+    ) -> [MemoryCandidate] {
+        let relevant = messages.filter { $0.role == .user || $0.role == .assistant }
+        guard relevant.count >= Self.minMessageCount else {
+            Log.storage.debug("메모리 추출 생략: 메시지 부족 (\(relevant.count)/\(Self.minMessageCount))")
+            return []
+        }
+
+        var candidates: [MemoryCandidate] = []
+
+        for message in relevant where message.role == .user {
+            let lines = extractFactLines(message.content)
+            for line in lines {
+                candidates.append(MemoryCandidate(
+                    content: line,
+                    source: .conversation,
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    agentId: agentId,
+                    userId: userId
+                ))
+            }
+        }
+
+        for message in relevant where message.role == .assistant {
+            let lines = extractUserFactsFromAssistant(message.content)
+            for line in lines {
+                candidates.append(MemoryCandidate(
+                    content: line,
+                    source: .conversation,
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    agentId: agentId,
+                    userId: userId
+                ))
+            }
+        }
+
+        let result = Array(candidates.prefix(Self.maxCandidates))
+        Log.storage.debug("대화에서 메모리 후보 \(result.count)건 추출")
+        return result
+    }
+
+    // MARK: - Extract from Tool Result
+
+    /// PostToolUse 훅에서 도구 결과를 메모리 후보로 변환한다.
+    func extractFromToolResult(
+        toolName: String,
+        result: String,
+        sessionId: String,
+        workspaceId: String,
+        agentId: String?,
+        userId: String?
+    ) -> [MemoryCandidate] {
+        guard result.count >= Self.minToolResultLength else { return [] }
+
+        let memoryTools: Set<String> = [
+            "save_memory", "update_memory", "delete_memory",
+        ]
+
+        if memoryTools.contains(toolName) {
+            return [MemoryCandidate(
+                content: result,
+                source: .toolResult,
+                sessionId: sessionId,
+                workspaceId: workspaceId,
+                agentId: agentId,
+                userId: userId
+            )]
+        }
+
+        let lines = result.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && $0.count >= 10 }
+            .prefix(5)
+
+        return lines.map { line in
+            MemoryCandidate(
+                content: "\(toolName): \(line)",
+                source: .toolResult,
+                sessionId: sessionId,
+                workspaceId: workspaceId,
+                agentId: agentId,
+                userId: userId
+            )
+        }
+    }
+
+    // MARK: - Private Extraction
+
+    /// 텍스트에서 사실/선호/결정 라인을 추출 (규칙 기반)
+    func extractFactLines(_ text: String) -> [String] {
+        let lines = text.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        var facts: [String] = []
+        for line in lines {
+            if containsPersonalPattern(line) || containsWorkspacePattern(line) {
+                facts.append(line)
+            }
+        }
+
+        return Array(facts.prefix(Self.maxCandidates))
+    }
+
+    /// 어시스턴트 메시지에서 사용자 관련 사실 추출
+    private func extractUserFactsFromAssistant(_ text: String) -> [String] {
+        let lines = text.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        var facts: [String] = []
+        for line in lines {
+            if containsUserReferencePattern(line) {
+                let cleaned = cleanAssistantFact(line)
+                if !cleaned.isEmpty {
+                    facts.append(cleaned)
+                }
+            }
+        }
+
+        return Array(facts.prefix(5))
+    }
+
+    // MARK: - Pattern Detection
+
+    private func containsPersonalPattern(_ text: String) -> Bool {
+        let patterns = [
+            "나는 ", "내가 ", "제가 ", "저는 ", "내 ", "제 ",
+            "좋아하", "싫어하", "선호하", "알레르기",
+            "생일", "취미", "직업", "이름은",
+        ]
+        let lower = text.lowercased()
+        return patterns.contains { lower.contains($0) }
+    }
+
+    private func containsWorkspacePattern(_ text: String) -> Bool {
+        let patterns = [
+            "프로젝트", "팀 ", "회의", "배포", "릴리스",
+            "마감", "일정", "결정했", "합의",
+            "아키텍처", "API ", "서버", "데이터베이스",
+        ]
+        let lower = text.lowercased()
+        return patterns.contains { lower.contains($0) }
+    }
+
+    private func containsUserReferencePattern(_ text: String) -> Bool {
+        let patterns = [
+            "사용자는", "님은", "님이", "사용자가",
+            "기억하겠습니다", "말씀하신", "선호하시는",
+        ]
+        return patterns.contains { text.contains($0) }
+    }
+
+    private func cleanAssistantFact(_ line: String) -> String {
+        var cleaned = line
+        let removePatterns = [
+            "알겠습니다. ", "네, ", "기억하겠습니다. ",
+            "말씀하신 대로 ", "확인했습니다. ",
+        ]
+        for pattern in removePatterns {
+            cleaned = cleaned.replacingOccurrences(of: pattern, with: "")
+        }
+        return cleaned.trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Dochi/Services/Context/MemoryDeduplicator.swift
+++ b/Dochi/Services/Context/MemoryDeduplicator.swift
@@ -1,0 +1,115 @@
+import Foundation
+import os
+
+// MARK: - MemoryDeduplicator
+
+/// 분류된 메모리 후보와 기존 메모리를 비교하여 중복/충돌을 검사한다.
+@MainActor
+final class MemoryDeduplicator {
+
+    static let duplicateThreshold: Double = 0.7
+    static let conflictLowerBound: Double = 0.3
+    static let conflictUpperBound: Double = 0.7
+    static let conflictMinSharedKeywords = 2
+
+    // MARK: - Check
+
+    /// 분류된 후보 목록에 대해 기존 메모리와 중복/충돌 검사를 수행한다.
+    func check(
+        candidates: [MemoryCandidate],
+        classifications: [MemoryClassification],
+        existingMemory: [MemoryTargetLayer: String]
+    ) -> [DeduplicationResult] {
+        zip(candidates, classifications).map { candidate, classification in
+            checkSingle(
+                candidate: candidate,
+                classification: classification,
+                existingMemory: existingMemory
+            )
+        }
+    }
+
+    /// 단일 후보에 대해 중복/충돌 검사
+    func checkSingle(
+        candidate: MemoryCandidate,
+        classification: MemoryClassification,
+        existingMemory: [MemoryTargetLayer: String]
+    ) -> DeduplicationResult {
+        guard classification.targetLayer != .drop else {
+            return DeduplicationResult(
+                classification: classification,
+                originalContent: candidate.content
+            )
+        }
+
+        let memory = existingMemory[classification.targetLayer] ?? ""
+        let lines = memory.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+
+        let content = candidate.content
+
+        for line in lines {
+            let normalizedLine = line
+                .replacingOccurrences(of: "- ", with: "")
+                .lowercased()
+                .trimmingCharacters(in: .whitespaces)
+            let normalizedContent = content.lowercased().trimmingCharacters(in: .whitespaces)
+
+            // 완전 일치
+            if normalizedContent == normalizedLine {
+                return DeduplicationResult(
+                    classification: classification,
+                    originalContent: candidate.content,
+                    isDuplicate: true,
+                    similarity: 1.0
+                )
+            }
+
+            // Jaccard 유사도
+            let similarity = jaccardSimilarity(normalizedContent, normalizedLine)
+            if similarity > Self.duplicateThreshold {
+                return DeduplicationResult(
+                    classification: classification,
+                    originalContent: candidate.content,
+                    isDuplicate: true,
+                    similarity: similarity
+                )
+            }
+
+            // 충돌 검사
+            if similarity > Self.conflictLowerBound && similarity <= Self.conflictUpperBound {
+                let contentWords = Set(normalizedContent.components(separatedBy: .whitespaces))
+                let lineWords = Set(normalizedLine.components(separatedBy: .whitespaces))
+                let shared = contentWords.intersection(lineWords)
+
+                if shared.count >= Self.conflictMinSharedKeywords
+                    && contentWords.symmetricDifference(lineWords).count >= 2 {
+                    return DeduplicationResult(
+                        classification: classification,
+                        originalContent: candidate.content,
+                        isConflict: true,
+                        conflictingContent: line,
+                        similarity: similarity
+                    )
+                }
+            }
+        }
+
+        return DeduplicationResult(
+            classification: classification,
+            originalContent: candidate.content
+        )
+    }
+
+    // MARK: - Jaccard Similarity
+
+    func jaccardSimilarity(_ a: String, _ b: String) -> Double {
+        let wordsA = Set(a.components(separatedBy: .whitespaces).filter { !$0.isEmpty })
+        let wordsB = Set(b.components(separatedBy: .whitespaces).filter { !$0.isEmpty })
+        guard !wordsA.isEmpty || !wordsB.isEmpty else { return 0.0 }
+        let intersection = wordsA.intersection(wordsB).count
+        let union = wordsA.union(wordsB).count
+        return Double(intersection) / Double(union)
+    }
+}

--- a/Dochi/Services/Context/MemoryPipeline.swift
+++ b/Dochi/Services/Context/MemoryPipeline.swift
@@ -1,0 +1,410 @@
+import Foundation
+import os
+
+// MARK: - MemoryPipelineService
+
+/// 메모리 파이프라인: 추출 → 분류 → 중복검사 → 저장 → 프로젝션 생성
+/// MemoryPipelineProtocol 구현체.
+@MainActor
+@Observable
+final class MemoryPipelineService: MemoryPipelineProtocol {
+
+    // MARK: - Components
+
+    let extractor: MemoryCandidateExtractor
+    let classifier: LayerClassifier
+    let deduplicator: MemoryDeduplicator
+    let projectionGenerator: ProjectionGenerator
+    let retryQueue: MemoryRetryQueue
+    private let contextService: ContextServiceProtocol
+
+    // MARK: - State
+
+    private(set) var currentProjections: [MemoryTargetLayer: MemoryProjection] = [:]
+    private(set) var auditLog: [MemoryAuditEvent] = []
+    private static let maxAuditEntries = 200
+
+    // MARK: - Init
+
+    init(contextService: ContextServiceProtocol) {
+        self.contextService = contextService
+        self.extractor = MemoryCandidateExtractor()
+        self.classifier = LayerClassifier()
+        self.deduplicator = MemoryDeduplicator()
+        self.projectionGenerator = ProjectionGenerator(contextService: contextService)
+        self.retryQueue = MemoryRetryQueue(contextService: contextService)
+    }
+
+    // MARK: - MemoryPipelineProtocol
+
+    func submitCandidate(_ candidate: MemoryCandidate) async {
+        let classification = classifyCandidate(candidate)
+
+        if classification.targetLayer == .drop {
+            recordAudit(candidateId: candidate.id, targetLayer: .drop,
+                       action: .dropped, workspaceId: candidate.workspaceId,
+                       agentId: candidate.agentId, userId: candidate.userId,
+                       reason: classification.reason)
+            return
+        }
+
+        do {
+            try await processAndStore(candidate)
+        } catch {
+            Log.storage.warning("후보 처리 실패, 재시도 큐 추가: \(error.localizedDescription)")
+        }
+    }
+
+    func classifyCandidate(_ candidate: MemoryCandidate) -> MemoryClassification {
+        classifier.classify(candidate)
+    }
+
+    func processAndStore(_ candidate: MemoryCandidate) async throws {
+        let classification = classifyCandidate(candidate)
+
+        guard classification.targetLayer != .drop else {
+            recordAudit(candidateId: candidate.id, targetLayer: .drop,
+                       action: .dropped, workspaceId: candidate.workspaceId,
+                       agentId: candidate.agentId, userId: candidate.userId,
+                       reason: classification.reason)
+            return
+        }
+
+        // 중복 검사
+        let existing = loadCurrentMemoryForLayer(
+            targetLayer: classification.targetLayer,
+            workspaceId: candidate.workspaceId,
+            agentId: candidate.agentId,
+            userId: candidate.userId
+        )
+        let dedupResult = deduplicator.checkSingle(
+            candidate: candidate,
+            classification: classification,
+            existingMemory: [classification.targetLayer: existing]
+        )
+
+        if dedupResult.isDuplicate {
+            recordAudit(candidateId: candidate.id, targetLayer: classification.targetLayer,
+                       action: .deduplicated, workspaceId: candidate.workspaceId,
+                       agentId: candidate.agentId, userId: candidate.userId,
+                       reason: "유사도 \(String(format: "%.2f", dedupResult.similarity))")
+            return
+        }
+
+        // 저장
+        let success = storeContent(
+            content: candidate.content,
+            targetLayer: classification.targetLayer,
+            workspaceId: candidate.workspaceId,
+            agentName: candidate.agentId ?? "",
+            userId: candidate.userId
+        )
+
+        if success {
+            recordAudit(candidateId: candidate.id, targetLayer: classification.targetLayer,
+                       action: .stored, workspaceId: candidate.workspaceId,
+                       agentId: candidate.agentId, userId: candidate.userId,
+                       reason: classification.reason)
+        } else {
+            retryQueue.enqueue(
+                content: candidate.content,
+                targetLayer: classification.targetLayer,
+                workspaceId: candidate.workspaceId,
+                agentName: candidate.agentId ?? "",
+                userId: candidate.userId,
+                error: "저장 실패"
+            )
+            recordAudit(candidateId: candidate.id, targetLayer: classification.targetLayer,
+                       action: .retryQueued, workspaceId: candidate.workspaceId,
+                       agentId: candidate.agentId, userId: candidate.userId,
+                       reason: "저장 실패, 재시도 큐 추가")
+        }
+    }
+
+    func pendingCount() -> Int {
+        retryQueue.pendingCount
+    }
+
+    // MARK: - Batch Processing
+
+    /// 대화 종료 시 메모리 파이프라인을 일괄 실행한다.
+    func processConversationEnd(
+        messages: [Message],
+        sessionId: String,
+        sessionContext: SessionContext,
+        settings: AppSettings
+    ) async -> MemoryPipelineResult {
+        Log.storage.info("메모리 파이프라인 시작: 대화 종료")
+
+        let candidates = extractor.extractFromConversation(
+            messages: messages,
+            sessionId: sessionId,
+            workspaceId: sessionContext.workspaceId.uuidString,
+            agentId: settings.activeAgentName,
+            userId: sessionContext.currentUserId
+        )
+
+        guard !candidates.isEmpty else {
+            Log.storage.debug("추출된 후보 없음, 파이프라인 종료")
+            return .empty
+        }
+
+        return await processCandidatesBatch(
+            candidates: candidates,
+            sessionContext: sessionContext,
+            settings: settings
+        )
+    }
+
+    /// PostToolUse 훅에서 도구 결과를 일괄 처리한다.
+    func processToolResult(
+        toolName: String,
+        result: String,
+        sessionId: String,
+        sessionContext: SessionContext,
+        settings: AppSettings
+    ) async -> MemoryPipelineResult {
+        Log.storage.info("메모리 파이프라인 시작: 도구 결과 (\(toolName))")
+
+        let candidates = extractor.extractFromToolResult(
+            toolName: toolName,
+            result: result,
+            sessionId: sessionId,
+            workspaceId: sessionContext.workspaceId.uuidString,
+            agentId: settings.activeAgentName,
+            userId: sessionContext.currentUserId
+        )
+
+        guard !candidates.isEmpty else { return .empty }
+
+        return await processCandidatesBatch(
+            candidates: candidates,
+            sessionContext: sessionContext,
+            settings: settings
+        )
+    }
+
+    // MARK: - Projection
+
+    func regenerateProjections(
+        workspaceId: UUID,
+        agentName: String,
+        userId: String?
+    ) -> [MemoryTargetLayer: MemoryProjection] {
+        let projections = projectionGenerator.generateAll(
+            workspaceId: workspaceId,
+            agentName: agentName,
+            userId: userId,
+            existingProjections: currentProjections
+        )
+        currentProjections = projections
+        return projections
+    }
+
+    // MARK: - Private Batch Pipeline
+
+    private func processCandidatesBatch(
+        candidates: [MemoryCandidate],
+        sessionContext: SessionContext,
+        settings: AppSettings
+    ) async -> MemoryPipelineResult {
+        // 분류
+        let classifications = classifier.classifyAll(candidates)
+        let dropped = classifications.filter { $0.targetLayer == .drop }
+        let active = zip(candidates, classifications).filter { $0.1.targetLayer != .drop }
+
+        // 현재 메모리 로드
+        let existingMemory = loadCurrentMemoryAll(sessionContext: sessionContext, settings: settings)
+
+        // 중복/충돌 검사
+        let activeCandidates = active.map(\.0)
+        let activeClassifications = active.map(\.1)
+        let deduped = deduplicator.check(
+            candidates: activeCandidates,
+            classifications: activeClassifications,
+            existingMemory: existingMemory
+        )
+        let duplicates = deduped.filter(\.isDuplicate)
+        let conflicts = deduped.filter(\.isConflict)
+        let toStore = deduped.filter { !$0.isDuplicate && !$0.isConflict }
+
+        // 저장
+        var stored = 0
+        var retryQueued = 0
+
+        for result in toStore {
+            let success = storeContent(
+                content: result.originalContent,
+                targetLayer: result.classification.targetLayer,
+                workspaceId: sessionContext.workspaceId.uuidString,
+                agentName: settings.activeAgentName,
+                userId: sessionContext.currentUserId
+            )
+            if success {
+                stored += 1
+                recordAudit(candidateId: result.classification.candidateId,
+                           targetLayer: result.classification.targetLayer,
+                           action: .stored, workspaceId: sessionContext.workspaceId.uuidString,
+                           agentId: settings.activeAgentName,
+                           userId: sessionContext.currentUserId,
+                           reason: result.classification.reason)
+            } else {
+                retryQueue.enqueue(
+                    content: result.originalContent,
+                    targetLayer: result.classification.targetLayer,
+                    workspaceId: sessionContext.workspaceId.uuidString,
+                    agentName: settings.activeAgentName,
+                    userId: sessionContext.currentUserId,
+                    error: "저장 실패"
+                )
+                retryQueued += 1
+            }
+        }
+
+        // 프로젝션 재생성
+        if stored > 0 {
+            _ = regenerateProjections(
+                workspaceId: sessionContext.workspaceId,
+                agentName: settings.activeAgentName,
+                userId: sessionContext.currentUserId
+            )
+        }
+
+        // 감사 로그 (드롭/중복)
+        for result in dropped {
+            recordAudit(candidateId: result.candidateId, targetLayer: .drop,
+                       action: .dropped, workspaceId: sessionContext.workspaceId.uuidString,
+                       agentId: settings.activeAgentName, userId: sessionContext.currentUserId,
+                       reason: result.reason)
+        }
+        for result in duplicates {
+            recordAudit(candidateId: result.classification.candidateId,
+                       targetLayer: result.classification.targetLayer,
+                       action: .deduplicated, workspaceId: sessionContext.workspaceId.uuidString,
+                       agentId: settings.activeAgentName, userId: sessionContext.currentUserId,
+                       reason: "유사도 \(String(format: "%.2f", result.similarity))")
+        }
+
+        Log.storage.info("메모리 파이프라인 완료: \(stored)건 저장, \(duplicates.count)건 중복")
+
+        return MemoryPipelineResult(
+            candidatesExtracted: candidates.count,
+            candidatesClassified: classifications.count,
+            candidatesDropped: dropped.count,
+            duplicatesSkipped: duplicates.count,
+            conflictsDetected: conflicts.count,
+            candidatesStored: stored,
+            retryQueued: retryQueued
+        )
+    }
+
+    // MARK: - Memory Operations
+
+    private func loadCurrentMemoryAll(
+        sessionContext: SessionContext,
+        settings: AppSettings
+    ) -> [MemoryTargetLayer: String] {
+        var result: [MemoryTargetLayer: String] = [:]
+        result[.workspace] = contextService.loadWorkspaceMemory(workspaceId: sessionContext.workspaceId) ?? ""
+        result[.agent] = contextService.loadAgentMemory(
+            workspaceId: sessionContext.workspaceId,
+            agentName: settings.activeAgentName
+        ) ?? ""
+        if let userId = sessionContext.currentUserId {
+            result[.personal] = contextService.loadUserMemory(userId: userId) ?? ""
+        }
+        return result
+    }
+
+    private func loadCurrentMemoryForLayer(
+        targetLayer: MemoryTargetLayer,
+        workspaceId: String,
+        agentId: String?,
+        userId: String?
+    ) -> String {
+        guard let wsUUID = UUID(uuidString: workspaceId) else { return "" }
+        switch targetLayer {
+        case .personal:
+            guard let userId, !userId.isEmpty else { return "" }
+            return contextService.loadUserMemory(userId: userId) ?? ""
+        case .workspace:
+            return contextService.loadWorkspaceMemory(workspaceId: wsUUID) ?? ""
+        case .agent:
+            return contextService.loadAgentMemory(workspaceId: wsUUID, agentName: agentId ?? "") ?? ""
+        case .drop:
+            return ""
+        }
+    }
+
+    private func storeContent(
+        content: String,
+        targetLayer: MemoryTargetLayer,
+        workspaceId: String,
+        agentName: String,
+        userId: String?
+    ) -> Bool {
+        guard let wsUUID = UUID(uuidString: workspaceId) else { return false }
+        let line = "- \(content)"
+
+        switch targetLayer {
+        case .personal:
+            guard let userId, !userId.isEmpty else {
+                Log.storage.warning("개인 메모리 저장 실패: userId 없음")
+                return false
+            }
+            contextService.appendUserMemory(userId: userId, content: line)
+        case .workspace:
+            contextService.appendWorkspaceMemory(workspaceId: wsUUID, content: line)
+        case .agent:
+            contextService.appendAgentMemory(workspaceId: wsUUID, agentName: agentName, content: line)
+        case .drop:
+            break
+        }
+        return true
+    }
+
+    // MARK: - Audit
+
+    private func recordAudit(
+        candidateId: String,
+        targetLayer: MemoryTargetLayer,
+        action: MemoryAuditAction,
+        workspaceId: String,
+        agentId: String?,
+        userId: String?,
+        reason: String
+    ) {
+        let event = MemoryAuditEvent(
+            candidateId: candidateId,
+            targetLayer: targetLayer,
+            action: action,
+            workspaceId: workspaceId,
+            agentId: agentId,
+            userId: userId,
+            reason: reason
+        )
+        auditLog.append(event)
+
+        if auditLog.count > Self.maxAuditEntries {
+            auditLog.removeFirst(auditLog.count - Self.maxAuditEntries)
+        }
+    }
+}
+
+// MARK: - MemoryPipelineError
+
+enum MemoryPipelineError: LocalizedError {
+    case invalidWorkspaceId(String)
+    case missingUserId
+    case missingAgentId
+    case storageFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidWorkspaceId(let id): return "유효하지 않은 workspaceId: \(id)"
+        case .missingUserId: return "개인 메모리 저장에 userId가 필요합니다."
+        case .missingAgentId: return "에이전트 메모리 저장에 agentId가 필요합니다."
+        case .storageFailed(let msg): return "메모리 저장 실패: \(msg)"
+        }
+    }
+}

--- a/Dochi/Services/Context/MemoryRetryQueue.swift
+++ b/Dochi/Services/Context/MemoryRetryQueue.swift
@@ -1,0 +1,145 @@
+import Foundation
+import os
+
+// MARK: - MemoryRetryQueue
+
+/// 메모리 저장 실패 시 비동기 재시도 큐.
+/// 지수 백오프로 재시도하며, 최대 횟수 초과 시 폐기한다.
+@MainActor
+@Observable
+final class MemoryRetryQueue {
+
+    private(set) var entries: [RetryEntry] = []
+    private(set) var isProcessing = false
+    private var processingTask: Task<Void, Never>?
+
+    private let contextService: ContextServiceProtocol
+
+    static let maxQueueSize = 50
+    static let checkIntervalSeconds: TimeInterval = 10
+
+    init(contextService: ContextServiceProtocol) {
+        self.contextService = contextService
+    }
+
+    nonisolated deinit {
+        // Note: processingTask is automatically cancelled when MemoryRetryQueue is deallocated
+    }
+
+    // MARK: - Enqueue
+
+    func enqueue(
+        content: String,
+        targetLayer: MemoryTargetLayer,
+        workspaceId: String,
+        agentName: String,
+        userId: String?,
+        error: String
+    ) {
+        guard entries.count < Self.maxQueueSize else {
+            Log.storage.warning("재시도 큐 가득 참, 항목 폐기: \(content.prefix(50))")
+            return
+        }
+
+        let entry = RetryEntry(
+            content: content,
+            targetLayer: targetLayer,
+            workspaceId: workspaceId,
+            agentName: agentName,
+            userId: userId,
+            errorMessage: error
+        )
+        entries.append(entry)
+        let queueCount = entries.count
+        Log.storage.info("재시도 큐 추가 (\(targetLayer.rawValue)): \(content.prefix(50))... (큐: \(queueCount))")
+
+        ensureProcessing()
+    }
+
+    // MARK: - Processing
+
+    func ensureProcessing() {
+        guard processingTask == nil else { return }
+        processingTask = Task { @MainActor in
+            await self.processLoop()
+            self.processingTask = nil
+        }
+    }
+
+    private func processLoop() async {
+        isProcessing = true
+        defer { isProcessing = false }
+
+        while !entries.isEmpty && !Task.isCancelled {
+            let now = Date()
+            var processed: [UUID] = []
+
+            for entry in entries {
+                guard !Task.isCancelled else { return }
+
+                guard now >= entry.nextRetryAt else { continue }
+
+                if entry.isExhausted {
+                    Log.storage.warning("재시도 횟수 초과, 폐기: \(entry.content.prefix(50))")
+                    processed.append(entry.id)
+                    continue
+                }
+
+                let success = attemptSave(entry: entry)
+                if success {
+                    Log.storage.info("재시도 성공: \(entry.content.prefix(50))")
+                    processed.append(entry.id)
+                } else {
+                    if let idx = entries.firstIndex(where: { $0.id == entry.id }) {
+                        entries[idx] = RetryEntry(
+                            id: entry.id,
+                            content: entry.content,
+                            targetLayer: entry.targetLayer,
+                            workspaceId: entry.workspaceId,
+                            agentName: entry.agentName,
+                            userId: entry.userId,
+                            attemptCount: entry.attemptCount + 1,
+                            lastAttemptAt: Date(),
+                            createdAt: entry.createdAt,
+                            errorMessage: entry.errorMessage
+                        )
+                    }
+                }
+            }
+
+            entries.removeAll { processed.contains($0.id) }
+            guard !entries.isEmpty else { break }
+            try? await Task.sleep(for: .seconds(Self.checkIntervalSeconds))
+        }
+    }
+
+    private func attemptSave(entry: RetryEntry) -> Bool {
+        guard let wsUUID = UUID(uuidString: entry.workspaceId) else { return false }
+
+        let content = "- \(entry.content)"
+
+        switch entry.targetLayer {
+        case .personal:
+            guard let userId = entry.userId, !userId.isEmpty else { return true }
+            contextService.appendUserMemory(userId: userId, content: content)
+        case .workspace:
+            contextService.appendWorkspaceMemory(workspaceId: wsUUID, content: content)
+        case .agent:
+            contextService.appendAgentMemory(workspaceId: wsUUID, agentName: entry.agentName, content: content)
+        case .drop:
+            break
+        }
+
+        return true
+    }
+
+    // MARK: - Query
+
+    var pendingCount: Int { entries.count }
+
+    func clear() {
+        entries.removeAll()
+        processingTask?.cancel()
+        processingTask = nil
+    }
+}

--- a/Dochi/Services/Context/ProjectionGenerator.swift
+++ b/Dochi/Services/Context/ProjectionGenerator.swift
@@ -1,0 +1,227 @@
+import Foundation
+import os
+
+// MARK: - ProjectionGenerator
+
+/// summary + hot facts 프로젝션을 생성한다.
+/// 최근 N개 항목 + 키워드 빈도 기반 핫 팩트 선정.
+/// fail-safe: 생성 실패 시 기존 프로젝션을 유지한다.
+@MainActor
+final class ProjectionGenerator {
+
+    static let maxHotFacts = 10
+    static let recentFactCount = 20
+    static let minMemoryLength = 50
+
+    private let contextService: ContextServiceProtocol
+
+    init(contextService: ContextServiceProtocol) {
+        self.contextService = contextService
+    }
+
+    // MARK: - Generate Projection
+
+    /// 특정 layer의 메모리에 대해 프로젝션을 생성한다.
+    func generate(
+        layer: MemoryTargetLayer,
+        workspaceId: UUID,
+        agentName: String,
+        userId: String?,
+        existingProjection: MemoryProjection?
+    ) -> MemoryProjection {
+        do {
+            let rawMemory = try loadMemory(layer: layer, workspaceId: workspaceId, agentName: agentName, userId: userId)
+
+            guard rawMemory.count >= Self.minMemoryLength else {
+                let facts = parseFactLines(rawMemory)
+                return MemoryProjection(
+                    layer: layer,
+                    summary: "",
+                    hotFacts: facts,
+                    generatedAt: Date(),
+                    sourceCharCount: rawMemory.count
+                )
+            }
+
+            let facts = parseFactLines(rawMemory)
+            let hotFacts = selectHotFacts(from: facts)
+            let summary = generateSummary(facts: facts, totalCount: facts.count)
+
+            return MemoryProjection(
+                layer: layer,
+                summary: summary,
+                hotFacts: hotFacts,
+                generatedAt: Date(),
+                sourceCharCount: rawMemory.count
+            )
+        } catch {
+            // Fail-safe: 생성 실패 시 기존 프로젝션 유지
+            Log.storage.warning("프로젝션 생성 실패 (\(layer.rawValue)), 기존 유지: \(error.localizedDescription)")
+            if let existing = existingProjection {
+                return existing
+            }
+            return MemoryProjection(
+                layer: layer,
+                summary: "",
+                hotFacts: [],
+                generatedAt: Date(),
+                sourceCharCount: 0
+            )
+        }
+    }
+
+    /// 모든 layer에 대해 프로젝션을 일괄 생성한다.
+    func generateAll(
+        workspaceId: UUID,
+        agentName: String,
+        userId: String?,
+        existingProjections: [MemoryTargetLayer: MemoryProjection]
+    ) -> [MemoryTargetLayer: MemoryProjection] {
+        var result: [MemoryTargetLayer: MemoryProjection] = [:]
+
+        result[.workspace] = generate(
+            layer: .workspace,
+            workspaceId: workspaceId,
+            agentName: agentName,
+            userId: nil,
+            existingProjection: existingProjections[.workspace]
+        )
+
+        result[.agent] = generate(
+            layer: .agent,
+            workspaceId: workspaceId,
+            agentName: agentName,
+            userId: nil,
+            existingProjection: existingProjections[.agent]
+        )
+
+        if let userId, !userId.isEmpty {
+            result[.personal] = generate(
+                layer: .personal,
+                workspaceId: workspaceId,
+                agentName: agentName,
+                userId: userId,
+                existingProjection: existingProjections[.personal]
+            )
+        }
+
+        return result
+    }
+
+    // MARK: - Private
+
+    private func loadMemory(
+        layer: MemoryTargetLayer,
+        workspaceId: UUID,
+        agentName: String,
+        userId: String?
+    ) throws -> String {
+        switch layer {
+        case .personal:
+            guard let userId, !userId.isEmpty else {
+                throw ProjectionError.noUserId
+            }
+            return contextService.loadUserMemory(userId: userId) ?? ""
+        case .workspace:
+            return contextService.loadWorkspaceMemory(workspaceId: workspaceId) ?? ""
+        case .agent:
+            return contextService.loadAgentMemory(workspaceId: workspaceId, agentName: agentName) ?? ""
+        case .drop:
+            return ""
+        }
+    }
+
+    /// 메모리에서 팩트 라인 파싱
+    func parseFactLines(_ memory: String) -> [String] {
+        memory.components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .map { line in
+                if line.hasPrefix("- ") {
+                    return String(line.dropFirst(2))
+                }
+                return line
+            }
+    }
+
+    /// 핫 팩트 선정: 최근 항목 우선 + 키워드 빈도 기반
+    func selectHotFacts(from facts: [String]) -> [String] {
+        guard facts.count > Self.maxHotFacts else { return facts }
+
+        let recentFacts = Array(facts.suffix(Self.recentFactCount))
+
+        // 키워드 빈도 계산
+        var wordFreq: [String: Int] = [:]
+        for fact in facts {
+            let words = fact.lowercased()
+                .components(separatedBy: .whitespacesAndNewlines)
+                .filter { $0.count > 1 }
+            for word in words {
+                wordFreq[word, default: 0] += 1
+            }
+        }
+
+        // 각 팩트의 중요도 점수
+        let scored = recentFacts.map { fact -> (String, Double) in
+            let words = fact.lowercased()
+                .components(separatedBy: .whitespacesAndNewlines)
+                .filter { $0.count > 1 }
+            let score = words.reduce(0.0) { sum, word in
+                sum + Double(wordFreq[word] ?? 0)
+            }
+            return (fact, score)
+        }
+
+        let sorted = scored.sorted { $0.1 > $1.1 }
+        return Array(sorted.prefix(Self.maxHotFacts).map(\.0))
+    }
+
+    /// 간단한 요약 생성
+    func generateSummary(facts: [String], totalCount: Int) -> String {
+        guard totalCount > Self.maxHotFacts else { return "" }
+
+        var categories: [String: Int] = [:]
+        for fact in facts {
+            let category = categorize(fact)
+            categories[category, default: 0] += 1
+        }
+
+        let topCategories = categories.sorted { $0.value > $1.value }
+            .prefix(3)
+            .map { "\($0.key) \($0.value)건" }
+            .joined(separator: ", ")
+
+        return "총 \(totalCount)건의 기억 (\(topCategories))"
+    }
+
+    private func categorize(_ fact: String) -> String {
+        let lower = fact.lowercased()
+        if lower.contains("선호") || lower.contains("좋아") || lower.contains("싫어") {
+            return "선호도"
+        }
+        if lower.contains("프로젝트") || lower.contains("배포") || lower.contains("일정") {
+            return "프로젝트"
+        }
+        if lower.contains("결정") || lower.contains("합의") || lower.contains("방침") {
+            return "결정사항"
+        }
+        if lower.contains("패턴") || lower.contains("스타일") || lower.contains("방식") {
+            return "패턴/스타일"
+        }
+        return "기타"
+    }
+}
+
+// MARK: - ProjectionError
+
+enum ProjectionError: LocalizedError {
+    case noUserId
+    case memoryLoadFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .noUserId: return "사용자 ID가 없습니다."
+        case .memoryLoadFailed: return "메모리 로드에 실패했습니다."
+        }
+    }
+}

--- a/Dochi/Services/Protocols/MemoryPipelineProtocol.swift
+++ b/Dochi/Services/Protocols/MemoryPipelineProtocol.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// MARK: - MemoryPipelineProtocol
+
+/// Processes memory candidates through classification, deduplication, and storage.
+///
+/// Pipeline stages (spec 05, section 5):
+/// 1. Extract candidate from conversation/tool result
+/// 2. Classify into target layer (personal/workspace/agent/drop)
+/// 3. Check for duplicates against existing memory
+/// 4. Store via ContextService
+/// 5. Emit audit event
+@MainActor
+protocol MemoryPipelineProtocol {
+    /// Submit a single candidate for async processing (classification + storage).
+    func submitCandidate(_ candidate: MemoryCandidate) async
+
+    /// Classify a candidate into its target layer.
+    func classifyCandidate(_ candidate: MemoryCandidate) -> MemoryClassification
+
+    /// Classify, deduplicate, and store a candidate. Throws on storage failure.
+    func processAndStore(_ candidate: MemoryCandidate) async throws
+
+    /// Number of candidates in the retry queue.
+    func pendingCount() -> Int
+
+    /// Batch: process conversation end — extract candidates and run full pipeline.
+    func processConversationEnd(
+        messages: [Message],
+        sessionId: String,
+        sessionContext: SessionContext,
+        settings: AppSettings
+    ) async -> MemoryPipelineResult
+
+    /// Batch: process tool result — extract candidates and run full pipeline.
+    func processToolResult(
+        toolName: String,
+        result: String,
+        sessionId: String,
+        sessionContext: SessionContext,
+        settings: AppSettings
+    ) async -> MemoryPipelineResult
+
+    /// Regenerate projections for all layers.
+    func regenerateProjections(
+        workspaceId: UUID,
+        agentName: String,
+        userId: String?
+    ) -> [MemoryTargetLayer: MemoryProjection]
+
+    /// Current cached projections.
+    var currentProjections: [MemoryTargetLayer: MemoryProjection] { get }
+
+    /// All audit events recorded during this session.
+    var auditLog: [MemoryAuditEvent] { get }
+}

--- a/Dochi/Services/Runtime/Hooks/HookPipeline.swift
+++ b/Dochi/Services/Runtime/Hooks/HookPipeline.swift
@@ -73,6 +73,21 @@ final class HookPipeline {
         }
     }
 
+    // MARK: - Memory Pipeline Integration
+
+    /// Attach a memory pipeline to the MemoryCandidateHook for structured processing.
+    func attachMemoryPipeline(_ pipeline: any MemoryPipelineProtocol, workspaceId: String) {
+        for hook in postHooks {
+            if let memoryHook = hook as? MemoryCandidateHook {
+                memoryHook.memoryPipeline = pipeline
+                memoryHook.currentWorkspaceId = workspaceId
+                Log.runtime.info("Memory pipeline attached to MemoryCandidateHook for workspace \(workspaceId)")
+                return
+            }
+        }
+        Log.runtime.warning("MemoryCandidateHook not found in post hooks — memory pipeline not attached")
+    }
+
     // MARK: - Utility
 
     /// Compute SHA-256 hash of tool arguments for audit logging.
@@ -201,9 +216,19 @@ final class MetricsRecordingHook: PostToolUseHook {
 // MARK: - MemoryCandidateHook
 
 /// PostToolUse hook that extracts memory-worthy content from tool results.
+///
+/// When a `memoryPipeline` is attached, extracted candidates are forwarded
+/// for classification and storage. Otherwise, candidates are only returned
+/// in the `PostHookOutput` for upstream consumers.
 @MainActor
 final class MemoryCandidateHook: PostToolUseHook {
     let name = "MemoryCandidate"
+
+    /// Optional pipeline for structured memory processing.
+    var memoryPipeline: (any MemoryPipelineProtocol)?
+
+    /// The workspace ID for the current session (set by runtime before use).
+    var currentWorkspaceId: String?
 
     /// Tools whose results may contain memory-worthy information.
     private let memoryToolNames: Set<String> = [
@@ -220,9 +245,25 @@ final class MemoryCandidateHook: PostToolUseHook {
 
         // Extract first meaningful line as summary
         let summary = String(result.content.prefix(200))
+        let candidateContent = "\(context.toolName): \(summary)"
+
+        // Forward to memory pipeline if available
+        if let pipeline = memoryPipeline, let workspaceId = currentWorkspaceId {
+            let candidate = MemoryCandidate(
+                content: candidateContent,
+                source: .toolResult,
+                sessionId: context.sessionId,
+                workspaceId: workspaceId,
+                agentId: context.agentId
+            )
+            Task { @MainActor in
+                await pipeline.submitCandidate(candidate)
+            }
+        }
+
         return PostHookOutput(
             resultSummary: summary,
-            memoryCandidates: ["\(context.toolName): \(summary)"]
+            memoryCandidates: [candidateContent]
         )
     }
 }

--- a/DochiTests/MemoryPipelineTests.swift
+++ b/DochiTests/MemoryPipelineTests.swift
@@ -1,0 +1,1001 @@
+import XCTest
+@testable import Dochi
+
+final class MemoryPipelineTests: XCTestCase {
+
+    // MARK: - Model Encoding Tests
+
+    func testMemoryCandidateEncodeDecode() throws {
+        let candidate = MemoryCandidate(
+            id: "test-1",
+            content: "오늘 팀 미팅에서 프로젝트 일정 확정",
+            source: .conversation,
+            timestamp: Date(timeIntervalSince1970: 1700000000),
+            sessionId: "session-1",
+            workspaceId: UUID().uuidString,
+            agentId: "assistant",
+            userId: "user-1"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(candidate)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(MemoryCandidate.self, from: data)
+
+        XCTAssertEqual(decoded.id, candidate.id)
+        XCTAssertEqual(decoded.content, candidate.content)
+        XCTAssertEqual(decoded.source, .conversation)
+        XCTAssertEqual(decoded.sessionId, "session-1")
+        XCTAssertEqual(decoded.agentId, "assistant")
+        XCTAssertEqual(decoded.userId, "user-1")
+    }
+
+    func testMemoryClassificationEncodeDecode() throws {
+        let classification = MemoryClassification(
+            candidateId: "c-1",
+            targetLayer: .personal,
+            confidence: 0.85,
+            reason: "개인 키워드 매칭"
+        )
+
+        let data = try JSONEncoder().encode(classification)
+        let decoded = try JSONDecoder().decode(MemoryClassification.self, from: data)
+
+        XCTAssertEqual(decoded.candidateId, "c-1")
+        XCTAssertEqual(decoded.targetLayer, .personal)
+        XCTAssertEqual(decoded.confidence, 0.85)
+    }
+
+    func testMemoryAuditEventEncodeDecode() throws {
+        let event = MemoryAuditEvent(
+            eventId: "e-1",
+            timestamp: Date(timeIntervalSince1970: 1700000000),
+            candidateId: "c-1",
+            targetLayer: .workspace,
+            action: .stored,
+            workspaceId: UUID().uuidString,
+            agentId: "bot",
+            userId: nil,
+            reason: "워크스페이스 키워드 매칭"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(MemoryAuditEvent.self, from: data)
+
+        XCTAssertEqual(decoded.eventId, "e-1")
+        XCTAssertEqual(decoded.action, .stored)
+        XCTAssertEqual(decoded.targetLayer, .workspace)
+    }
+
+    func testMemoryTargetLayerRawValues() {
+        XCTAssertEqual(MemoryTargetLayer.personal.rawValue, "personal")
+        XCTAssertEqual(MemoryTargetLayer.workspace.rawValue, "workspace")
+        XCTAssertEqual(MemoryTargetLayer.agent.rawValue, "agent")
+        XCTAssertEqual(MemoryTargetLayer.drop.rawValue, "drop")
+    }
+
+    func testMemoryAuditActionRawValues() {
+        XCTAssertEqual(MemoryAuditAction.stored.rawValue, "stored")
+        XCTAssertEqual(MemoryAuditAction.dropped.rawValue, "dropped")
+        XCTAssertEqual(MemoryAuditAction.deduplicated.rawValue, "deduplicated")
+        XCTAssertEqual(MemoryAuditAction.retryQueued.rawValue, "retryQueued")
+        XCTAssertEqual(MemoryAuditAction.retryFailed.rawValue, "retryFailed")
+        XCTAssertEqual(MemoryAuditAction.projectionRefreshed.rawValue, "projectionRefreshed")
+        XCTAssertEqual(MemoryAuditAction.projectionFailed.rawValue, "projectionFailed")
+    }
+
+    func testMemoryProjectionEncodeDecode() throws {
+        let projection = MemoryProjection(
+            layer: .workspace,
+            summary: "프로젝트 진행 상황 요약",
+            hotFacts: ["스프린트 3주차", "디자인 리뷰 완료"],
+            generatedAt: Date(timeIntervalSince1970: 1700000000),
+            sourceCharCount: 5000
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(projection)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(MemoryProjection.self, from: data)
+
+        XCTAssertEqual(decoded.layer, .workspace)
+        XCTAssertEqual(decoded.hotFacts.count, 2)
+        XCTAssertEqual(decoded.sourceCharCount, 5000)
+    }
+
+    func testMemoryPipelineResultEquality() {
+        let a = MemoryPipelineResult(
+            candidatesExtracted: 5, candidatesClassified: 5,
+            candidatesDropped: 1, duplicatesSkipped: 1,
+            conflictsDetected: 0, candidatesStored: 3, retryQueued: 0
+        )
+        let b = MemoryPipelineResult(
+            candidatesExtracted: 5, candidatesClassified: 5,
+            candidatesDropped: 1, duplicatesSkipped: 1,
+            conflictsDetected: 0, candidatesStored: 3, retryQueued: 0
+        )
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(MemoryPipelineResult.empty.candidatesStored, 0)
+    }
+
+    func testDeduplicationResultFields() {
+        let classification = MemoryClassification(
+            candidateId: "c-1", targetLayer: .workspace, confidence: 0.8, reason: "test"
+        )
+        let result = DeduplicationResult(
+            classification: classification,
+            originalContent: "test content",
+            isDuplicate: true,
+            similarity: 0.95
+        )
+        XCTAssertTrue(result.isDuplicate)
+        XCTAssertFalse(result.isConflict)
+        XCTAssertEqual(result.similarity, 0.95)
+        XCTAssertEqual(result.classification.candidateId, "c-1")
+    }
+
+    func testRetryEntryExhaustion() {
+        let entry = RetryEntry(
+            content: "test",
+            targetLayer: .workspace,
+            workspaceId: UUID().uuidString,
+            agentName: "bot",
+            userId: nil,
+            attemptCount: RetryEntry.maxAttempts
+        )
+        XCTAssertTrue(entry.isExhausted)
+
+        let fresh = RetryEntry(
+            content: "test",
+            targetLayer: .workspace,
+            workspaceId: UUID().uuidString,
+            agentName: "bot",
+            userId: nil,
+            attemptCount: 0
+        )
+        XCTAssertFalse(fresh.isExhausted)
+    }
+
+    // MARK: - LayerClassifier Tests
+
+    @MainActor
+    func testClassifyPersonalByKeyword() {
+        let classifier = LayerClassifier()
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "나는 커피를 좋아하는 사람이야",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString,
+            userId: "user-1"
+        )
+
+        let result = classifier.classify(candidate)
+        XCTAssertEqual(result.targetLayer, .personal)
+        XCTAssertGreaterThan(result.confidence, 0.3)
+    }
+
+    @MainActor
+    func testClassifyWorkspaceByKeyword() {
+        let classifier = LayerClassifier()
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "프로젝트 배포 일정은 다음 주 월요일로 결정",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString
+        )
+
+        let result = classifier.classify(candidate)
+        XCTAssertEqual(result.targetLayer, .workspace)
+    }
+
+    @MainActor
+    func testClassifyAgentByKeyword() {
+        let classifier = LayerClassifier()
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "보통 이 스타일 포맷으로 응답하면 좋겠어",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString,
+            agentId: "helper"
+        )
+
+        let result = classifier.classify(candidate)
+        XCTAssertEqual(result.targetLayer, .agent)
+    }
+
+    @MainActor
+    func testClassifyDropForShortGreeting() {
+        let classifier = LayerClassifier()
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "안녕 ㅋㅋ",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString
+        )
+
+        let result = classifier.classify(candidate)
+        XCTAssertEqual(result.targetLayer, .drop)
+    }
+
+    @MainActor
+    func testClassifyAllBatch() {
+        let classifier = LayerClassifier()
+        let wsId = UUID()
+
+        let candidates = [
+            MemoryCandidate(content: "내 취미는 등산이야", source: .conversation, sessionId: "s-1", workspaceId: wsId.uuidString, userId: "u1"),
+            MemoryCandidate(content: "프로젝트 마감 일정 확인", source: .conversation, sessionId: "s-1", workspaceId: wsId.uuidString),
+            MemoryCandidate(content: "ㅋㅋ ok", source: .conversation, sessionId: "s-1", workspaceId: wsId.uuidString),
+        ]
+
+        let results = classifier.classifyAll(candidates)
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(results[0].targetLayer, .personal)
+        XCTAssertEqual(results[1].targetLayer, .workspace)
+        XCTAssertEqual(results[2].targetLayer, .drop)
+    }
+
+    // MARK: - MemoryDeduplicator Tests
+
+    @MainActor
+    func testDeduplicateExactMatch() {
+        let deduplicator = MemoryDeduplicator()
+        let classification = MemoryClassification(
+            candidateId: "c-1", targetLayer: .workspace, confidence: 0.8, reason: "test"
+        )
+        let candidate = MemoryCandidate(
+            content: "팀 회의 월요일 10시",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: UUID().uuidString
+        )
+
+        let result = deduplicator.checkSingle(
+            candidate: candidate,
+            classification: classification,
+            existingMemory: [.workspace: "- 팀 회의 월요일 10시"]
+        )
+        XCTAssertTrue(result.isDuplicate)
+    }
+
+    @MainActor
+    func testDeduplicateNonDuplicate() {
+        let deduplicator = MemoryDeduplicator()
+        let classification = MemoryClassification(
+            candidateId: "c-1", targetLayer: .workspace, confidence: 0.8, reason: "test"
+        )
+        let candidate = MemoryCandidate(
+            content: "신규 기능 배포 완료",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: UUID().uuidString
+        )
+
+        let result = deduplicator.checkSingle(
+            candidate: candidate,
+            classification: classification,
+            existingMemory: [.workspace: "- 디자인 리뷰 일정 확인"]
+        )
+        XCTAssertFalse(result.isDuplicate)
+    }
+
+    @MainActor
+    func testJaccardSimilarity() {
+        let deduplicator = MemoryDeduplicator()
+        // Identical strings
+        XCTAssertEqual(deduplicator.jaccardSimilarity("a b c", "a b c"), 1.0)
+        // No overlap
+        XCTAssertEqual(deduplicator.jaccardSimilarity("a b", "c d"), 0.0)
+        // Partial overlap
+        let sim = deduplicator.jaccardSimilarity("a b c", "a b d")
+        XCTAssertGreaterThan(sim, 0.3)
+        XCTAssertLessThan(sim, 1.0)
+    }
+
+    // MARK: - Pipeline Single Candidate Tests
+
+    @MainActor
+    func testSubmitCandidateDropped() async {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+
+        let candidate = MemoryCandidate(
+            content: "ㅋㅋ ok",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: UUID().uuidString
+        )
+
+        await pipeline.submitCandidate(candidate)
+
+        // Should be dropped; nothing stored
+        XCTAssertTrue(ctx.userMemory.isEmpty)
+        XCTAssertTrue(ctx.workspaceMemory.isEmpty)
+
+        // Audit log should record drop
+        let dropEvents = pipeline.auditLog.filter { $0.action == MemoryAuditAction.dropped }
+        XCTAssertFalse(dropEvents.isEmpty)
+    }
+
+    @MainActor
+    func testProcessAndStorePersonal() async throws {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "나는 매일 아침 운동을 좋아해",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString,
+            userId: "user-1"
+        )
+
+        try await pipeline.processAndStore(candidate)
+
+        // Should be stored in personal memory
+        let stored = ctx.userMemory["user-1"]
+        XCTAssertNotNil(stored)
+        XCTAssertTrue(stored!.contains("운동"))
+
+        // Audit log should have stored event
+        let storedEvents = pipeline.auditLog.filter { $0.action == MemoryAuditAction.stored }
+        XCTAssertFalse(storedEvents.isEmpty)
+        XCTAssertEqual(storedEvents.first?.targetLayer, .personal)
+        XCTAssertEqual(storedEvents.first?.userId, "user-1")
+    }
+
+    @MainActor
+    func testProcessAndStoreWorkspace() async throws {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "프로젝트 배포 일정: 다음 주 월요일 마감 결정",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString
+        )
+
+        try await pipeline.processAndStore(candidate)
+
+        let stored = ctx.workspaceMemory[wsId]
+        XCTAssertNotNil(stored)
+        XCTAssertTrue(stored!.contains("배포"))
+
+        let storedEvents = pipeline.auditLog.filter { $0.action == MemoryAuditAction.stored }
+        XCTAssertEqual(storedEvents.first?.targetLayer, .workspace)
+    }
+
+    @MainActor
+    func testProcessAndStoreAgent() async throws {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "이 에이전트의 응답 스타일을 격식체 포맷으로 변경",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString,
+            agentId: "translator"
+        )
+
+        try await pipeline.processAndStore(candidate)
+
+        let key = "\(wsId)|translator"
+        let stored = ctx.agentMemories[key]
+        XCTAssertNotNil(stored)
+        XCTAssertTrue(stored!.contains("스타일"))
+
+        let storedEvents = pipeline.auditLog.filter { $0.action == MemoryAuditAction.stored }
+        XCTAssertEqual(storedEvents.first?.targetLayer, .agent)
+    }
+
+    @MainActor
+    func testDeduplicateInPipeline() async throws {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+        let wsId = UUID()
+
+        // Pre-populate workspace memory
+        ctx.workspaceMemory[wsId] = "- 프로젝트 마감 일정 확인"
+
+        let candidate = MemoryCandidate(
+            content: "프로젝트 마감 일정 확인",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString
+        )
+
+        try await pipeline.processAndStore(candidate)
+
+        // Should be deduplicated
+        let dedupEvents = pipeline.auditLog.filter { $0.action == MemoryAuditAction.deduplicated }
+        XCTAssertFalse(dedupEvents.isEmpty)
+    }
+
+    // MARK: - Privacy Boundary Tests
+
+    @MainActor
+    func testPersonalMemoryNotStoredInWorkspace() async throws {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "내 비밀번호 힌트는 고양이 이름이야",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString,
+            userId: "user-1"
+        )
+
+        try await pipeline.processAndStore(candidate)
+
+        // Should be in personal memory only
+        XCTAssertNotNil(ctx.userMemory["user-1"])
+        XCTAssertTrue(ctx.userMemory["user-1"]!.contains("비밀번호"))
+
+        // Should NOT be in workspace memory
+        XCTAssertNil(ctx.workspaceMemory[wsId])
+    }
+
+    // MARK: - Retry Queue Tests
+
+    @MainActor
+    func testRetryQueueInitiallyEmpty() {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+        XCTAssertEqual(pipeline.pendingCount(), 0)
+    }
+
+    @MainActor
+    func testRetryQueueEnqueue() {
+        let ctx = MockContextService()
+        let retryQueue = MemoryRetryQueue(contextService: ctx)
+
+        retryQueue.enqueue(
+            content: "test content",
+            targetLayer: .workspace,
+            workspaceId: UUID().uuidString,
+            agentName: "bot",
+            userId: nil,
+            error: "저장 실패"
+        )
+
+        XCTAssertEqual(retryQueue.pendingCount, 1)
+    }
+
+    @MainActor
+    func testRetryQueueClear() {
+        let ctx = MockContextService()
+        let retryQueue = MemoryRetryQueue(contextService: ctx)
+
+        retryQueue.enqueue(
+            content: "test",
+            targetLayer: .workspace,
+            workspaceId: UUID().uuidString,
+            agentName: "bot",
+            userId: nil,
+            error: "err"
+        )
+        retryQueue.clear()
+
+        XCTAssertEqual(retryQueue.pendingCount, 0)
+    }
+
+    @MainActor
+    func testRetryQueueMaxSize() {
+        let ctx = MockContextService()
+        let retryQueue = MemoryRetryQueue(contextService: ctx)
+
+        for i in 0..<(MemoryRetryQueue.maxQueueSize + 5) {
+            retryQueue.enqueue(
+                content: "item \(i)",
+                targetLayer: .workspace,
+                workspaceId: UUID().uuidString,
+                agentName: "bot",
+                userId: nil,
+                error: "err"
+            )
+        }
+
+        XCTAssertLessThanOrEqual(retryQueue.pendingCount, MemoryRetryQueue.maxQueueSize)
+    }
+
+    // MARK: - Audit Log Tests
+
+    @MainActor
+    func testAuditLogRecordsAllActions() async throws {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+        let wsId = UUID()
+
+        // 1. Stored (personal)
+        let c1 = MemoryCandidate(
+            content: "나는 한국어를 선호해",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString,
+            userId: "user-1"
+        )
+        try await pipeline.processAndStore(c1)
+
+        // 2. Dropped
+        let c2 = MemoryCandidate(
+            content: "ㅎㅎ ok",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString
+        )
+        try await pipeline.processAndStore(c2)
+
+        // 3. Deduplicated
+        let c3 = MemoryCandidate(
+            content: "나는 한국어를 선호해",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString,
+            userId: "user-1"
+        )
+        try await pipeline.processAndStore(c3)
+
+        // Verify all action types present
+        let actions = Set(pipeline.auditLog.map { $0.action })
+        XCTAssertTrue(actions.contains(MemoryAuditAction.stored))
+        XCTAssertTrue(actions.contains(MemoryAuditAction.dropped))
+        XCTAssertTrue(actions.contains(MemoryAuditAction.deduplicated))
+    }
+
+    @MainActor
+    func testAuditLogContainsCorrectMetadata() async throws {
+        let ctx = MockContextService()
+        let pipeline = MemoryPipelineService(contextService: ctx)
+        let wsId = UUID()
+
+        let candidate = MemoryCandidate(
+            content: "프로젝트 일정: 3월 20일 마감 결정",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: wsId.uuidString,
+            agentId: "planner"
+        )
+
+        try await pipeline.processAndStore(candidate)
+
+        let event = pipeline.auditLog.first!
+        XCTAssertEqual(event.candidateId, candidate.id)
+        XCTAssertEqual(event.workspaceId, wsId.uuidString)
+        XCTAssertFalse(event.reason.isEmpty)
+        XCTAssertFalse(event.eventId.isEmpty)
+    }
+
+    // MARK: - ProjectionGenerator Tests
+
+    @MainActor
+    func testProjectionGenerateEmpty() {
+        let ctx = MockContextService()
+        let generator = ProjectionGenerator(contextService: ctx)
+        let wsId = UUID()
+
+        let projection = generator.generate(
+            layer: .workspace,
+            workspaceId: wsId,
+            agentName: "bot",
+            userId: nil,
+            existingProjection: nil
+        )
+
+        XCTAssertEqual(projection.layer, .workspace)
+        XCTAssertTrue(projection.hotFacts.isEmpty)
+        XCTAssertEqual(projection.sourceCharCount, 0)
+    }
+
+    @MainActor
+    func testProjectionGenerateWithContent() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.workspaceMemory[wsId] = """
+        - 스프린트 3주차 진행 중
+        - 디자인 리뷰 완료
+        - 백엔드 API 개발 70% 완료
+        - 프론트엔드 컴포넌트 설계 시작
+        - QA 테스트 계획 수립 필요
+        - 배포 일정 다음 주 확정
+        - 코드리뷰 프로세스 개선 필요
+        - 데이터베이스 마이그레이션 준비
+        - 클라이언트 피드백 반영 예정
+        - 모니터링 대시보드 구성 완료
+        - 보안 감사 요청
+        """
+
+        let generator = ProjectionGenerator(contextService: ctx)
+
+        let projection = generator.generate(
+            layer: .workspace,
+            workspaceId: wsId,
+            agentName: "bot",
+            userId: nil,
+            existingProjection: nil
+        )
+
+        XCTAssertFalse(projection.hotFacts.isEmpty)
+        XCTAssertGreaterThan(projection.sourceCharCount, 0)
+        XCTAssertEqual(projection.layer, .workspace)
+    }
+
+    @MainActor
+    func testProjectionGeneratePersonal() {
+        let ctx = MockContextService()
+        ctx.userMemory["user-1"] = """
+        - 취미: 등산, 독서
+        - 좋아하는 음식: 파스타
+        - 생일: 3월 15일
+        """
+
+        let generator = ProjectionGenerator(contextService: ctx)
+        let wsId = UUID()
+
+        let projection = generator.generate(
+            layer: .personal,
+            workspaceId: wsId,
+            agentName: "bot",
+            userId: "user-1",
+            existingProjection: nil
+        )
+
+        XCTAssertFalse(projection.hotFacts.isEmpty)
+        XCTAssertEqual(projection.layer, .personal)
+    }
+
+    @MainActor
+    func testProjectionFailSafePreservesExisting() {
+        let ctx = MockContextService()
+        let generator = ProjectionGenerator(contextService: ctx)
+        let wsId = UUID()
+
+        let existing = MemoryProjection(
+            layer: .personal,
+            summary: "기존 요약",
+            hotFacts: ["기존 팩트1", "기존 팩트2"],
+            generatedAt: Date(),
+            sourceCharCount: 500
+        )
+
+        // Generate for personal without userId -> should fail and return existing
+        let projection = generator.generate(
+            layer: .personal,
+            workspaceId: wsId,
+            agentName: "bot",
+            userId: nil,
+            existingProjection: existing
+        )
+
+        XCTAssertEqual(projection.summary, existing.summary)
+        XCTAssertEqual(projection.hotFacts, existing.hotFacts)
+    }
+
+    @MainActor
+    func testProjectionGenerateAll() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.workspaceMemory[wsId] = """
+        - 프로젝트 일정 확인
+        - 디자인 리뷰 완료 프로젝트
+        - 백엔드 API 개발 프로젝트
+        - QA 테스트 계획 프로젝트
+        - 배포 일정 확정 프로젝트
+        - 코드리뷰 프로세스 개선 프로젝트
+        - 데이터베이스 마이그레이션 프로젝트
+        - 보안 감사 요청 프로젝트
+        - 모니터링 대시보드 프로젝트
+        - 클라이언트 피드백 프로젝트
+        - 인프라 구축 프로젝트
+        """
+        ctx.userMemory["user-1"] = "- 선호 언어: 한국어\n- 취미: 등산\n- 생일: 3월"
+
+        let generator = ProjectionGenerator(contextService: ctx)
+
+        let projections = generator.generateAll(
+            workspaceId: wsId,
+            agentName: "bot",
+            userId: "user-1",
+            existingProjections: [:]
+        )
+
+        XCTAssertNotNil(projections[.workspace])
+        XCTAssertNotNil(projections[.agent])
+        XCTAssertNotNil(projections[.personal])
+    }
+
+    @MainActor
+    func testParseFactLines() {
+        let generator = ProjectionGenerator(contextService: MockContextService())
+
+        let facts = generator.parseFactLines("- fact1\n- fact2\nfact3\n\n")
+        XCTAssertEqual(facts.count, 3)
+        XCTAssertEqual(facts[0], "fact1")
+        XCTAssertEqual(facts[1], "fact2")
+        XCTAssertEqual(facts[2], "fact3")
+    }
+
+    @MainActor
+    func testSelectHotFacts() {
+        let generator = ProjectionGenerator(contextService: MockContextService())
+
+        var manyFacts: [String] = []
+        for i in 0..<30 {
+            manyFacts.append("항목 \(i)번째 기억 내용입니다")
+        }
+
+        let hot = generator.selectHotFacts(from: manyFacts)
+        XCTAssertLessThanOrEqual(hot.count, ProjectionGenerator.maxHotFacts)
+    }
+
+    // MARK: - MemoryCandidateExtractor Tests
+
+    @MainActor
+    func testExtractFromConversationMinMessages() {
+        let extractor = MemoryCandidateExtractor()
+
+        // Too few messages
+        let messages = [
+            Message(role: .user, content: "안녕"),
+        ]
+
+        let candidates = extractor.extractFromConversation(
+            messages: messages,
+            sessionId: "s-1",
+            workspaceId: UUID().uuidString,
+            agentId: "bot",
+            userId: "user-1"
+        )
+
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    @MainActor
+    func testExtractFromConversationWithFacts() {
+        let extractor = MemoryCandidateExtractor()
+
+        let messages = [
+            Message(role: .user, content: "나는 커피를 좋아해"),
+            Message(role: .assistant, content: "알겠습니다. 커피를 좋아하시는군요!"),
+            Message(role: .user, content: "프로젝트 마감이 다음 주야"),
+            Message(role: .assistant, content: "프로젝트 마감 일정을 기억하겠습니다."),
+        ]
+
+        let candidates = extractor.extractFromConversation(
+            messages: messages,
+            sessionId: "s-1",
+            workspaceId: UUID().uuidString,
+            agentId: "bot",
+            userId: "user-1"
+        )
+
+        XCTAssertFalse(candidates.isEmpty)
+        XCTAssertTrue(candidates.allSatisfy { $0.source == .conversation })
+    }
+
+    @MainActor
+    func testExtractFromToolResult() {
+        let extractor = MemoryCandidateExtractor()
+
+        let result = "Today: 10am Team meeting, 2pm Design review, 4pm Planning session"
+
+        let candidates = extractor.extractFromToolResult(
+            toolName: "calendar.today",
+            result: result,
+            sessionId: "s-1",
+            workspaceId: UUID().uuidString,
+            agentId: "bot",
+            userId: "user-1"
+        )
+
+        XCTAssertFalse(candidates.isEmpty)
+        XCTAssertTrue(candidates.allSatisfy { $0.source == .toolResult })
+    }
+
+    @MainActor
+    func testExtractFromToolResultTooShort() {
+        let extractor = MemoryCandidateExtractor()
+
+        let candidates = extractor.extractFromToolResult(
+            toolName: "test.tool",
+            result: "OK",
+            sessionId: "s-1",
+            workspaceId: UUID().uuidString,
+            agentId: nil,
+            userId: nil
+        )
+
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    // MARK: - Pipeline Regenerate Projections
+
+    @MainActor
+    func testRegenerateProjections() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.workspaceMemory[wsId] = """
+        - 프로젝트 A 진행 중
+        - 프로젝트 B 완료
+        - 스프린트 리뷰 금요일 3시
+        - 코드리뷰 프로세스 개선
+        - 배포 파이프라인 구축
+        - 테스트 자동화 적용
+        - 문서화 업데이트 필요
+        - 인프라 모니터링 설정
+        - 보안 감사 일정
+        - 팀 빌딩 행사
+        - 신규 입사자 온보딩
+        """
+        ctx.userMemory["user-1"] = "- 좋아하는 색: 파란색\n- 커피: 아메리카노"
+
+        let pipeline = MemoryPipelineService(contextService: ctx)
+
+        let projections = pipeline.regenerateProjections(
+            workspaceId: wsId,
+            agentName: "bot",
+            userId: "user-1"
+        )
+
+        XCTAssertNotNil(projections[.workspace])
+        XCTAssertNotNil(projections[.personal])
+        XCTAssertEqual(pipeline.currentProjections.count, projections.count)
+    }
+
+    // MARK: - Hook Integration Tests
+
+    @MainActor
+    func testMemoryCandidateHookForwardsToMockPipeline() {
+        let mockPipeline = MockMemoryPipelineService()
+        let hook = MemoryCandidateHook()
+        hook.memoryPipeline = mockPipeline
+        hook.currentWorkspaceId = UUID().uuidString
+
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: "helper",
+            toolName: "calendar.today",
+            arguments: [:],
+            riskLevel: "safe"
+        )
+        let result = ToolResult(toolCallId: "tc-1", content: "Today: 10am Team meeting, 2pm Design review, 4pm Planning")
+
+        let output = hook.process(context: context, result: result, latencyMs: 30)
+        XCTAssertNotNil(output)
+        XCTAssertFalse(output!.memoryCandidates.isEmpty)
+
+        // Give the Task a moment to execute
+        let expectation = XCTestExpectation(description: "Pipeline receives candidate")
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            XCTAssertEqual(mockPipeline.submitCallCount, 1)
+            XCTAssertEqual(mockPipeline.submittedCandidates.first?.source, .toolResult)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    @MainActor
+    func testHookPipelineAttachMemoryPipeline() {
+        let pipeline = HookPipeline()
+        let mockMemPipeline = MockMemoryPipelineService()
+        let wsId = UUID().uuidString
+
+        pipeline.attachMemoryPipeline(mockMemPipeline, workspaceId: wsId)
+
+        // Verify the hook has the pipeline attached
+        if let memHook = pipeline.postHooks.first(where: { $0.name == "MemoryCandidate" }) as? MemoryCandidateHook {
+            XCTAssertNotNil(memHook.memoryPipeline)
+            XCTAssertEqual(memHook.currentWorkspaceId, wsId)
+        } else {
+            XCTFail("MemoryCandidateHook not found in pipeline")
+        }
+    }
+
+    @MainActor
+    func testHookDoesNotForwardWithoutPipeline() {
+        let hook = MemoryCandidateHook()
+        // No pipeline attached
+
+        let context = ToolHookContext(
+            toolCallId: "tc-1",
+            sessionId: "s-1",
+            agentId: nil,
+            toolName: "calendar.today",
+            arguments: [:],
+            riskLevel: "safe"
+        )
+        let result = ToolResult(toolCallId: "tc-1", content: "Today: 10am Team meeting and more events listed here")
+
+        let output = hook.process(context: context, result: result, latencyMs: 30)
+        // Output should still be returned (for PostHookOutput consumers)
+        XCTAssertNotNil(output)
+        // But no pipeline submission happens (just no crash)
+    }
+
+    // MARK: - Mock Tests
+
+    @MainActor
+    func testMockMemoryPipelineService() async {
+        let mock = MockMemoryPipelineService()
+        let candidate = MemoryCandidate(
+            content: "test",
+            source: .conversation,
+            sessionId: "s-1",
+            workspaceId: UUID().uuidString
+        )
+
+        await mock.submitCandidate(candidate)
+        XCTAssertEqual(mock.submitCallCount, 1)
+        XCTAssertEqual(mock.submittedCandidates.count, 1)
+
+        let classification = mock.classifyCandidate(candidate)
+        XCTAssertEqual(classification.targetLayer, .workspace)
+
+        try? await mock.processAndStore(candidate)
+        XCTAssertEqual(mock.processCallCount, 1)
+
+        XCTAssertEqual(mock.pendingCount(), 0)
+    }
+
+    @MainActor
+    func testMockPipelineBatchMethods() async {
+        let mock = MockMemoryPipelineService()
+        let wsId = UUID()
+        let sessionContext = SessionContext(workspaceId: wsId, currentUserId: "u1")
+        let settings = AppSettings()
+
+        let result1 = await mock.processConversationEnd(
+            messages: [],
+            sessionId: "s-1",
+            sessionContext: sessionContext,
+            settings: settings
+        )
+        XCTAssertEqual(mock.processConversationEndCallCount, 1)
+        XCTAssertEqual(result1, .empty)
+
+        let result2 = await mock.processToolResult(
+            toolName: "test",
+            result: "ok",
+            sessionId: "s-1",
+            sessionContext: sessionContext,
+            settings: settings
+        )
+        XCTAssertEqual(mock.processToolResultCallCount, 1)
+        XCTAssertEqual(result2, .empty)
+
+        let projections = mock.regenerateProjections(
+            workspaceId: wsId,
+            agentName: "bot",
+            userId: "u1"
+        )
+        XCTAssertEqual(mock.regenerateProjectionsCallCount, 1)
+        XCTAssertTrue(projections.isEmpty)
+    }
+}

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -1477,3 +1477,77 @@ final class MockRuntimeBridgeService: RuntimeBridgeProtocol {
         )
     }
 }
+
+// MARK: - MockMemoryPipelineService (#288)
+
+@MainActor
+final class MockMemoryPipelineService: MemoryPipelineProtocol {
+    var auditLog: [MemoryAuditEvent] = []
+    var currentProjections: [MemoryTargetLayer: MemoryProjection] = [:]
+    var submittedCandidates: [MemoryCandidate] = []
+    var processedCandidates: [MemoryCandidate] = []
+    var submitCallCount = 0
+    var processCallCount = 0
+    var processConversationEndCallCount = 0
+    var processToolResultCallCount = 0
+    var regenerateProjectionsCallCount = 0
+    var stubbedClassification: MemoryClassification?
+    var stubbedError: Error?
+    var stubbedPipelineResult: MemoryPipelineResult = .empty
+    var retryQueueCount = 0
+
+    func submitCandidate(_ candidate: MemoryCandidate) async {
+        submitCallCount += 1
+        submittedCandidates.append(candidate)
+    }
+
+    func classifyCandidate(_ candidate: MemoryCandidate) -> MemoryClassification {
+        if let stubbed = stubbedClassification { return stubbed }
+        return MemoryClassification(
+            candidateId: candidate.id,
+            targetLayer: .workspace,
+            confidence: 0.5,
+            reason: "mock classification"
+        )
+    }
+
+    func processAndStore(_ candidate: MemoryCandidate) async throws {
+        processCallCount += 1
+        processedCandidates.append(candidate)
+        if let error = stubbedError { throw error }
+    }
+
+    func pendingCount() -> Int {
+        retryQueueCount
+    }
+
+    func processConversationEnd(
+        messages: [Message],
+        sessionId: String,
+        sessionContext: SessionContext,
+        settings: AppSettings
+    ) async -> MemoryPipelineResult {
+        processConversationEndCallCount += 1
+        return stubbedPipelineResult
+    }
+
+    func processToolResult(
+        toolName: String,
+        result: String,
+        sessionId: String,
+        sessionContext: SessionContext,
+        settings: AppSettings
+    ) async -> MemoryPipelineResult {
+        processToolResultCallCount += 1
+        return stubbedPipelineResult
+    }
+
+    func regenerateProjections(
+        workspaceId: UUID,
+        agentName: String,
+        userId: String?
+    ) -> [MemoryTargetLayer: MemoryProjection] {
+        regenerateProjectionsCallCount += 1
+        return currentProjections
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the 5-stage memory pipeline: **Extract → Classify → Deduplicate → Store → Project**
- **MemoryCandidateExtractor**: Extracts candidates from conversations (min 3 messages) and PostToolUse results
- **LayerClassifier**: Rule-based keyword classification into personal/workspace/agent/drop layers (Korean + English keywords)
- **MemoryDeduplicator**: Jaccard word-similarity dedup (>0.7 = duplicate, 0.3-0.7 = conflict detection)
- **ProjectionGenerator**: Summary + hot facts (keyword frequency scoring), fail-safe preserves existing projection on failure
- **MemoryRetryQueue**: Async retry with exponential backoff (2^n × 5s, max 5 attempts, max 300s)
- **MemoryPipelineService**: Orchestrator implementing MemoryPipelineProtocol with single-candidate and batch processing
- **MemoryCandidateHook**: Integrated into HookPipeline for automatic PostToolUse → pipeline forwarding
- Privacy: Personal memory stored per-userId only; workspace boundary absolute
- Audit logging for all pipeline actions (stored/dropped/deduplicated/retryQueued)

## Test plan
- [x] 46 unit tests all passing (0 failures)
- [x] Model encode/decode roundtrip (MemoryCandidate, MemoryClassification, MemoryAuditEvent, MemoryProjection)
- [x] LayerClassifier accuracy: personal, workspace, agent, drop classification by keyword
- [x] Deduplication: exact match, Jaccard similarity, non-duplicate pass-through
- [x] Pipeline integration: single candidate store/drop/dedup, privacy boundary (personal not in workspace)
- [x] Retry queue: enqueue, clear, max size enforcement
- [x] Audit log: correct action types and metadata
- [x] ProjectionGenerator: empty/content/personal/fail-safe/generateAll/parseFactLines/selectHotFacts
- [x] Hook integration: MemoryCandidateHook forwards to pipeline, no-crash without pipeline

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)