### PR TITLE
feat: native provider adapter abstraction + Anthropic adapter (phase1 #320)

### DIFF
--- a/Dochi/Models/NativeLLMModels.swift
+++ b/Dochi/Models/NativeLLMModels.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+enum NativeLLMStreamEventKind: String, Codable, Sendable {
+    case partial
+    case toolUse = "tool_use"
+    case toolResult = "tool_result"
+    case done
+    case error
+}
+
+struct NativeLLMStreamEvent: Sendable {
+    let kind: NativeLLMStreamEventKind
+    let text: String?
+    let toolCallId: String?
+    let toolName: String?
+    let toolInputJSON: String?
+    let toolResultText: String?
+    let isToolResultError: Bool?
+    let error: NativeLLMError?
+
+    static func partial(_ delta: String) -> NativeLLMStreamEvent {
+        NativeLLMStreamEvent(
+            kind: .partial,
+            text: delta,
+            toolCallId: nil,
+            toolName: nil,
+            toolInputJSON: nil,
+            toolResultText: nil,
+            isToolResultError: nil,
+            error: nil
+        )
+    }
+
+    static func toolUse(toolCallId: String, toolName: String, toolInputJSON: String) -> NativeLLMStreamEvent {
+        NativeLLMStreamEvent(
+            kind: .toolUse,
+            text: nil,
+            toolCallId: toolCallId,
+            toolName: toolName,
+            toolInputJSON: toolInputJSON,
+            toolResultText: nil,
+            isToolResultError: nil,
+            error: nil
+        )
+    }
+
+    static func toolResult(toolCallId: String, content: String, isError: Bool) -> NativeLLMStreamEvent {
+        NativeLLMStreamEvent(
+            kind: .toolResult,
+            text: nil,
+            toolCallId: toolCallId,
+            toolName: nil,
+            toolInputJSON: nil,
+            toolResultText: content,
+            isToolResultError: isError,
+            error: nil
+        )
+    }
+
+    static func done(text: String?) -> NativeLLMStreamEvent {
+        NativeLLMStreamEvent(
+            kind: .done,
+            text: text,
+            toolCallId: nil,
+            toolName: nil,
+            toolInputJSON: nil,
+            toolResultText: nil,
+            isToolResultError: nil,
+            error: nil
+        )
+    }
+
+    static func error(_ error: NativeLLMError) -> NativeLLMStreamEvent {
+        NativeLLMStreamEvent(
+            kind: .error,
+            text: nil,
+            toolCallId: nil,
+            toolName: nil,
+            toolInputJSON: nil,
+            toolResultText: nil,
+            isToolResultError: nil,
+            error: error
+        )
+    }
+}
+
+enum NativeLLMErrorCode: String, Codable, Sendable {
+    case rateLimited = "rate_limited"
+    case server = "server_error"
+    case network = "network_error"
+    case timeout = "timeout"
+    case authentication = "authentication_error"
+    case modelNotFound = "model_not_found"
+    case invalidResponse = "invalid_response"
+    case cancelled = "cancelled"
+    case unsupportedProvider = "unsupported_provider"
+    case unknown = "unknown_error"
+}
+
+struct NativeLLMError: Error, LocalizedError, Codable, Sendable, Equatable {
+    let code: NativeLLMErrorCode
+    let message: String
+    let statusCode: Int?
+    let retryAfterSeconds: TimeInterval?
+
+    var errorDescription: String? { message }
+}
+
+enum NativeLLMMessageRole: String, Codable, Sendable {
+    case user
+    case assistant
+}
+
+enum NativeLLMMessageContent: Sendable {
+    case text(String)
+    case toolResult(toolCallId: String, content: String, isError: Bool)
+}
+
+struct NativeLLMMessage: Sendable {
+    let role: NativeLLMMessageRole
+    let contents: [NativeLLMMessageContent]
+
+    init(role: NativeLLMMessageRole, contents: [NativeLLMMessageContent]) {
+        self.role = role
+        self.contents = contents
+    }
+
+    init(role: NativeLLMMessageRole, text: String) {
+        self.role = role
+        self.contents = [.text(text)]
+    }
+}
+
+struct NativeLLMToolDefinition: Sendable {
+    let name: String
+    let description: String
+    let inputSchema: [String: AnyCodableValue]
+}
+
+struct NativeLLMRequest: Sendable {
+    let provider: LLMProvider
+    let model: String
+    let apiKey: String?
+    let systemPrompt: String?
+    let messages: [NativeLLMMessage]
+    let tools: [NativeLLMToolDefinition]
+    let maxTokens: Int
+    let temperature: Double?
+    let endpointURL: URL?
+    let timeoutSeconds: TimeInterval
+    let anthropicVersion: String
+
+    init(
+        provider: LLMProvider,
+        model: String,
+        apiKey: String?,
+        systemPrompt: String? = nil,
+        messages: [NativeLLMMessage],
+        tools: [NativeLLMToolDefinition] = [],
+        maxTokens: Int = 4096,
+        temperature: Double? = nil,
+        endpointURL: URL? = nil,
+        timeoutSeconds: TimeInterval = 60,
+        anthropicVersion: String = "2023-06-01"
+    ) {
+        self.provider = provider
+        self.model = model
+        self.apiKey = apiKey
+        self.systemPrompt = systemPrompt
+        self.messages = messages
+        self.tools = tools
+        self.maxTokens = maxTokens
+        self.temperature = temperature
+        self.endpointURL = endpointURL
+        self.timeoutSeconds = timeoutSeconds
+        self.anthropicVersion = anthropicVersion
+    }
+}

--- a/Dochi/Services/NativeLLM/AnthropicNativeLLMProviderAdapter.swift
+++ b/Dochi/Services/NativeLLM/AnthropicNativeLLMProviderAdapter.swift
@@ -1,0 +1,603 @@
+import Foundation
+
+protocol NativeLLMHTTPClient: Sendable {
+    func send(_ request: URLRequest) async throws -> (data: Data, response: HTTPURLResponse)
+}
+
+struct URLSessionNativeLLMHTTPClient: NativeLLMHTTPClient {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func send(_ request: URLRequest) async throws -> (data: Data, response: HTTPURLResponse) {
+        let (data, rawResponse) = try await session.data(for: request)
+        guard let response = rawResponse as? HTTPURLResponse else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "Invalid HTTP response from Anthropic",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+        return (data, response)
+    }
+}
+
+struct AnthropicNativeLLMProviderAdapter: NativeLLMProviderAdapter {
+    let provider: LLMProvider = .anthropic
+
+    private let httpClient: any NativeLLMHTTPClient
+
+    init(httpClient: any NativeLLMHTTPClient = URLSessionNativeLLMHTTPClient()) {
+        self.httpClient = httpClient
+    }
+
+    func stream(request: NativeLLMRequest) -> AsyncThrowingStream<NativeLLMStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let urlRequest = try Self.makeURLRequest(from: request)
+                    let (data, response) = try await httpClient.send(urlRequest)
+
+                    guard (200...299).contains(response.statusCode) else {
+                        let mappedError = Self.mapHTTPError(
+                            statusCode: response.statusCode,
+                            data: data,
+                            headers: response.allHeaderFields
+                        )
+                        continuation.yield(.error(mappedError))
+                        throw mappedError
+                    }
+
+                    let events = try Self.parseStreamEvents(from: data)
+                    var emittedDone = false
+                    for event in events {
+                        continuation.yield(event)
+                        if event.kind == .done {
+                            emittedDone = true
+                        }
+                        if event.kind == .error, let error = event.error {
+                            throw error
+                        }
+                    }
+
+                    if !emittedDone {
+                        continuation.yield(.done(text: nil))
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: NativeLLMError(
+                        code: .cancelled,
+                        message: "Anthropic request cancelled",
+                        statusCode: nil,
+                        retryAfterSeconds: nil
+                    ))
+                } catch let error as NativeLLMError {
+                    continuation.finish(throwing: error)
+                } catch let error as URLError {
+                    continuation.finish(throwing: Self.mapURLError(error))
+                } catch {
+                    continuation.finish(throwing: NativeLLMError(
+                        code: .unknown,
+                        message: error.localizedDescription,
+                        statusCode: nil,
+                        retryAfterSeconds: nil
+                    ))
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+}
+
+private extension AnthropicNativeLLMProviderAdapter {
+    struct AnthropicRequestPayload: Encodable {
+        let model: String
+        let maxTokens: Int
+        let stream: Bool
+        let system: String?
+        let temperature: Double?
+        let messages: [AnthropicMessage]
+        let tools: [AnthropicTool]?
+
+        enum CodingKeys: String, CodingKey {
+            case model
+            case maxTokens = "max_tokens"
+            case stream
+            case system
+            case temperature
+            case messages
+            case tools
+        }
+    }
+
+    struct AnthropicMessage: Encodable {
+        let role: String
+        let content: [AnthropicContentBlock]
+    }
+
+    enum AnthropicContentBlock: Encodable {
+        case text(String)
+        case toolResult(toolUseId: String, content: String, isError: Bool)
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case text
+            case toolUseId = "tool_use_id"
+            case content
+            case isError = "is_error"
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .text(let text):
+                try container.encode("text", forKey: .type)
+                try container.encode(text, forKey: .text)
+            case .toolResult(let toolUseId, let content, let isError):
+                try container.encode("tool_result", forKey: .type)
+                try container.encode(toolUseId, forKey: .toolUseId)
+                try container.encode(content, forKey: .content)
+                try container.encode(isError, forKey: .isError)
+            }
+        }
+    }
+
+    struct AnthropicTool: Encodable {
+        let name: String
+        let description: String
+        let inputSchema: [String: AnyCodableValue]
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case description
+            case inputSchema = "input_schema"
+        }
+    }
+
+    struct SSEEvent {
+        let name: String
+        let data: String
+    }
+
+    struct SSEEventAccumulator {
+        private(set) var eventName: String = "message"
+        private(set) var dataLines: [String] = []
+
+        mutating func append(line: String) -> SSEEvent? {
+            let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedLine.isEmpty {
+                return flush()
+            }
+
+            if trimmedLine.hasPrefix(":") {
+                return nil
+            }
+
+            if let value = trimmedLine.removing(prefix: "event:") {
+                eventName = value.trimmingCharacters(in: .whitespaces)
+                return nil
+            }
+
+            if let value = trimmedLine.removing(prefix: "data:") {
+                dataLines.append(value.trimmingCharacters(in: .whitespaces))
+                return nil
+            }
+
+            return nil
+        }
+
+        mutating func flush() -> SSEEvent? {
+            guard !dataLines.isEmpty else {
+                eventName = "message"
+                return nil
+            }
+            defer {
+                eventName = "message"
+                dataLines.removeAll(keepingCapacity: true)
+            }
+            return SSEEvent(name: eventName, data: dataLines.joined(separator: "\n"))
+        }
+    }
+
+    struct ToolUseBuffer {
+        let toolCallId: String
+        let toolName: String
+        var inputJSON: String
+    }
+
+    struct ContentBlockStartEnvelope: Decodable {
+        let index: Int
+        let contentBlock: ContentBlock
+
+        enum CodingKeys: String, CodingKey {
+            case index
+            case contentBlock = "content_block"
+        }
+    }
+
+    struct ContentBlock: Decodable {
+        let type: String
+        let id: String?
+        let name: String?
+        let input: AnyCodableValue?
+    }
+
+    struct ContentBlockDeltaEnvelope: Decodable {
+        let index: Int
+        let delta: Delta
+    }
+
+    struct Delta: Decodable {
+        let type: String
+        let text: String?
+        let partialJSON: String?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case text
+            case partialJSON = "partial_json"
+        }
+    }
+
+    struct ContentBlockStopEnvelope: Decodable {
+        let index: Int
+    }
+
+    struct StreamErrorEnvelope: Decodable {
+        let error: StreamErrorBody
+    }
+
+    struct StreamErrorBody: Decodable {
+        let type: String?
+        let message: String
+    }
+
+    static func makeURLRequest(from request: NativeLLMRequest) throws -> URLRequest {
+        guard request.provider == .anthropic else {
+            throw NativeLLMError(
+                code: .unsupportedProvider,
+                message: "Anthropic adapter cannot handle provider: \(request.provider.rawValue)",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        guard let apiKey = request.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !apiKey.isEmpty else {
+            throw NativeLLMError(
+                code: .authentication,
+                message: "Anthropic API key is required",
+                statusCode: 401,
+                retryAfterSeconds: nil
+            )
+        }
+
+        guard request.maxTokens > 0 else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "maxTokens must be greater than 0",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        let endpoint = request.endpointURL ?? request.provider.apiURL
+        var urlRequest = URLRequest(url: endpoint)
+        urlRequest.httpMethod = "POST"
+        urlRequest.timeoutInterval = request.timeoutSeconds
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        urlRequest.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        urlRequest.setValue(request.anthropicVersion, forHTTPHeaderField: "anthropic-version")
+
+        let payload = AnthropicRequestPayload(
+            model: request.model,
+            maxTokens: request.maxTokens,
+            stream: true,
+            system: request.systemPrompt,
+            temperature: request.temperature,
+            messages: request.messages.map(Self.convertMessage),
+            tools: request.tools.isEmpty ? nil : request.tools.map { tool in
+                AnthropicTool(name: tool.name, description: tool.description, inputSchema: tool.inputSchema)
+            }
+        )
+        urlRequest.httpBody = try JSONEncoder().encode(payload)
+        return urlRequest
+    }
+
+    static func convertMessage(_ message: NativeLLMMessage) -> AnthropicMessage {
+        let blocks = message.contents.map { content -> AnthropicContentBlock in
+            switch content {
+            case .text(let text):
+                return .text(text)
+            case .toolResult(let toolCallId, let content, let isError):
+                return .toolResult(toolUseId: toolCallId, content: content, isError: isError)
+            }
+        }
+        return AnthropicMessage(
+            role: message.role.rawValue,
+            content: blocks.isEmpty ? [.text("")] : blocks
+        )
+    }
+
+    static func parseStreamEvents(from data: Data) throws -> [NativeLLMStreamEvent] {
+        guard let payload = String(data: data, encoding: .utf8) else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "Anthropic response body is not valid UTF-8",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        var accumulator = SSEEventAccumulator()
+        var toolBuffers: [Int: ToolUseBuffer] = [:]
+        var events: [NativeLLMStreamEvent] = []
+        var hasDone = false
+
+        let lines = payload.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map(String.init)
+        for line in lines {
+            if let sseEvent = accumulator.append(line: line.replacingOccurrences(of: "\r", with: "")) {
+                let mapped = try mapSSEEvent(sseEvent, toolBuffers: &toolBuffers)
+                events.append(contentsOf: mapped)
+                if mapped.contains(where: { $0.kind == .done }) {
+                    hasDone = true
+                }
+            }
+        }
+
+        if let pending = accumulator.flush() {
+            let mapped = try mapSSEEvent(pending, toolBuffers: &toolBuffers)
+            events.append(contentsOf: mapped)
+            if mapped.contains(where: { $0.kind == .done }) {
+                hasDone = true
+            }
+        }
+
+        if !toolBuffers.isEmpty {
+            for index in toolBuffers.keys.sorted() {
+                if let buffer = toolBuffers[index] {
+                    events.append(.toolUse(
+                        toolCallId: buffer.toolCallId,
+                        toolName: buffer.toolName,
+                        toolInputJSON: buffer.inputJSON
+                    ))
+                }
+            }
+        }
+
+        if !hasDone {
+            events.append(.done(text: nil))
+        }
+
+        return events
+    }
+
+    static func mapSSEEvent(
+        _ event: SSEEvent,
+        toolBuffers: inout [Int: ToolUseBuffer]
+    ) throws -> [NativeLLMStreamEvent] {
+        if event.data == "[DONE]" {
+            return [.done(text: nil)]
+        }
+
+        switch event.name {
+        case "content_block_start":
+            let envelope: ContentBlockStartEnvelope = try decode(event.data)
+            guard envelope.contentBlock.type == "tool_use" else { return [] }
+
+            let toolCallId = envelope.contentBlock.id ?? UUID().uuidString
+            let toolName = envelope.contentBlock.name ?? "unknown_tool"
+            let initialInput = jsonString(from: envelope.contentBlock.input) ?? ""
+            toolBuffers[envelope.index] = ToolUseBuffer(
+                toolCallId: toolCallId,
+                toolName: toolName,
+                inputJSON: initialInput
+            )
+            return []
+
+        case "content_block_delta":
+            let envelope: ContentBlockDeltaEnvelope = try decode(event.data)
+            switch envelope.delta.type {
+            case "text_delta":
+                guard let text = envelope.delta.text, !text.isEmpty else { return [] }
+                return [.partial(text)]
+
+            case "input_json_delta":
+                guard var buffer = toolBuffers[envelope.index] else { return [] }
+                if let partialJSON = envelope.delta.partialJSON {
+                    buffer.inputJSON += partialJSON
+                    toolBuffers[envelope.index] = buffer
+                }
+                return []
+
+            default:
+                return []
+            }
+
+        case "content_block_stop":
+            let envelope: ContentBlockStopEnvelope = try decode(event.data)
+            guard let tool = toolBuffers.removeValue(forKey: envelope.index) else { return [] }
+            return [.toolUse(
+                toolCallId: tool.toolCallId,
+                toolName: tool.toolName,
+                toolInputJSON: tool.inputJSON
+            )]
+
+        case "message_stop":
+            var events: [NativeLLMStreamEvent] = []
+            if !toolBuffers.isEmpty {
+                for index in toolBuffers.keys.sorted() {
+                    if let tool = toolBuffers.removeValue(forKey: index) {
+                        events.append(.toolUse(
+                            toolCallId: tool.toolCallId,
+                            toolName: tool.toolName,
+                            toolInputJSON: tool.inputJSON
+                        ))
+                    }
+                }
+            }
+            events.append(.done(text: nil))
+            return events
+
+        case "error":
+            let envelope: StreamErrorEnvelope = try decode(event.data)
+            let mappedError = mapStreamError(
+                type: envelope.error.type,
+                message: envelope.error.message
+            )
+            return [.error(mappedError)]
+
+        default:
+            return []
+        }
+    }
+
+    static func decode<T: Decodable>(_ raw: String) throws -> T {
+        guard let data = raw.data(using: .utf8) else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "Failed to decode SSE JSON payload",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "Failed to parse Anthropic SSE payload: \(error.localizedDescription)",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+    }
+
+    static func jsonString(from value: AnyCodableValue?) -> String? {
+        guard let value else { return nil }
+        guard let data = try? JSONEncoder().encode(value) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func mapHTTPError(
+        statusCode: Int,
+        data: Data,
+        headers: [AnyHashable: Any]
+    ) -> NativeLLMError {
+        let message = extractErrorMessage(from: data) ?? "Anthropic API request failed"
+        let retryAfter = parseRetryAfter(headers: headers)
+
+        let code: NativeLLMErrorCode
+        switch statusCode {
+        case 401, 403:
+            code = .authentication
+        case 404:
+            code = .modelNotFound
+        case 429:
+            code = .rateLimited
+        case 500...599:
+            code = .server
+        default:
+            code = .invalidResponse
+        }
+
+        return NativeLLMError(
+            code: code,
+            message: message,
+            statusCode: statusCode,
+            retryAfterSeconds: retryAfter
+        )
+    }
+
+    static func mapURLError(_ error: URLError) -> NativeLLMError {
+        let code: NativeLLMErrorCode
+        switch error.code {
+        case .timedOut:
+            code = .timeout
+        case .cancelled:
+            code = .cancelled
+        case .notConnectedToInternet, .networkConnectionLost, .cannotFindHost, .cannotConnectToHost, .dnsLookupFailed:
+            code = .network
+        default:
+            code = .unknown
+        }
+
+        return NativeLLMError(
+            code: code,
+            message: error.localizedDescription,
+            statusCode: nil,
+            retryAfterSeconds: nil
+        )
+    }
+
+    static func mapStreamError(type: String?, message: String) -> NativeLLMError {
+        let normalizedType = (type ?? "").lowercased()
+        let loweredMessage = message.lowercased()
+
+        let code: NativeLLMErrorCode
+        if normalizedType == "rate_limit_error" {
+            code = .rateLimited
+        } else if normalizedType == "authentication_error" || normalizedType == "permission_error" {
+            code = .authentication
+        } else if normalizedType == "overloaded_error" || normalizedType == "api_error" {
+            code = .server
+        } else if loweredMessage.contains("model") && loweredMessage.contains("not found") {
+            code = .modelNotFound
+        } else {
+            code = .unknown
+        }
+
+        return NativeLLMError(
+            code: code,
+            message: message,
+            statusCode: nil,
+            retryAfterSeconds: nil
+        )
+    }
+
+    static func parseRetryAfter(headers: [AnyHashable: Any]) -> TimeInterval? {
+        for (key, value) in headers {
+            if String(describing: key).caseInsensitiveCompare("Retry-After") == .orderedSame {
+                if let seconds = TimeInterval(String(describing: value)) {
+                    return seconds
+                }
+            }
+        }
+        return nil
+    }
+
+    static func extractErrorMessage(from data: Data) -> String? {
+        if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let errorObject = object["error"] as? [String: Any],
+               let message = errorObject["message"] as? String,
+               !message.isEmpty {
+                return message
+            }
+            if let message = object["message"] as? String, !message.isEmpty {
+                return message
+            }
+        }
+
+        if let plain = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !plain.isEmpty {
+            return plain
+        }
+        return nil
+    }
+}
+
+private extension String {
+    func removing(prefix: String) -> String? {
+        guard hasPrefix(prefix) else { return nil }
+        return String(dropFirst(prefix.count))
+    }
+}

--- a/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
+++ b/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+final class NativeAgentLoopService {
+    private let adapters: [LLMProvider: any NativeLLMProviderAdapter]
+
+    init(adapters: [any NativeLLMProviderAdapter]) {
+        var map: [LLMProvider: any NativeLLMProviderAdapter] = [:]
+        for adapter in adapters {
+            map[adapter.provider] = adapter
+        }
+        self.adapters = map
+    }
+
+    func run(request: NativeLLMRequest) -> AsyncThrowingStream<NativeLLMStreamEvent, Error> {
+        guard let adapter = adapters[request.provider] else {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: NativeLLMError(
+                    code: .unsupportedProvider,
+                    message: "No native adapter registered for provider: \(request.provider.rawValue)",
+                    statusCode: nil,
+                    retryAfterSeconds: nil
+                ))
+            }
+        }
+        return adapter.stream(request: request)
+    }
+}

--- a/Dochi/Services/Protocols/NativeLLMProviderAdapter.swift
+++ b/Dochi/Services/Protocols/NativeLLMProviderAdapter.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+protocol NativeLLMProviderAdapter: Sendable {
+    var provider: LLMProvider { get }
+
+    func stream(request: NativeLLMRequest) -> AsyncThrowingStream<NativeLLMStreamEvent, Error>
+}

--- a/DochiTests/AnthropicNativeLLMProviderAdapterTests.swift
+++ b/DochiTests/AnthropicNativeLLMProviderAdapterTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+@testable import Dochi
+
+final class AnthropicNativeLLMProviderAdapterTests: XCTestCase {
+    func testAnthropicAdapterParsesPartialToolUseAndDoneEvents() async throws {
+        let streamPayload = """
+        event: content_block_start
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+        event: content_block_delta
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"안녕하세요"}}
+
+        event: content_block_start
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"calendar.create","input":{"title":"회의"}}}
+
+        event: content_block_stop
+        data: {"type":"content_block_stop","index":1}
+
+        event: message_stop
+        data: {"type":"message_stop","stop_reason":"end_turn"}
+        """
+
+        let httpClient = MockNativeLLMHTTPClient(
+            statusCode: 200,
+            headers: [:],
+            body: Data(streamPayload.utf8)
+        )
+        let adapter = AnthropicNativeLLMProviderAdapter(httpClient: httpClient)
+        let request = makeRequest(provider: .anthropic, apiKey: "test-key")
+
+        let events = try await collectEvents(from: adapter.stream(request: request))
+
+        XCTAssertTrue(events.contains(where: { $0.kind == .partial && $0.text == "안녕하세요" }))
+        XCTAssertTrue(events.contains(where: { event in
+            event.kind == .toolUse &&
+                event.toolCallId == "toolu_1" &&
+                event.toolName == "calendar.create" &&
+                (event.toolInputJSON?.contains("\"title\":\"회의\"") ?? false)
+        }))
+        XCTAssertEqual(events.last?.kind, .done)
+
+        let captured = await httpClient.capturedRequest()
+        XCTAssertEqual(captured?.value(forHTTPHeaderField: "x-api-key"), "test-key")
+        XCTAssertEqual(captured?.value(forHTTPHeaderField: "anthropic-version"), "2023-06-01")
+        XCTAssertEqual(captured?.value(forHTTPHeaderField: "Accept"), "text/event-stream")
+        XCTAssertEqual(captured?.httpMethod, "POST")
+    }
+
+    func testAnthropicAdapterMapsRateLimitError() async {
+        let errorPayload = """
+        {"error":{"type":"rate_limit_error","message":"Too many requests"}}
+        """
+        let httpClient = MockNativeLLMHTTPClient(
+            statusCode: 429,
+            headers: ["Retry-After": "7"],
+            body: Data(errorPayload.utf8)
+        )
+        let adapter = AnthropicNativeLLMProviderAdapter(httpClient: httpClient)
+        let request = makeRequest(provider: .anthropic, apiKey: "test-key")
+
+        do {
+            _ = try await collectEvents(from: adapter.stream(request: request))
+            XCTFail("Expected NativeLLMError")
+        } catch let error as NativeLLMError {
+            XCTAssertEqual(error.code, .rateLimited)
+            XCTAssertEqual(error.statusCode, 429)
+            XCTAssertEqual(error.retryAfterSeconds, 7)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testAnthropicAdapterMapsAuthenticationError() async {
+        let errorPayload = """
+        {"error":{"type":"authentication_error","message":"Invalid API key"}}
+        """
+        let httpClient = MockNativeLLMHTTPClient(
+            statusCode: 401,
+            headers: [:],
+            body: Data(errorPayload.utf8)
+        )
+        let adapter = AnthropicNativeLLMProviderAdapter(httpClient: httpClient)
+        let request = makeRequest(provider: .anthropic, apiKey: "bad-key")
+
+        do {
+            _ = try await collectEvents(from: adapter.stream(request: request))
+            XCTFail("Expected NativeLLMError")
+        } catch let error as NativeLLMError {
+            XCTAssertEqual(error.code, .authentication)
+            XCTAssertEqual(error.statusCode, 401)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testAnthropicAdapterMapsTimeoutError() async {
+        let httpClient = MockNativeLLMHTTPClient(
+            statusCode: 200,
+            headers: [:],
+            body: Data(),
+            stubbedError: URLError(.timedOut)
+        )
+        let adapter = AnthropicNativeLLMProviderAdapter(httpClient: httpClient)
+        let request = makeRequest(provider: .anthropic, apiKey: "test-key")
+
+        do {
+            _ = try await collectEvents(from: adapter.stream(request: request))
+            XCTFail("Expected NativeLLMError")
+        } catch let error as NativeLLMError {
+            XCTAssertEqual(error.code, .timeout)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testAnthropicAdapterMapsCancellationAsInterrupted() async {
+        let httpClient = MockNativeLLMHTTPClient(
+            statusCode: 200,
+            headers: [:],
+            body: Data(),
+            stubbedError: CancellationError()
+        )
+        let adapter = AnthropicNativeLLMProviderAdapter(httpClient: httpClient)
+        let request = makeRequest(provider: .anthropic, apiKey: "test-key")
+
+        do {
+            _ = try await collectEvents(from: adapter.stream(request: request))
+            XCTFail("Expected NativeLLMError")
+        } catch let error as NativeLLMError {
+            XCTAssertEqual(error.code, .cancelled)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}
+
+private extension AnthropicNativeLLMProviderAdapterTests {
+    func makeRequest(provider: LLMProvider, apiKey: String?) -> NativeLLMRequest {
+        NativeLLMRequest(
+            provider: provider,
+            model: "claude-sonnet-4-5-20250514",
+            apiKey: apiKey,
+            systemPrompt: "테스트 시스템 프롬프트",
+            messages: [.init(role: .user, text: "안녕")]
+        )
+    }
+
+    func collectEvents(
+        from stream: AsyncThrowingStream<NativeLLMStreamEvent, Error>
+    ) async throws -> [NativeLLMStreamEvent] {
+        var events: [NativeLLMStreamEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+        return events
+    }
+}
+
+private actor MockNativeLLMHTTPClient: NativeLLMHTTPClient {
+    private let statusCode: Int
+    private let headers: [String: String]
+    private let body: Data
+    private let stubbedError: Error?
+    private(set) var lastRequest: URLRequest?
+
+    init(
+        statusCode: Int,
+        headers: [String: String],
+        body: Data,
+        stubbedError: Error? = nil
+    ) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.body = body
+        self.stubbedError = stubbedError
+    }
+
+    func send(_ request: URLRequest) async throws -> (data: Data, response: HTTPURLResponse) {
+        lastRequest = request
+        if let stubbedError {
+            throw stubbedError
+        }
+
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: headers
+              ) else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "Failed to build HTTPURLResponse in test",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+        return (body, response)
+    }
+
+    func capturedRequest() -> URLRequest? {
+        lastRequest
+    }
+}

--- a/DochiTests/NativeAgentLoopServiceTests.swift
+++ b/DochiTests/NativeAgentLoopServiceTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import Dochi
+
+final class NativeAgentLoopServiceTests: XCTestCase {
+    func testNativeAgentLoopServiceRoutesToMatchingProviderAdapter() async throws {
+        let anthropicAdapter = StubNativeLLMProviderAdapter(
+            provider: .anthropic,
+            events: [.partial("anthropic"), .done(text: "anthropic")]
+        )
+        let openAIAdapter = StubNativeLLMProviderAdapter(
+            provider: .openai,
+            events: [.partial("openai"), .done(text: "openai")]
+        )
+
+        let service = NativeAgentLoopService(adapters: [anthropicAdapter, openAIAdapter])
+
+        let anthropicEvents = try await collectEvents(from: service.run(request: makeRequest(provider: .anthropic)))
+        XCTAssertEqual(anthropicEvents.first?.text, "anthropic")
+
+        let openAIEvents = try await collectEvents(from: service.run(request: makeRequest(provider: .openai)))
+        XCTAssertEqual(openAIEvents.first?.text, "openai")
+    }
+
+    func testNativeAgentLoopServiceReturnsUnsupportedProviderError() async {
+        let service = NativeAgentLoopService(adapters: [
+            StubNativeLLMProviderAdapter(
+                provider: .anthropic,
+                events: [.done(text: nil)]
+            ),
+        ])
+
+        do {
+            _ = try await collectEvents(from: service.run(request: makeRequest(provider: .zai)))
+            XCTFail("Expected NativeLLMError.unsupportedProvider")
+        } catch let error as NativeLLMError {
+            XCTAssertEqual(error.code, .unsupportedProvider)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+}
+
+private extension NativeAgentLoopServiceTests {
+    func makeRequest(provider: LLMProvider) -> NativeLLMRequest {
+        NativeLLMRequest(
+            provider: provider,
+            model: "test-model",
+            apiKey: "test-key",
+            messages: [.init(role: .user, text: "hello")]
+        )
+    }
+
+    func collectEvents(
+        from stream: AsyncThrowingStream<NativeLLMStreamEvent, Error>
+    ) async throws -> [NativeLLMStreamEvent] {
+        var events: [NativeLLMStreamEvent] = []
+        for try await event in stream {
+            events.append(event)
+        }
+        return events
+    }
+}
+
+private struct StubNativeLLMProviderAdapter: NativeLLMProviderAdapter {
+    let provider: LLMProvider
+    let events: [NativeLLMStreamEvent]
+
+    func stream(request _: NativeLLMRequest) -> AsyncThrowingStream<NativeLLMStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            for event in events {
+                continuation.yield(event)
+            }
+            continuation.finish()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add provider-agnostic native LLM models (`NativeLLMRequest`, stream event/error normalization)
- add `NativeLLMProviderAdapter` protocol and `NativeAgentLoopService` adapter injection path
- implement 1st-pass `AnthropicNativeLLMProviderAdapter` with normalized stream events (`partial/tool_use/done/error`)
- normalize Anthropic error mapping for `429/5xx/network/timeout/auth` cases
- add unit tests for happy path, error mapping, interruption(cancellation), and provider swap routing

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/AnthropicNativeLLMProviderAdapterTests -only-testing:DochiTests/NativeAgentLoopServiceTests`
  - 7 tests passed

## Spec Impact
- aligns with `spec/llm-requirements.md` adapter/error normalization requirements
- no spec doc changes in this PR

## Follow-up
- created follow-up issue for true incremental SSE parsing: #339

Closes #320
