### PR TITLE
feat: implement Agent Definition v2 with loader, validator, and wake word router (#289)

### DIFF
--- a/Dochi/Models/AgentDefinition.swift
+++ b/Dochi/Models/AgentDefinition.swift
@@ -1,0 +1,286 @@
+import Foundation
+
+// MARK: - AgentDefinition
+
+/// 선언적 에이전트 정의 v2.
+/// config.json에서 디코딩되며, 기존 AgentConfig와 역호환된다.
+struct AgentDefinition: Codable, Sendable, Identifiable {
+    let id: String
+    let name: String
+    var wakeWord: String?
+    var description: String?
+    var defaultModel: String?
+    var permissionProfile: PermissionProfile?
+    var toolGroups: [String]
+    var subagents: [SubagentDefinition]
+    var memoryPolicy: MemoryPolicy?
+    var version: Int
+    var updatedAt: Date
+
+    // Legacy fields for backward compatibility
+    var permissions: [String]?
+    var shellPermissions: ShellPermissionConfig?
+    var delegationPolicy: DelegationPolicy?
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        wakeWord: String? = nil,
+        description: String? = nil,
+        defaultModel: String? = nil,
+        permissionProfile: PermissionProfile? = nil,
+        toolGroups: [String] = [],
+        subagents: [SubagentDefinition] = [],
+        memoryPolicy: MemoryPolicy? = nil,
+        version: Int = 1,
+        updatedAt: Date = Date(),
+        permissions: [String]? = nil,
+        shellPermissions: ShellPermissionConfig? = nil,
+        delegationPolicy: DelegationPolicy? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.wakeWord = wakeWord
+        self.description = description
+        self.defaultModel = defaultModel
+        self.permissionProfile = permissionProfile
+        self.toolGroups = toolGroups
+        self.subagents = subagents
+        self.memoryPolicy = memoryPolicy
+        self.version = version
+        self.updatedAt = updatedAt
+        self.permissions = permissions
+        self.shellPermissions = shellPermissions
+        self.delegationPolicy = delegationPolicy
+    }
+
+    // MARK: - Backward Compatible Decoding
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // id: 없으면 name에서 생성
+        id = try container.decodeIfPresent(String.self, forKey: .id)
+            ?? container.decode(String.self, forKey: .name)
+        name = try container.decode(String.self, forKey: .name)
+        wakeWord = try container.decodeIfPresent(String.self, forKey: .wakeWord)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        defaultModel = try container.decodeIfPresent(String.self, forKey: .defaultModel)
+        permissionProfile = try container.decodeIfPresent(PermissionProfile.self, forKey: .permissionProfile)
+
+        // toolGroups or legacy preferredToolGroups
+        if let groups = try container.decodeIfPresent([String].self, forKey: .toolGroups) {
+            toolGroups = groups
+        } else if let legacy = try container.decodeIfPresent([String].self, forKey: .preferredToolGroups) {
+            toolGroups = legacy
+        } else {
+            toolGroups = []
+        }
+
+        subagents = try container.decodeIfPresent([SubagentDefinition].self, forKey: .subagents) ?? []
+        memoryPolicy = try container.decodeIfPresent(MemoryPolicy.self, forKey: .memoryPolicy)
+        version = try container.decodeIfPresent(Int.self, forKey: .version) ?? 1
+        updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt) ?? Date()
+
+        // Legacy fields
+        permissions = try container.decodeIfPresent([String].self, forKey: .permissions)
+        shellPermissions = try container.decodeIfPresent(ShellPermissionConfig.self, forKey: .shellPermissions)
+        delegationPolicy = try container.decodeIfPresent(DelegationPolicy.self, forKey: .delegationPolicy)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, wakeWord, description, defaultModel
+        case permissionProfile, toolGroups, preferredToolGroups
+        case subagents, memoryPolicy, version, updatedAt
+        case permissions, shellPermissions, delegationPolicy
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encodeIfPresent(wakeWord, forKey: .wakeWord)
+        try container.encodeIfPresent(description, forKey: .description)
+        try container.encodeIfPresent(defaultModel, forKey: .defaultModel)
+        try container.encodeIfPresent(permissionProfile, forKey: .permissionProfile)
+        try container.encode(toolGroups, forKey: .toolGroups)
+        if !subagents.isEmpty {
+            try container.encode(subagents, forKey: .subagents)
+        }
+        try container.encodeIfPresent(memoryPolicy, forKey: .memoryPolicy)
+        try container.encode(version, forKey: .version)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(permissions, forKey: .permissions)
+        try container.encodeIfPresent(shellPermissions, forKey: .shellPermissions)
+        try container.encodeIfPresent(delegationPolicy, forKey: .delegationPolicy)
+    }
+
+    // MARK: - Computed
+
+    /// 유효한 permissionProfile 또는 레거시 permissions에서 변환
+    var effectivePermissionProfile: PermissionProfile {
+        if let profile = permissionProfile { return profile }
+        // 레거시 permissions 배열에서 변환
+        let perms = permissions ?? ["safe", "sensitive", "restricted"]
+        return PermissionProfile(
+            safe: perms.contains("safe") ? .allow : .deny,
+            sensitive: perms.contains("sensitive") ? .confirm : .deny,
+            restricted: perms.contains("restricted") ? .confirm : .deny
+        )
+    }
+
+    var effectiveToolGroups: [String] {
+        var result: [String] = []
+        var seen: Set<String> = []
+        for raw in toolGroups {
+            let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty else { continue }
+            if seen.insert(normalized).inserted {
+                result.append(normalized)
+            }
+        }
+        return result
+    }
+
+    /// AgentConfig로 변환 (레거시 호환)
+    func toAgentConfig() -> AgentConfig {
+        AgentConfig(
+            name: name,
+            wakeWord: wakeWord,
+            description: description,
+            defaultModel: defaultModel,
+            permissions: permissions,
+            preferredToolGroups: toolGroups.isEmpty ? nil : toolGroups,
+            shellPermissions: shellPermissions,
+            delegationPolicy: delegationPolicy
+        )
+    }
+
+    /// AgentConfig에서 변환
+    static func from(config: AgentConfig) -> AgentDefinition {
+        AgentDefinition(
+            id: config.name,
+            name: config.name,
+            wakeWord: config.wakeWord,
+            description: config.description,
+            defaultModel: config.defaultModel,
+            toolGroups: config.preferredToolGroups ?? [],
+            version: 1,
+            permissions: config.permissions,
+            shellPermissions: config.shellPermissions,
+            delegationPolicy: config.delegationPolicy
+        )
+    }
+
+    /// 버전 증가 복사본
+    func incrementedVersion() -> AgentDefinition {
+        var copy = self
+        copy.version = version + 1
+        copy.updatedAt = Date()
+        return copy
+    }
+}
+
+// MARK: - PermissionProfile
+
+/// safe/sensitive/restricted 각각의 권한 정책
+struct PermissionProfile: Codable, Sendable, Equatable {
+    let safe: PermissionAction
+    let sensitive: PermissionAction
+    let restricted: PermissionAction
+
+    static let `default` = PermissionProfile(
+        safe: .allow,
+        sensitive: .confirm,
+        restricted: .deny
+    )
+
+    /// 최소 권한 프로필 (safe만 허용)
+    static let minimal = PermissionProfile(
+        safe: .allow,
+        sensitive: .deny,
+        restricted: .deny
+    )
+}
+
+// MARK: - PermissionAction
+
+enum PermissionAction: String, Codable, Sendable {
+    case allow
+    case confirm
+    case deny
+}
+
+// MARK: - SubagentDefinition
+
+/// 서브에이전트 선언
+struct SubagentDefinition: Codable, Sendable, Identifiable {
+    let id: String
+    var name: String?
+    var description: String?
+    var toolGroups: [String]
+    var permissionProfile: PermissionProfile?
+
+    init(
+        id: String,
+        name: String? = nil,
+        description: String? = nil,
+        toolGroups: [String] = [],
+        permissionProfile: PermissionProfile? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.toolGroups = toolGroups
+        self.permissionProfile = permissionProfile
+    }
+}
+
+// MARK: - MemoryPolicy
+
+/// 에이전트별 메모리 정책
+struct MemoryPolicy: Codable, Sendable, Equatable {
+    /// 개인 메모리 접근 가능 여부
+    var personalMemoryAccess: Bool
+
+    /// 워크스페이스 메모리 접근 가능 여부
+    var workspaceMemoryAccess: Bool
+
+    /// 에이전트 메모리 접근 가능 여부
+    var agentMemoryAccess: Bool
+
+    /// 메모리 자동 추출 활성화 여부
+    var autoExtractEnabled: Bool
+
+    init(
+        personalMemoryAccess: Bool = true,
+        workspaceMemoryAccess: Bool = true,
+        agentMemoryAccess: Bool = true,
+        autoExtractEnabled: Bool = true
+    ) {
+        self.personalMemoryAccess = personalMemoryAccess
+        self.workspaceMemoryAccess = workspaceMemoryAccess
+        self.agentMemoryAccess = agentMemoryAccess
+        self.autoExtractEnabled = autoExtractEnabled
+    }
+
+    static let `default` = MemoryPolicy()
+
+    /// 서브에이전트 기본 정책: 개인 메모리 없음
+    static let subagentDefault = MemoryPolicy(
+        personalMemoryAccess: false,
+        workspaceMemoryAccess: true,
+        agentMemoryAccess: true,
+        autoExtractEnabled: false
+    )
+}
+
+// MARK: - LoadedAgentDefinition
+
+/// 파일시스템에서 로드된 에이전트 정의 (config + persona + memory)
+struct LoadedAgentDefinition: Sendable {
+    let definition: AgentDefinition
+    let systemPrompt: String?
+    let memory: String?
+    let workspaceId: UUID
+}

--- a/Dochi/Services/Context/AgentDefinitionLoader.swift
+++ b/Dochi/Services/Context/AgentDefinitionLoader.swift
@@ -1,0 +1,82 @@
+import Foundation
+import os
+
+// MARK: - AgentDefinitionLoader
+
+/// 파일시스템에서 에이전트 정의를 로드한다.
+/// system.md + config.json + memory.md를 통합하여 LoadedAgentDefinition을 반환.
+@MainActor
+final class AgentDefinitionLoader {
+
+    private let contextService: ContextServiceProtocol
+
+    init(contextService: ContextServiceProtocol) {
+        self.contextService = contextService
+    }
+
+    // MARK: - Load Single Agent
+
+    /// 특정 에이전트의 전체 정의를 로드한다.
+    func load(workspaceId: UUID, agentName: String) -> LoadedAgentDefinition? {
+        guard let definition = loadDefinition(workspaceId: workspaceId, agentName: agentName) else {
+            Log.app.debug("에이전트 정의 로드 실패: \(agentName)")
+            return nil
+        }
+
+        let systemPrompt = contextService.loadAgentPersona(workspaceId: workspaceId, agentName: agentName)
+        let memory = contextService.loadAgentMemory(workspaceId: workspaceId, agentName: agentName)
+
+        return LoadedAgentDefinition(
+            definition: definition,
+            systemPrompt: systemPrompt,
+            memory: memory,
+            workspaceId: workspaceId
+        )
+    }
+
+    // MARK: - Load All Agents in Workspace
+
+    /// 워크스페이스 내 모든 에이전트 정의를 로드한다.
+    func loadAll(workspaceId: UUID) -> [LoadedAgentDefinition] {
+        let agentNames = contextService.listAgents(workspaceId: workspaceId)
+        return agentNames.compactMap { load(workspaceId: workspaceId, agentName: $0) }
+    }
+
+    // MARK: - Load Definition Only
+
+    /// config.json에서 AgentDefinition을 로드한다.
+    /// v2 포맷 우선 시도, 실패 시 기존 AgentConfig에서 변환.
+    func loadDefinition(workspaceId: UUID, agentName: String) -> AgentDefinition? {
+        // v2: raw JSON에서 직접 AgentDefinition 디코딩
+        if let data = contextService.loadAgentConfigData(workspaceId: workspaceId, agentName: agentName) {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            if let definition = try? decoder.decode(AgentDefinition.self, from: data) {
+                return definition
+            }
+        }
+
+        // 레거시: AgentConfig에서 변환
+        if let config = contextService.loadAgentConfig(workspaceId: workspaceId, agentName: agentName) {
+            return AgentDefinition.from(config: config)
+        }
+
+        return nil
+    }
+
+    // MARK: - Save Definition
+
+    /// AgentDefinition을 config.json에 저장한다.
+    func save(workspaceId: UUID, definition: AgentDefinition) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(definition)
+
+        contextService.saveAgentConfigData(workspaceId: workspaceId, agentName: definition.name, data: data)
+
+        // 레거시 AgentConfig도 동기화 (기존 코드 호환)
+        let config = definition.toAgentConfig()
+        contextService.saveAgentConfig(workspaceId: workspaceId, config: config)
+    }
+}

--- a/Dochi/Services/Context/AgentDefinitionValidator.swift
+++ b/Dochi/Services/Context/AgentDefinitionValidator.swift
@@ -1,0 +1,146 @@
+import Foundation
+import os
+
+// MARK: - AgentDefinitionValidator
+
+/// AgentDefinition 필수 필드 검증, permissionProfile 유효성, toolGroups 존재 확인.
+@MainActor
+final class AgentDefinitionValidator {
+
+    /// 등록된 toolGroup 이름 (ToolRegistry에서 주입)
+    private let knownToolGroups: Set<String>
+
+    /// 등록된 에이전트 ID (중복 검사용)
+    private let existingAgentIds: Set<String>
+
+    init(knownToolGroups: Set<String> = [], existingAgentIds: Set<String> = []) {
+        self.knownToolGroups = knownToolGroups
+        self.existingAgentIds = existingAgentIds
+    }
+
+    // MARK: - Validate
+
+    /// 에이전트 정의를 검증하고 오류 목록을 반환한다.
+    func validate(_ definition: AgentDefinition) -> [AgentValidationError] {
+        var errors: [AgentValidationError] = []
+
+        // 1. 필수 필드
+        if definition.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors.append(.emptyName)
+        }
+
+        if definition.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors.append(.emptyId)
+        }
+
+        // 2. 이름 형식 (특수문자 제한)
+        if !definition.name.isEmpty && !isValidAgentName(definition.name) {
+            errors.append(.invalidNameFormat(definition.name))
+        }
+
+        // 3. permissionProfile 유효성
+        if let profile = definition.permissionProfile {
+            errors.append(contentsOf: validatePermissionProfile(profile))
+        }
+
+        // 4. toolGroups 존재 확인
+        if !knownToolGroups.isEmpty {
+            for group in definition.toolGroups {
+                let normalized = group.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                if !knownToolGroups.contains(normalized) {
+                    errors.append(.unknownToolGroup(normalized))
+                }
+            }
+        }
+
+        // 5. subagent 검증
+        for subagent in definition.subagents {
+            if subagent.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                errors.append(.subagentEmptyId)
+            }
+            if let profile = subagent.permissionProfile {
+                errors.append(contentsOf: validatePermissionProfile(profile))
+            }
+        }
+
+        // 6. version 유효성
+        if definition.version < 1 {
+            errors.append(.invalidVersion(definition.version))
+        }
+
+        // 7. wakeWord 중복/형식 검증
+        if let wakeWord = definition.wakeWord {
+            if wakeWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                errors.append(.emptyWakeWord)
+            }
+        }
+
+        // 8. memoryPolicy 검증
+        if let policy = definition.memoryPolicy {
+            if !policy.personalMemoryAccess && !policy.workspaceMemoryAccess && !policy.agentMemoryAccess {
+                errors.append(.noMemoryAccess)
+            }
+        }
+
+        return errors
+    }
+
+    /// 에이전트 정의가 유효한지 간단히 확인
+    func isValid(_ definition: AgentDefinition) -> Bool {
+        validate(definition).isEmpty
+    }
+
+    // MARK: - Private
+
+    private func isValidAgentName(_ name: String) -> Bool {
+        // 허용: 한글, 영문, 숫자, 공백, 하이픈, 언더스코어
+        let pattern = "^[\\p{L}\\p{N}\\s\\-_]+$"
+        return name.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    private func validatePermissionProfile(_ profile: PermissionProfile) -> [AgentValidationError] {
+        var errors: [AgentValidationError] = []
+
+        // restricted가 allow이면 보안 경고
+        if profile.restricted == .allow {
+            errors.append(.restrictedToolsAllowed)
+        }
+
+        // safe가 deny이면 에이전트가 아무것도 못함
+        if profile.safe == .deny {
+            errors.append(.safeToolsDenied)
+        }
+
+        return errors
+    }
+}
+
+// MARK: - AgentValidationError
+
+enum AgentValidationError: LocalizedError, Equatable, Sendable {
+    case emptyName
+    case emptyId
+    case invalidNameFormat(String)
+    case unknownToolGroup(String)
+    case subagentEmptyId
+    case invalidVersion(Int)
+    case emptyWakeWord
+    case noMemoryAccess
+    case restrictedToolsAllowed
+    case safeToolsDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyName: return "에이전트 이름이 비어있습니다."
+        case .emptyId: return "에이전트 ID가 비어있습니다."
+        case .invalidNameFormat(let name): return "에이전트 이름 형식이 유효하지 않습니다: '\(name)'"
+        case .unknownToolGroup(let group): return "등록되지 않은 toolGroup: '\(group)'"
+        case .subagentEmptyId: return "서브에이전트 ID가 비어있습니다."
+        case .invalidVersion(let v): return "유효하지 않은 버전: \(v) (1 이상이어야 합니다)"
+        case .emptyWakeWord: return "wakeWord가 비어있습니다."
+        case .noMemoryAccess: return "모든 메모리 접근이 비활성화되어 있습니다."
+        case .restrictedToolsAllowed: return "restricted 도구가 무조건 허용 상태입니다. 보안에 주의하세요."
+        case .safeToolsDenied: return "safe 도구가 거부 상태이면 에이전트가 동작할 수 없습니다."
+        }
+    }
+}

--- a/Dochi/Services/Context/ContextService.swift
+++ b/Dochi/Services/Context/ContextService.swift
@@ -272,6 +272,22 @@ final class ContextService: ContextServiceProtocol {
         }
     }
 
+    func loadAgentConfigData(workspaceId: UUID, agentName: String) -> Data? {
+        let url = agentURL(workspaceId: workspaceId, agentName: agentName).appendingPathComponent("config.json")
+        return try? Data(contentsOf: url)
+    }
+
+    func saveAgentConfigData(workspaceId: UUID, agentName: String, data: Data) {
+        let dir = agentURL(workspaceId: workspaceId, agentName: agentName)
+        let url = dir.appendingPathComponent("config.json")
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            Log.storage.error("에이전트 config 데이터 저장 실패: \(error.localizedDescription)")
+        }
+    }
+
     func listAgents(workspaceId: UUID) -> [String] {
         let agentsDir = workspaceURL(workspaceId).appendingPathComponent("agents")
         guard let contents = try? FileManager.default.contentsOfDirectory(atPath: agentsDir.path) else { return [] }

--- a/Dochi/Services/Context/WakeWordRouter.swift
+++ b/Dochi/Services/Context/WakeWordRouter.swift
@@ -1,0 +1,191 @@
+import Foundation
+import os
+
+// MARK: - WakeWordRouter
+
+/// 입력 텍스트에서 wakeWord를 매칭하여 workspace + agent를 확정한다.
+@MainActor
+final class WakeWordRouter {
+
+    private let contextService: ContextServiceProtocol
+    private let loader: AgentDefinitionLoader
+
+    init(contextService: ContextServiceProtocol) {
+        self.contextService = contextService
+        self.loader = AgentDefinitionLoader(contextService: contextService)
+    }
+
+    // MARK: - Route
+
+    /// 입력 텍스트를 분석하여 라우팅 결정을 반환한다.
+    func route(
+        input: String,
+        availableWorkspaces: [UUID],
+        currentWorkspaceId: UUID,
+        currentAgentName: String
+    ) -> RoutingDecision {
+        let trimmedInput = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedInput.isEmpty else {
+            return RoutingDecision(
+                workspaceId: currentWorkspaceId,
+                agentName: currentAgentName,
+                matchedWakeWord: nil,
+                confidence: 1.0,
+                reason: .currentDefault
+            )
+        }
+
+        // 모든 워크스페이스에서 에이전트 로드
+        var allAgents: [(UUID, AgentDefinition)] = []
+        for wsId in availableWorkspaces {
+            let loaded = loader.loadAll(workspaceId: wsId)
+            for agent in loaded {
+                allAgents.append((wsId, agent.definition))
+            }
+        }
+
+        // wakeWord 매칭
+        let inputLower = trimmedInput.lowercased()
+        var bestMatch: (UUID, AgentDefinition, String, MatchType)?
+        var bestScore = 0
+
+        for (wsId, definition) in allAgents {
+            guard let wakeWord = definition.wakeWord, !wakeWord.isEmpty else { continue }
+            let wakeWordLower = wakeWord.lowercased()
+
+            // 접두사 매칭
+            if inputLower.hasPrefix(wakeWordLower) {
+                let score = wakeWordLower.count * 2  // 접두사 매칭은 가중치 2배
+                if score > bestScore {
+                    bestScore = score
+                    bestMatch = (wsId, definition, wakeWord, .prefix)
+                }
+            }
+            // 포함 매칭
+            else if inputLower.contains(wakeWordLower) {
+                let score = wakeWordLower.count
+                if score > bestScore {
+                    bestScore = score
+                    bestMatch = (wsId, definition, wakeWord, .contains)
+                }
+            }
+        }
+
+        if let (wsId, definition, wakeWord, matchType) = bestMatch {
+            let confidence: Double = matchType == .prefix ? 0.95 : 0.7
+            Log.app.info("wakeWord 라우팅: '\(wakeWord)' → \(definition.name) (\(matchType))")
+
+            return RoutingDecision(
+                workspaceId: wsId,
+                agentName: definition.name,
+                matchedWakeWord: wakeWord,
+                confidence: confidence,
+                reason: matchType == .prefix ? .wakeWordPrefix : .wakeWordContains
+            )
+        }
+
+        // 매칭 없음: 현재 에이전트 유지
+        return RoutingDecision(
+            workspaceId: currentWorkspaceId,
+            agentName: currentAgentName,
+            matchedWakeWord: nil,
+            confidence: 1.0,
+            reason: .currentDefault
+        )
+    }
+
+    // MARK: - Quick Match (no workspace scan)
+
+    /// 사전에 로드된 에이전트 목록에서 wakeWord 매칭만 수행.
+    func quickMatch(
+        input: String,
+        agents: [(workspaceId: UUID, definition: AgentDefinition)]
+    ) -> RoutingDecision? {
+        let inputLower = input.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !inputLower.isEmpty else { return nil }
+
+        var bestMatch: (UUID, AgentDefinition, String, MatchType)?
+        var bestScore = 0
+
+        for (wsId, definition) in agents {
+            guard let wakeWord = definition.wakeWord, !wakeWord.isEmpty else { continue }
+            let wakeWordLower = wakeWord.lowercased()
+
+            if inputLower.hasPrefix(wakeWordLower) {
+                let score = wakeWordLower.count * 2
+                if score > bestScore {
+                    bestScore = score
+                    bestMatch = (wsId, definition, wakeWord, .prefix)
+                }
+            } else if inputLower.contains(wakeWordLower) {
+                let score = wakeWordLower.count
+                if score > bestScore {
+                    bestScore = score
+                    bestMatch = (wsId, definition, wakeWord, .contains)
+                }
+            }
+        }
+
+        guard let (wsId, definition, wakeWord, matchType) = bestMatch else { return nil }
+
+        return RoutingDecision(
+            workspaceId: wsId,
+            agentName: definition.name,
+            matchedWakeWord: wakeWord,
+            confidence: matchType == .prefix ? 0.95 : 0.7,
+            reason: matchType == .prefix ? .wakeWordPrefix : .wakeWordContains
+        )
+    }
+
+    private enum MatchType: CustomStringConvertible {
+        case prefix, contains
+
+        var description: String {
+            switch self {
+            case .prefix: return "prefix"
+            case .contains: return "contains"
+            }
+        }
+    }
+}
+
+// MARK: - RoutingDecision
+
+/// wakeWord 라우팅 결과
+struct RoutingDecision: Sendable, Equatable {
+    let workspaceId: UUID
+    let agentName: String
+    let matchedWakeWord: String?
+    let confidence: Double
+    let reason: RoutingReason
+    let timestamp: Date
+
+    init(
+        workspaceId: UUID,
+        agentName: String,
+        matchedWakeWord: String? = nil,
+        confidence: Double = 1.0,
+        reason: RoutingReason = .currentDefault,
+        timestamp: Date = Date()
+    ) {
+        self.workspaceId = workspaceId
+        self.agentName = agentName
+        self.matchedWakeWord = matchedWakeWord
+        self.confidence = confidence
+        self.reason = reason
+        self.timestamp = timestamp
+    }
+
+    var isWakeWordMatch: Bool {
+        matchedWakeWord != nil
+    }
+}
+
+// MARK: - RoutingReason
+
+enum RoutingReason: String, Codable, Sendable {
+    case wakeWordPrefix
+    case wakeWordContains
+    case currentDefault
+    case explicit
+}

--- a/Dochi/Services/Protocols/ContextServiceProtocol.swift
+++ b/Dochi/Services/Protocols/ContextServiceProtocol.swift
@@ -42,6 +42,8 @@ protocol ContextServiceProtocol {
     // Agent config
     func loadAgentConfig(workspaceId: UUID, agentName: String) -> AgentConfig?
     func saveAgentConfig(workspaceId: UUID, config: AgentConfig)
+    func loadAgentConfigData(workspaceId: UUID, agentName: String) -> Data?
+    func saveAgentConfigData(workspaceId: UUID, agentName: String, data: Data)
     func listAgents(workspaceId: UUID) -> [String]
     func createAgent(workspaceId: UUID, name: String, wakeWord: String?, description: String?)
 
@@ -90,4 +92,8 @@ extension ContextServiceProtocol {
     func saveProjectMemory(workspaceId: UUID, projectId: String, content: String) {}
 
     func appendProjectMemory(workspaceId: UUID, projectId: String, content: String) {}
+
+    func loadAgentConfigData(workspaceId: UUID, agentName: String) -> Data? { nil }
+
+    func saveAgentConfigData(workspaceId: UUID, agentName: String, data: Data) {}
 }

--- a/DochiTests/AgentDefinitionTests.swift
+++ b/DochiTests/AgentDefinitionTests.swift
@@ -1,0 +1,722 @@
+import XCTest
+@testable import Dochi
+
+final class AgentDefinitionTests: XCTestCase {
+
+    // MARK: - Model Codable Tests
+
+    func testAgentDefinitionEncodeDecode() throws {
+        let definition = AgentDefinition(
+            id: "assistant-1",
+            name: "도치",
+            wakeWord: "도치야",
+            description: "가정 비서",
+            defaultModel: "claude-sonnet-4-6",
+            permissionProfile: .default,
+            toolGroups: ["calendar", "reminders", "memory"],
+            subagents: [
+                SubagentDefinition(id: "planner", name: "플래너", toolGroups: ["calendar"])
+            ],
+            memoryPolicy: .default,
+            version: 3,
+            updatedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(definition)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(AgentDefinition.self, from: data)
+
+        XCTAssertEqual(decoded.id, "assistant-1")
+        XCTAssertEqual(decoded.name, "도치")
+        XCTAssertEqual(decoded.wakeWord, "도치야")
+        XCTAssertEqual(decoded.description, "가정 비서")
+        XCTAssertEqual(decoded.defaultModel, "claude-sonnet-4-6")
+        XCTAssertEqual(decoded.toolGroups, ["calendar", "reminders", "memory"])
+        XCTAssertEqual(decoded.subagents.count, 1)
+        XCTAssertEqual(decoded.subagents.first?.id, "planner")
+        XCTAssertEqual(decoded.memoryPolicy, .default)
+        XCTAssertEqual(decoded.version, 3)
+    }
+
+    func testAgentDefinitionBackwardCompatibility() throws {
+        // 기존 AgentConfig JSON 형식 → AgentDefinition 디코딩
+        let legacyJSON = """
+        {
+            "name": "도치",
+            "wakeWord": "도치야",
+            "description": "가정 비서",
+            "defaultModel": "gpt-4o",
+            "permissions": ["safe", "sensitive"],
+            "preferredToolGroups": ["calendar", "reminders"]
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let definition = try decoder.decode(AgentDefinition.self, from: legacyJSON)
+
+        XCTAssertEqual(definition.name, "도치")
+        XCTAssertEqual(definition.id, "도치") // name에서 생성
+        XCTAssertEqual(definition.wakeWord, "도치야")
+        XCTAssertEqual(definition.toolGroups, ["calendar", "reminders"]) // preferredToolGroups에서 변환
+        XCTAssertEqual(definition.permissions, ["safe", "sensitive"])
+        XCTAssertEqual(definition.version, 1) // 기본값
+        XCTAssertTrue(definition.subagents.isEmpty) // 기본값
+    }
+
+    func testAgentDefinitionMinimalJSON() throws {
+        let minimalJSON = """
+        { "name": "테스트" }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let definition = try decoder.decode(AgentDefinition.self, from: minimalJSON)
+
+        XCTAssertEqual(definition.name, "테스트")
+        XCTAssertEqual(definition.id, "테스트")
+        XCTAssertEqual(definition.version, 1)
+        XCTAssertTrue(definition.toolGroups.isEmpty)
+        XCTAssertTrue(definition.subagents.isEmpty)
+        XCTAssertNil(definition.permissionProfile)
+        XCTAssertNil(definition.memoryPolicy)
+    }
+
+    func testPermissionProfileEncodeDecode() throws {
+        let profile = PermissionProfile(safe: .allow, sensitive: .confirm, restricted: .deny)
+        let data = try JSONEncoder().encode(profile)
+        let decoded = try JSONDecoder().decode(PermissionProfile.self, from: data)
+
+        XCTAssertEqual(decoded.safe, .allow)
+        XCTAssertEqual(decoded.sensitive, .confirm)
+        XCTAssertEqual(decoded.restricted, .deny)
+    }
+
+    func testSubagentDefinitionEncodeDecode() throws {
+        let subagent = SubagentDefinition(
+            id: "reviewer",
+            name: "리뷰어",
+            description: "코드 리뷰 전용",
+            toolGroups: ["code"],
+            permissionProfile: .minimal
+        )
+
+        let data = try JSONEncoder().encode(subagent)
+        let decoded = try JSONDecoder().decode(SubagentDefinition.self, from: data)
+
+        XCTAssertEqual(decoded.id, "reviewer")
+        XCTAssertEqual(decoded.name, "리뷰어")
+        XCTAssertEqual(decoded.toolGroups, ["code"])
+        XCTAssertEqual(decoded.permissionProfile?.safe, .allow)
+        XCTAssertEqual(decoded.permissionProfile?.restricted, .deny)
+    }
+
+    func testMemoryPolicyEncodeDecode() throws {
+        let policy = MemoryPolicy(
+            personalMemoryAccess: false,
+            workspaceMemoryAccess: true,
+            agentMemoryAccess: true,
+            autoExtractEnabled: false
+        )
+
+        let data = try JSONEncoder().encode(policy)
+        let decoded = try JSONDecoder().decode(MemoryPolicy.self, from: data)
+
+        XCTAssertFalse(decoded.personalMemoryAccess)
+        XCTAssertTrue(decoded.workspaceMemoryAccess)
+        XCTAssertFalse(decoded.autoExtractEnabled)
+    }
+
+    func testMemoryPolicyDefaults() {
+        XCTAssertTrue(MemoryPolicy.default.personalMemoryAccess)
+        XCTAssertTrue(MemoryPolicy.default.autoExtractEnabled)
+        XCTAssertFalse(MemoryPolicy.subagentDefault.personalMemoryAccess)
+        XCTAssertFalse(MemoryPolicy.subagentDefault.autoExtractEnabled)
+    }
+
+    // MARK: - Conversion Tests
+
+    func testToAgentConfig() {
+        let definition = AgentDefinition(
+            name: "도치",
+            wakeWord: "도치야",
+            description: "가정 비서",
+            defaultModel: "gpt-4o",
+            toolGroups: ["calendar", "memory"],
+            permissions: ["safe"]
+        )
+
+        let config = definition.toAgentConfig()
+        XCTAssertEqual(config.name, "도치")
+        XCTAssertEqual(config.wakeWord, "도치야")
+        XCTAssertEqual(config.description, "가정 비서")
+        XCTAssertEqual(config.defaultModel, "gpt-4o")
+        XCTAssertEqual(config.preferredToolGroups, ["calendar", "memory"])
+        XCTAssertEqual(config.permissions, ["safe"])
+    }
+
+    func testFromAgentConfig() {
+        let config = AgentConfig(
+            name: "보조",
+            wakeWord: "보조야",
+            description: "보조 에이전트",
+            permissions: ["safe", "sensitive"],
+            preferredToolGroups: ["calendar"]
+        )
+
+        let definition = AgentDefinition.from(config: config)
+        XCTAssertEqual(definition.name, "보조")
+        XCTAssertEqual(definition.id, "보조")
+        XCTAssertEqual(definition.wakeWord, "보조야")
+        XCTAssertEqual(definition.toolGroups, ["calendar"])
+        XCTAssertEqual(definition.permissions, ["safe", "sensitive"])
+        XCTAssertEqual(definition.version, 1)
+    }
+
+    func testEffectivePermissionProfile() {
+        // v2 profile이 있으면 그것을 사용
+        let withProfile = AgentDefinition(
+            name: "test",
+            permissionProfile: .minimal
+        )
+        XCTAssertEqual(withProfile.effectivePermissionProfile.restricted, .deny)
+
+        // v2 profile이 없으면 레거시 permissions에서 변환
+        let withLegacy = AgentDefinition(
+            name: "test",
+            permissions: ["safe"]
+        )
+        XCTAssertEqual(withLegacy.effectivePermissionProfile.safe, .allow)
+        XCTAssertEqual(withLegacy.effectivePermissionProfile.sensitive, .deny)
+        XCTAssertEqual(withLegacy.effectivePermissionProfile.restricted, .deny)
+    }
+
+    func testEffectiveToolGroups() {
+        let definition = AgentDefinition(
+            name: "test",
+            toolGroups: ["Calendar", " memory ", "CALENDAR", ""]
+        )
+        let effective = definition.effectiveToolGroups
+        XCTAssertEqual(effective, ["calendar", "memory"]) // 정규화 + 중복 제거
+    }
+
+    func testIncrementedVersion() {
+        let definition = AgentDefinition(name: "test", version: 2)
+        let incremented = definition.incrementedVersion()
+        XCTAssertEqual(incremented.version, 3)
+        XCTAssertGreaterThanOrEqual(incremented.updatedAt, definition.updatedAt)
+    }
+
+    // MARK: - AgentDefinitionValidator Tests
+
+    @MainActor
+    func testValidatorAcceptsValidDefinition() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(
+            name: "도치",
+            wakeWord: "도치야",
+            toolGroups: ["calendar"],
+            version: 1
+        )
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.isEmpty, "Errors: \(errors)")
+    }
+
+    @MainActor
+    func testValidatorRejectsEmptyName() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(id: "test", name: "")
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.emptyName))
+    }
+
+    @MainActor
+    func testValidatorRejectsEmptyId() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(id: "", name: "test")
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.emptyId))
+    }
+
+    @MainActor
+    func testValidatorRejectsInvalidNameFormat() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(name: "agent@#$!")
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(where: {
+            if case .invalidNameFormat = $0 { return true }
+            return false
+        }))
+    }
+
+    @MainActor
+    func testValidatorAcceptsKoreanName() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(name: "도치 비서-1")
+        let errors = validator.validate(definition)
+        XCTAssertFalse(errors.contains(where: {
+            if case .invalidNameFormat = $0 { return true }
+            return false
+        }))
+    }
+
+    @MainActor
+    func testValidatorWarnsRestrictedAllowed() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(
+            name: "test",
+            permissionProfile: PermissionProfile(safe: .allow, sensitive: .allow, restricted: .allow)
+        )
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.restrictedToolsAllowed))
+    }
+
+    @MainActor
+    func testValidatorWarnsSafeDenied() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(
+            name: "test",
+            permissionProfile: PermissionProfile(safe: .deny, sensitive: .deny, restricted: .deny)
+        )
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.safeToolsDenied))
+    }
+
+    @MainActor
+    func testValidatorChecksUnknownToolGroups() {
+        let validator = AgentDefinitionValidator(knownToolGroups: ["calendar", "memory", "reminders"])
+        let definition = AgentDefinition(
+            name: "test",
+            toolGroups: ["calendar", "nonexistent"]
+        )
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.unknownToolGroup("nonexistent")))
+    }
+
+    @MainActor
+    func testValidatorAcceptsKnownToolGroups() {
+        let validator = AgentDefinitionValidator(knownToolGroups: ["calendar", "memory"])
+        let definition = AgentDefinition(
+            name: "test",
+            toolGroups: ["calendar", "memory"]
+        )
+        let errors = validator.validate(definition)
+        XCTAssertFalse(errors.contains(where: {
+            if case .unknownToolGroup = $0 { return true }
+            return false
+        }))
+    }
+
+    @MainActor
+    func testValidatorChecksSubagentEmptyId() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(
+            name: "test",
+            subagents: [SubagentDefinition(id: "")]
+        )
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.subagentEmptyId))
+    }
+
+    @MainActor
+    func testValidatorChecksInvalidVersion() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(name: "test", version: 0)
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.invalidVersion(0)))
+    }
+
+    @MainActor
+    func testValidatorChecksEmptyWakeWord() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(name: "test", wakeWord: "  ")
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.emptyWakeWord))
+    }
+
+    @MainActor
+    func testValidatorChecksNoMemoryAccess() {
+        let validator = AgentDefinitionValidator()
+        let definition = AgentDefinition(
+            name: "test",
+            memoryPolicy: MemoryPolicy(
+                personalMemoryAccess: false,
+                workspaceMemoryAccess: false,
+                agentMemoryAccess: false
+            )
+        )
+        let errors = validator.validate(definition)
+        XCTAssertTrue(errors.contains(.noMemoryAccess))
+    }
+
+    @MainActor
+    func testIsValidConvenience() {
+        let validator = AgentDefinitionValidator()
+        let valid = AgentDefinition(name: "도치")
+        XCTAssertTrue(validator.isValid(valid))
+
+        let invalid = AgentDefinition(id: "", name: "")
+        XCTAssertFalse(validator.isValid(invalid))
+    }
+
+    // MARK: - AgentDefinitionLoader Tests
+
+    @MainActor
+    func testLoaderLoadDefinitionFromV2Data() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "도치", wakeWord: "도치야", description: "가정 비서")
+
+        // v2 데이터 저장
+        let v2 = AgentDefinition(
+            id: "agent-v2",
+            name: "도치",
+            wakeWord: "도치야",
+            description: "가정 비서 v2",
+            toolGroups: ["calendar", "memory"],
+            version: 2,
+            updatedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try! encoder.encode(v2)
+        ctx.saveAgentConfigData(workspaceId: wsId, agentName: "도치", data: data)
+
+        let loader = AgentDefinitionLoader(contextService: ctx)
+        let loaded = loader.loadDefinition(workspaceId: wsId, agentName: "도치")
+
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.id, "agent-v2")
+        XCTAssertEqual(loaded?.version, 2)
+        XCTAssertEqual(loaded?.toolGroups, ["calendar", "memory"])
+    }
+
+    @MainActor
+    func testLoaderFallbackToLegacyConfig() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "보조", wakeWord: "보조야", description: "보조 에이전트")
+
+        let loader = AgentDefinitionLoader(contextService: ctx)
+        let loaded = loader.loadDefinition(workspaceId: wsId, agentName: "보조")
+
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.name, "보조")
+        XCTAssertEqual(loaded?.id, "보조") // name에서 자동 생성
+        XCTAssertEqual(loaded?.version, 1)
+    }
+
+    @MainActor
+    func testLoaderLoadFull() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "도치", wakeWord: "도치야", description: nil)
+        ctx.saveAgentPersona(workspaceId: wsId, agentName: "도치", content: "You are a helpful assistant.")
+        ctx.saveAgentMemory(workspaceId: wsId, agentName: "도치", content: "- 사용자가 커피를 좋아함")
+
+        let loader = AgentDefinitionLoader(contextService: ctx)
+        let loaded = loader.load(workspaceId: wsId, agentName: "도치")
+
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.definition.name, "도치")
+        XCTAssertEqual(loaded?.systemPrompt, "You are a helpful assistant.")
+        XCTAssertEqual(loaded?.memory, "- 사용자가 커피를 좋아함")
+        XCTAssertEqual(loaded?.workspaceId, wsId)
+    }
+
+    @MainActor
+    func testLoaderLoadAll() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "도치", wakeWord: "도치야", description: nil)
+        ctx.createAgent(workspaceId: wsId, name: "번역기", wakeWord: "번역해줘", description: nil)
+
+        let loader = AgentDefinitionLoader(contextService: ctx)
+        let all = loader.loadAll(workspaceId: wsId)
+
+        XCTAssertEqual(all.count, 2)
+    }
+
+    @MainActor
+    func testLoaderLoadNonexistent() {
+        let ctx = MockContextService()
+        let loader = AgentDefinitionLoader(contextService: ctx)
+        let loaded = loader.load(workspaceId: UUID(), agentName: "없는에이전트")
+        XCTAssertNil(loaded)
+    }
+
+    @MainActor
+    func testLoaderSaveAndReload() throws {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createLocalWorkspace(id: wsId)
+        ctx.agents[wsId] = ["도치"]
+
+        let definition = AgentDefinition(
+            id: "dochi-1",
+            name: "도치",
+            wakeWord: "도치야",
+            toolGroups: ["calendar"],
+            version: 2,
+            updatedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+
+        let loader = AgentDefinitionLoader(contextService: ctx)
+        try loader.save(workspaceId: wsId, definition: definition)
+
+        // Reload
+        let reloaded = loader.loadDefinition(workspaceId: wsId, agentName: "도치")
+        XCTAssertNotNil(reloaded)
+        XCTAssertEqual(reloaded?.id, "dochi-1")
+        XCTAssertEqual(reloaded?.version, 2)
+        XCTAssertEqual(reloaded?.toolGroups, ["calendar"])
+
+        // Legacy config도 동기화 확인
+        let legacyConfig = ctx.loadAgentConfig(workspaceId: wsId, agentName: "도치")
+        XCTAssertNotNil(legacyConfig)
+        XCTAssertEqual(legacyConfig?.name, "도치")
+    }
+
+    // MARK: - WakeWordRouter Tests
+
+    @MainActor
+    func testWakeWordRoutingPrefixMatch() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "도치", wakeWord: "도치야", description: nil)
+
+        let router = WakeWordRouter(contextService: ctx)
+        let decision = router.route(
+            input: "도치야 오늘 일정 알려줘",
+            availableWorkspaces: [wsId],
+            currentWorkspaceId: wsId,
+            currentAgentName: "기본"
+        )
+
+        XCTAssertEqual(decision.agentName, "도치")
+        XCTAssertEqual(decision.matchedWakeWord, "도치야")
+        XCTAssertEqual(decision.reason, .wakeWordPrefix)
+        XCTAssertGreaterThan(decision.confidence, 0.9)
+    }
+
+    @MainActor
+    func testWakeWordRoutingContainsMatch() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "도치", wakeWord: "도치야", description: nil)
+
+        let router = WakeWordRouter(contextService: ctx)
+        let decision = router.route(
+            input: "오늘 도치야 일정 알려줘",
+            availableWorkspaces: [wsId],
+            currentWorkspaceId: wsId,
+            currentAgentName: "기본"
+        )
+
+        XCTAssertEqual(decision.agentName, "도치")
+        XCTAssertEqual(decision.matchedWakeWord, "도치야")
+        XCTAssertEqual(decision.reason, .wakeWordContains)
+        XCTAssertLessThan(decision.confidence, 0.9)
+    }
+
+    @MainActor
+    func testWakeWordRoutingNoMatch() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "도치", wakeWord: "도치야", description: nil)
+
+        let router = WakeWordRouter(contextService: ctx)
+        let decision = router.route(
+            input: "오늘 날씨 어때",
+            availableWorkspaces: [wsId],
+            currentWorkspaceId: wsId,
+            currentAgentName: "기본"
+        )
+
+        XCTAssertEqual(decision.agentName, "기본")
+        XCTAssertNil(decision.matchedWakeWord)
+        XCTAssertEqual(decision.reason, .currentDefault)
+    }
+
+    @MainActor
+    func testWakeWordRoutingEmptyInput() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+
+        let router = WakeWordRouter(contextService: ctx)
+        let decision = router.route(
+            input: "",
+            availableWorkspaces: [wsId],
+            currentWorkspaceId: wsId,
+            currentAgentName: "기본"
+        )
+
+        XCTAssertEqual(decision.agentName, "기본")
+        XCTAssertEqual(decision.reason, .currentDefault)
+    }
+
+    @MainActor
+    func testWakeWordRoutingLongestMatch() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "도치", wakeWord: "도치", description: nil)
+        ctx.createAgent(workspaceId: wsId, name: "도치비서", wakeWord: "도치비서야", description: nil)
+
+        let router = WakeWordRouter(contextService: ctx)
+        let decision = router.route(
+            input: "도치비서야 오늘 일정",
+            availableWorkspaces: [wsId],
+            currentWorkspaceId: wsId,
+            currentAgentName: "기본"
+        )
+
+        // 더 긴 wakeWord가 우선
+        XCTAssertEqual(decision.agentName, "도치비서")
+    }
+
+    @MainActor
+    func testWakeWordRoutingCaseInsensitive() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.createAgent(workspaceId: wsId, name: "CodeBot", wakeWord: "CodeBot", description: nil)
+
+        let router = WakeWordRouter(contextService: ctx)
+        let decision = router.route(
+            input: "codebot help me",
+            availableWorkspaces: [wsId],
+            currentWorkspaceId: wsId,
+            currentAgentName: "기본"
+        )
+
+        XCTAssertEqual(decision.agentName, "CodeBot")
+    }
+
+    @MainActor
+    func testWakeWordRoutingCrossWorkspace() {
+        let ctx = MockContextService()
+        let ws1 = UUID()
+        let ws2 = UUID()
+        ctx.createAgent(workspaceId: ws1, name: "도치", wakeWord: "도치야", description: nil)
+        ctx.createAgent(workspaceId: ws2, name: "번역기", wakeWord: "번역해줘", description: nil)
+
+        let router = WakeWordRouter(contextService: ctx)
+        let decision = router.route(
+            input: "번역해줘 이 문장",
+            availableWorkspaces: [ws1, ws2],
+            currentWorkspaceId: ws1,
+            currentAgentName: "도치"
+        )
+
+        XCTAssertEqual(decision.agentName, "번역기")
+        XCTAssertEqual(decision.workspaceId, ws2)
+    }
+
+    @MainActor
+    func testQuickMatchWithPreloadedAgents() {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        let router = WakeWordRouter(contextService: ctx)
+
+        let agents: [(workspaceId: UUID, definition: AgentDefinition)] = [
+            (wsId, AgentDefinition(name: "도치", wakeWord: "도치야")),
+            (wsId, AgentDefinition(name: "번역기", wakeWord: "번역해줘")),
+        ]
+
+        let decision = router.quickMatch(input: "도치야 안녕", agents: agents)
+        XCTAssertNotNil(decision)
+        XCTAssertEqual(decision?.agentName, "도치")
+
+        let noMatch = router.quickMatch(input: "안녕하세요", agents: agents)
+        XCTAssertNil(noMatch)
+    }
+
+    // MARK: - Version Tests
+
+    @MainActor
+    func testVersionChangeAppliesOnNewSession() throws {
+        let ctx = MockContextService()
+        let wsId = UUID()
+        ctx.agents[wsId] = ["도치"]
+
+        let loader = AgentDefinitionLoader(contextService: ctx)
+
+        // Save v1
+        let v1 = AgentDefinition(
+            id: "dochi",
+            name: "도치",
+            toolGroups: ["calendar"],
+            version: 1,
+            updatedAt: Date(timeIntervalSince1970: 1700000000)
+        )
+        try loader.save(workspaceId: wsId, definition: v1)
+
+        // Simulate "session starts" - load v1
+        let sessionSnapshot = loader.loadDefinition(workspaceId: wsId, agentName: "도치")
+        XCTAssertEqual(sessionSnapshot?.version, 1)
+        XCTAssertEqual(sessionSnapshot?.toolGroups, ["calendar"])
+
+        // Agent is updated to v2 while session is running
+        let v2 = v1.incrementedVersion()
+        var updated = v2
+        updated.toolGroups = ["calendar", "memory"]
+        try loader.save(workspaceId: wsId, definition: updated)
+
+        // Session snapshot stays at v1 (session pins version at start)
+        XCTAssertEqual(sessionSnapshot?.version, 1)
+        XCTAssertEqual(sessionSnapshot?.toolGroups, ["calendar"])
+
+        // New session loads v2
+        let newSession = loader.loadDefinition(workspaceId: wsId, agentName: "도치")
+        XCTAssertEqual(newSession?.version, 2)
+        XCTAssertEqual(newSession?.toolGroups, ["calendar", "memory"])
+    }
+
+    // MARK: - RoutingDecision Tests
+
+    func testRoutingDecisionIsWakeWordMatch() {
+        let wsId = UUID()
+        let withMatch = RoutingDecision(
+            workspaceId: wsId,
+            agentName: "도치",
+            matchedWakeWord: "도치야",
+            reason: .wakeWordPrefix
+        )
+        XCTAssertTrue(withMatch.isWakeWordMatch)
+
+        let noMatch = RoutingDecision(
+            workspaceId: wsId,
+            agentName: "기본",
+            reason: .currentDefault
+        )
+        XCTAssertFalse(noMatch.isWakeWordMatch)
+    }
+
+    func testRoutingReasonRawValues() {
+        XCTAssertEqual(RoutingReason.wakeWordPrefix.rawValue, "wakeWordPrefix")
+        XCTAssertEqual(RoutingReason.wakeWordContains.rawValue, "wakeWordContains")
+        XCTAssertEqual(RoutingReason.currentDefault.rawValue, "currentDefault")
+        XCTAssertEqual(RoutingReason.explicit.rawValue, "explicit")
+    }
+
+    // MARK: - LoadedAgentDefinition Tests
+
+    func testLoadedAgentDefinitionFields() {
+        let wsId = UUID()
+        let definition = AgentDefinition(name: "도치")
+        let loaded = LoadedAgentDefinition(
+            definition: definition,
+            systemPrompt: "You are helpful.",
+            memory: "- fact1",
+            workspaceId: wsId
+        )
+
+        XCTAssertEqual(loaded.definition.name, "도치")
+        XCTAssertEqual(loaded.systemPrompt, "You are helpful.")
+        XCTAssertEqual(loaded.memory, "- fact1")
+        XCTAssertEqual(loaded.workspaceId, wsId)
+    }
+}

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -79,6 +79,7 @@ final class MockContextService: ContextServiceProtocol {
     var agentPersonas: [String: String] = [:]
     var agentMemories: [String: String] = [:]
     var agentConfigs: [String: AgentConfig] = [:]
+    var agentConfigDataStore: [String: Data] = [:]
     var agents: [UUID: [String]] = [:]
     var migrateCallCount = 0
     var workspaceMemorySnapshots: [UUID: String] = [:]
@@ -169,6 +170,12 @@ final class MockContextService: ContextServiceProtocol {
     }
     func saveAgentConfig(workspaceId: UUID, config: AgentConfig) {
         agentConfigs[agentKey(workspaceId, config.name)] = config
+    }
+    func loadAgentConfigData(workspaceId: UUID, agentName: String) -> Data? {
+        agentConfigDataStore[agentKey(workspaceId, agentName)]
+    }
+    func saveAgentConfigData(workspaceId: UUID, agentName: String, data: Data) {
+        agentConfigDataStore[agentKey(workspaceId, agentName)] = data
     }
     func listAgents(workspaceId: UUID) -> [String] {
         agents[workspaceId] ?? []


### PR DESCRIPTION
## Summary
- **AgentDefinition v2 model**: id, name, wakeWord, permissionProfile, toolGroups, subagents, memoryPolicy, version, updatedAt — backward compatible with AgentConfig
- **AgentDefinitionLoader**: Loads system.md + config.json + memory.md; v2 preferred with legacy fallback
- **AgentDefinitionValidator**: Required fields, permissionProfile safety, toolGroup existence, subagent IDs
- **WakeWordRouter**: wakeWord matching (prefix/contains) → workspace + agent resolution, cross-workspace
- **PermissionProfile/SubagentDefinition/MemoryPolicy**: Structured agent policy models
- **Version management**: session pins version at start, incrementedVersion()
- **ContextServiceProtocol**: loadAgentConfigData/saveAgentConfigData for raw JSON

## Test plan
- [x] 44 unit tests all passing
- [x] Codable roundtrip (v2, legacy backward compat, minimal JSON)
- [x] Validator: name/id, format, permissions, toolGroups, subagent, version, wakeWord, memory policy
- [x] Loader: v2 data, legacy fallback, full load, save/reload roundtrip
- [x] WakeWordRouter: prefix/contains/no match, case-insensitive, cross-workspace, longest match
- [x] Version change applies on new session only

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)