### PR TITLE
fix: address PR #316 review — remove duplicate deploy gate, fix privacy logging

### DIFF
--- a/Dochi/Services/Observability/AuditLogRetention.swift
+++ b/Dochi/Services/Observability/AuditLogRetention.swift
@@ -97,7 +97,7 @@ final class DiagnosticLogManager {
             entries.removeFirst(entries.count - Self.maxEntries)
         }
 
-        Log.runtime.debug("Diagnostic [\(level.rawValue, privacy: .public)] session=\(sessionId, privacy: .public): \(message, privacy: .public)")
+        Log.runtime.debug("Diagnostic [\(level.rawValue, privacy: .public)] session=\(sessionId, privacy: .public): \(message, privacy: .private)")
     }
 
     // MARK: - Query

--- a/Dochi/Services/Observability/DeployGate.swift
+++ b/Dochi/Services/Observability/DeployGate.swift
@@ -50,7 +50,7 @@ struct DeployGateReport: Sendable, Codable {
 // MARK: - DeployGate
 
 /// 배포 게이트 — 모든 체크 항목 통과 여부를 평가하여 배포 가능 여부 판정.
-/// SLOEvaluator.evaluateDeploymentGate와 별도로, 체크 항목별 개별 평가를 제공한다.
+/// 체크 항목별 개별 평가를 제공하며 SLO 판정은 SLOEvaluator에 위임한다.
 @MainActor
 final class DeployGate {
 

--- a/Dochi/Services/Observability/SLOGate.swift
+++ b/Dochi/Services/Observability/SLOGate.swift
@@ -113,50 +113,9 @@ struct SecurityCheckItem: Codable, Sendable, Identifiable {
     }
 }
 
-// MARK: - Deployment Gate
-
-/// 배포 게이트 통합 판정 결과.
-struct DeploymentGateResult: Codable, Sendable {
-    let passed: Bool
-    let timestamp: Date
-    let sloResult: SLOResult
-    let testsPassedResult: TestGateResult
-    let securityCheckResult: SecurityCheckResult
-
-    var summary: String {
-        let status = passed ? "PASS" : "FAIL"
-        let sloStatus = sloResult.passed ? "pass" : "fail"
-        let testStatus = testsPassedResult.passed ? "pass" : "fail"
-        let secStatus = securityCheckResult.passed ? "pass" : "fail"
-        return "[\(status)] SLO: \(sloStatus), Tests: \(testStatus), Security: \(secStatus)"
-    }
-}
-
-/// 테스트 게이트 결과.
-struct TestGateResult: Codable, Sendable {
-    let passed: Bool
-    let totalTests: Int
-    let passedTests: Int
-    let failedTests: Int
-    let regressionPassed: Bool
-
-    var passRate: Double {
-        guard totalTests > 0 else { return 0.0 }
-        return Double(passedTests) / Double(totalTests)
-    }
-}
-
-/// 보안 점검 결과.
-struct SecurityCheckResult: Codable, Sendable {
-    let passed: Bool
-    let items: [SecurityCheckItem]
-
-    var failedItems: [SecurityCheckItem] { items.filter { !$0.passed } }
-}
-
 // MARK: - SLOEvaluator
 
-/// SLO 평가 및 배포 게이트 통합 판정.
+/// SLO 평가. 배포 게이트 판정은 DeployGate가 담당한다.
 @MainActor
 @Observable
 final class SLOEvaluator: SLOEvaluatorProtocol {
@@ -233,36 +192,6 @@ final class SLOEvaluator: SLOEvaluatorProtocol {
                 thresholdValue: 0.99
             ),
         ]
-    }
-
-    // MARK: - Deployment Gate
-
-    /// 배포 게이트 통합 판정.
-    func evaluateDeploymentGate(
-        metricsSnapshot: MetricsSnapshot,
-        testResult: TestGateResult,
-        securityChecks: [SecurityCheckItem]
-    ) -> DeploymentGateResult {
-        let sloResult = evaluate(snapshot: metricsSnapshot)
-
-        let securityPassed = securityChecks.allSatisfy(\.passed)
-        let securityResult = SecurityCheckResult(
-            passed: securityPassed,
-            items: securityChecks
-        )
-
-        let allPassed = sloResult.passed && testResult.passed && securityResult.passed
-
-        let result = DeploymentGateResult(
-            passed: allPassed,
-            timestamp: Date(),
-            sloResult: sloResult,
-            testsPassedResult: testResult,
-            securityCheckResult: securityResult
-        )
-
-        Log.app.info("Deployment gate: \(result.summary)")
-        return result
     }
 
     // MARK: - Private

--- a/DochiTests/ObservabilityTests.swift
+++ b/DochiTests/ObservabilityTests.swift
@@ -500,83 +500,76 @@ final class SLOGateTests: XCTestCase {
             metrics.recordHistogram(name: MetricName.totalResponseLatencyMs, labels: [:], value: 2000)
         }
 
-        let testResult = TestGateResult(
-            passed: true,
-            totalTests: 50,
-            passedTests: 50,
-            failedTests: 0,
-            regressionPassed: true
+        let deployGate = DeployGate()
+        let regressionReport = RegressionReport(
+            timestamp: Date(),
+            results: [],
+            categorySummaries: [],
+            overallPassRate: 1.0,
+            totalDurationMs: 0
         )
 
-        let securityChecks = [
-            SecurityCheckItem(name: "API Key 노출 점검", description: "코드에 하드코딩된 API 키 없음", passed: true),
-            SecurityCheckItem(name: "권한 정책 점검", description: "민감 도구 승인 플로우 동작", passed: true),
-        ]
-
-        let result = evaluator.evaluateDeploymentGate(
-            metricsSnapshot: metrics.snapshot(),
-            testResult: testResult,
-            securityChecks: securityChecks
+        let report = deployGate.runAllChecks(
+            metrics: metrics,
+            sloEvaluator: evaluator,
+            unitTestsPassed: true,
+            integrationTestsPassed: true,
+            regressionReport: regressionReport,
+            securityChecksPassed: true
         )
 
-        XCTAssertTrue(result.passed)
-        XCTAssertTrue(result.sloResult.passed)
-        XCTAssertTrue(result.testsPassedResult.passed)
-        XCTAssertTrue(result.securityCheckResult.passed)
+        XCTAssertTrue(report.deployable)
+        XCTAssertEqual(report.passCount, report.totalCount)
     }
 
     func testDeploymentGate_failsOnTestFailure() {
         let evaluator = SLOEvaluator()
         let metrics = RuntimeMetrics()
-
-        let testResult = TestGateResult(
-            passed: false,
-            totalTests: 50,
-            passedTests: 45,
-            failedTests: 5,
-            regressionPassed: false
+        let deployGate = DeployGate()
+        let regressionReport = RegressionReport(
+            timestamp: Date(),
+            results: [],
+            categorySummaries: [],
+            overallPassRate: 1.0,
+            totalDurationMs: 0
         )
 
-        let securityChecks = [
-            SecurityCheckItem(name: "Check", description: "Check", passed: true),
-        ]
-
-        let result = evaluator.evaluateDeploymentGate(
-            metricsSnapshot: metrics.snapshot(),
-            testResult: testResult,
-            securityChecks: securityChecks
+        let report = deployGate.runAllChecks(
+            metrics: metrics,
+            sloEvaluator: evaluator,
+            unitTestsPassed: false,
+            integrationTestsPassed: true,
+            regressionReport: regressionReport,
+            securityChecksPassed: true
         )
 
-        XCTAssertFalse(result.passed)
-        XCTAssertFalse(result.testsPassedResult.passed)
+        XCTAssertFalse(report.deployable)
+        XCTAssertTrue(report.failedChecks.contains { $0.check == .unitTests })
     }
 
     func testDeploymentGate_failsOnSecurityFailure() {
         let evaluator = SLOEvaluator()
         let metrics = RuntimeMetrics()
-
-        let testResult = TestGateResult(
-            passed: true,
-            totalTests: 50,
-            passedTests: 50,
-            failedTests: 0,
-            regressionPassed: true
+        let deployGate = DeployGate()
+        let regressionReport = RegressionReport(
+            timestamp: Date(),
+            results: [],
+            categorySummaries: [],
+            overallPassRate: 1.0,
+            totalDurationMs: 0
         )
 
-        let securityChecks = [
-            SecurityCheckItem(name: "API Key 노출 점검", description: "", passed: true),
-            SecurityCheckItem(name: "권한 정책 점검", description: "", passed: false),
-        ]
-
-        let result = evaluator.evaluateDeploymentGate(
-            metricsSnapshot: metrics.snapshot(),
-            testResult: testResult,
-            securityChecks: securityChecks
+        let report = deployGate.runAllChecks(
+            metrics: metrics,
+            sloEvaluator: evaluator,
+            unitTestsPassed: true,
+            integrationTestsPassed: true,
+            regressionReport: regressionReport,
+            securityChecksPassed: false
         )
 
-        XCTAssertFalse(result.passed)
-        XCTAssertFalse(result.securityCheckResult.passed)
-        XCTAssertEqual(result.securityCheckResult.failedItems.count, 1)
+        XCTAssertFalse(report.deployable)
+        XCTAssertTrue(report.failedChecks.contains { $0.check == .securityChecklist })
     }
 
     func testSLOResult_passRate() {


### PR DESCRIPTION
## Summary
- **C1**: Remove `evaluateDeploymentGate()` from `SLOEvaluator` — `DeployGate` is the single source for deployment gate logic
- **C2**: Change diagnostic log `message` privacy from `.public` to `.private` (spec §8 sensitive data minimization)
- Remove orphaned types (`DeploymentGateResult`, `TestGateResult`, `SecurityCheckResult`)
- Update 3 deployment gate tests to use `DeployGate` instead of removed `SLOEvaluator.evaluateDeploymentGate()`

## Test plan
- [x] All 96 observability tests pass
- [x] Build succeeds