### PR TITLE
feat: native agent tool-use loop + guards (phase1 #321)

### DIFF
--- a/Dochi/Models/NativeLLMModels.swift
+++ b/Dochi/Models/NativeLLMModels.swift
@@ -94,6 +94,8 @@ enum NativeLLMErrorCode: String, Codable, Sendable {
     case invalidResponse = "invalid_response"
     case cancelled = "cancelled"
     case unsupportedProvider = "unsupported_provider"
+    case loopGuardTriggered = "loop_guard_triggered"
+    case toolExecutionFailed = "tool_execution_failed"
     case unknown = "unknown_error"
 }
 
@@ -113,6 +115,7 @@ enum NativeLLMMessageRole: String, Codable, Sendable {
 
 enum NativeLLMMessageContent: Sendable {
     case text(String)
+    case toolUse(toolCallId: String, name: String, inputJSON: String)
     case toolResult(toolCallId: String, content: String, isError: Bool)
 }
 

--- a/Dochi/Services/NativeLLM/AnthropicNativeLLMProviderAdapter.swift
+++ b/Dochi/Services/NativeLLM/AnthropicNativeLLMProviderAdapter.swift
@@ -123,11 +123,15 @@ private extension AnthropicNativeLLMProviderAdapter {
 
     enum AnthropicContentBlock: Encodable {
         case text(String)
+        case toolUse(id: String, name: String, input: AnyCodableValue)
         case toolResult(toolUseId: String, content: String, isError: Bool)
 
         enum CodingKeys: String, CodingKey {
             case type
             case text
+            case id
+            case name
+            case input
             case toolUseId = "tool_use_id"
             case content
             case isError = "is_error"
@@ -139,6 +143,11 @@ private extension AnthropicNativeLLMProviderAdapter {
             case .text(let text):
                 try container.encode("text", forKey: .type)
                 try container.encode(text, forKey: .text)
+            case .toolUse(let id, let name, let input):
+                try container.encode("tool_use", forKey: .type)
+                try container.encode(id, forKey: .id)
+                try container.encode(name, forKey: .name)
+                try container.encode(input, forKey: .input)
             case .toolResult(let toolUseId, let content, let isError):
                 try container.encode("tool_result", forKey: .type)
                 try container.encode(toolUseId, forKey: .toolUseId)
@@ -316,6 +325,12 @@ private extension AnthropicNativeLLMProviderAdapter {
             switch content {
             case .text(let text):
                 return .text(text)
+            case .toolUse(let toolCallId, let name, let inputJSON):
+                return .toolUse(
+                    id: toolCallId,
+                    name: name,
+                    input: parseToolUseInputJSON(inputJSON)
+                )
             case .toolResult(let toolCallId, let content, let isError):
                 return .toolResult(toolUseId: toolCallId, content: content, isError: isError)
             }
@@ -485,6 +500,17 @@ private extension AnthropicNativeLLMProviderAdapter {
         guard let value else { return nil }
         guard let data = try? JSONEncoder().encode(value) else { return nil }
         return String(data: data, encoding: .utf8)
+    }
+
+    static func parseToolUseInputJSON(_ raw: String) -> AnyCodableValue {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else {
+            return .object([:])
+        }
+        if let value = try? JSONDecoder().decode(AnyCodableValue.self, from: data) {
+            return value
+        }
+        return .object([:])
     }
 
     static func mapHTTPError(

--- a/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
+++ b/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
@@ -1,14 +1,47 @@
 import Foundation
 
-final class NativeAgentLoopService {
-    private let adapters: [LLMProvider: any NativeLLMProviderAdapter]
+struct NativeAgentLoopGuardPolicy: Sendable {
+    let maxIterations: Int
+    let maxRepeatedSignatures: Int
 
-    init(adapters: [any NativeLLMProviderAdapter]) {
+    init(maxIterations: Int = 8, maxRepeatedSignatures: Int = 2) {
+        self.maxIterations = max(1, maxIterations)
+        self.maxRepeatedSignatures = max(1, maxRepeatedSignatures)
+    }
+
+    static let `default` = NativeAgentLoopGuardPolicy()
+}
+
+@MainActor
+final class NativeAgentLoopService {
+    private struct PendingToolUse: Sendable {
+        let toolCallId: String
+        let name: String
+        let inputJSON: String
+    }
+
+    private struct ExecutedToolResult: Sendable {
+        let toolCallId: String
+        let content: String
+        let isError: Bool
+    }
+
+    private let adapters: [LLMProvider: any NativeLLMProviderAdapter]
+    private let toolService: (any BuiltInToolServiceProtocol)?
+    private let guardPolicy: NativeAgentLoopGuardPolicy
+
+    init(
+        adapters: [any NativeLLMProviderAdapter],
+        toolService: (any BuiltInToolServiceProtocol)? = nil,
+        guardPolicy: NativeAgentLoopGuardPolicy = .default
+    ) {
         var map: [LLMProvider: any NativeLLMProviderAdapter] = [:]
         for adapter in adapters {
             map[adapter.provider] = adapter
         }
         self.adapters = map
+        self.toolService = toolService
+        self.guardPolicy = guardPolicy
     }
 
     func run(request: NativeLLMRequest) -> AsyncThrowingStream<NativeLLMStreamEvent, Error> {
@@ -22,6 +55,286 @@ final class NativeAgentLoopService {
                 ))
             }
         }
-        return adapter.stream(request: request)
+
+        return AsyncThrowingStream { continuation in
+            let task = Task { @MainActor [guardPolicy, toolService] in
+                do {
+                    var currentRequest = request
+                    var iteration = 0
+                    var lastToolSignature: String?
+                    var repeatedSignatureCount = 0
+
+                    while !Task.isCancelled {
+                        iteration += 1
+                        if iteration > guardPolicy.maxIterations {
+                            throw NativeLLMError(
+                                code: .loopGuardTriggered,
+                                message: "Native loop exceeded max iterations (\(guardPolicy.maxIterations))",
+                                statusCode: nil,
+                                retryAfterSeconds: nil
+                            )
+                        }
+
+                        var pendingToolUses: [PendingToolUse] = []
+                        var executedToolResults: [ExecutedToolResult] = []
+                        var accumulatedAssistantText = ""
+                        var doneEvent: NativeLLMStreamEvent?
+
+                        for try await event in adapter.stream(request: currentRequest) {
+                            if Task.isCancelled {
+                                throw CancellationError()
+                            }
+
+                            switch event.kind {
+                            case .partial:
+                                if let text = event.text {
+                                    accumulatedAssistantText += text
+                                }
+                                continuation.yield(event)
+
+                            case .toolUse:
+                                guard let toolCallId = event.toolCallId,
+                                      let toolName = event.toolName,
+                                      let toolInputJSON = event.toolInputJSON else {
+                                    throw NativeLLMError(
+                                        code: .invalidResponse,
+                                        message: "tool_use event is missing required fields",
+                                        statusCode: nil,
+                                        retryAfterSeconds: nil
+                                    )
+                                }
+                                pendingToolUses.append(PendingToolUse(
+                                    toolCallId: toolCallId,
+                                    name: toolName,
+                                    inputJSON: toolInputJSON
+                                ))
+                                continuation.yield(event)
+
+                            case .toolResult:
+                                continuation.yield(event)
+
+                            case .done:
+                                doneEvent = event
+                                if let text = event.text, !text.isEmpty {
+                                    accumulatedAssistantText = text
+                                }
+
+                            case .error:
+                                continuation.yield(event)
+                                if let error = event.error {
+                                    throw error
+                                }
+                                throw NativeLLMError(
+                                    code: .unknown,
+                                    message: "Provider emitted error event without payload",
+                                    statusCode: nil,
+                                    retryAfterSeconds: nil
+                                )
+                            }
+                        }
+
+                        if pendingToolUses.isEmpty {
+                            continuation.yield(doneEvent ?? .done(
+                                text: accumulatedAssistantText.isEmpty ? nil : accumulatedAssistantText
+                            ))
+                            continuation.finish()
+                            return
+                        }
+
+                        let signature = Self.makeToolSignature(for: pendingToolUses)
+                        if signature == lastToolSignature {
+                            repeatedSignatureCount += 1
+                        } else {
+                            lastToolSignature = signature
+                            repeatedSignatureCount = 1
+                        }
+
+                        if repeatedSignatureCount > guardPolicy.maxRepeatedSignatures {
+                            throw NativeLLMError(
+                                code: .loopGuardTriggered,
+                                message: "Native loop repeated identical tool signature \(repeatedSignatureCount) times",
+                                statusCode: nil,
+                                retryAfterSeconds: nil
+                            )
+                        }
+
+                        guard let toolService else {
+                            throw NativeLLMError(
+                                code: .toolExecutionFailed,
+                                message: "Tool service is not configured for native tool loop",
+                                statusCode: nil,
+                                retryAfterSeconds: nil
+                            )
+                        }
+
+                        for pending in pendingToolUses {
+                            let arguments: [String: Any]
+                            do {
+                                arguments = try Self.parseToolArguments(from: pending.inputJSON)
+                            } catch let parseError as NativeLLMError {
+                                let message = "Invalid tool input for '\(pending.name)': \(parseError.message)"
+                                continuation.yield(.toolResult(
+                                    toolCallId: pending.toolCallId,
+                                    content: message,
+                                    isError: true
+                                ))
+                                throw NativeLLMError(
+                                    code: .toolExecutionFailed,
+                                    message: message,
+                                    statusCode: nil,
+                                    retryAfterSeconds: nil
+                                )
+                            }
+
+                            let result = await toolService.execute(name: pending.name, arguments: arguments)
+                            continuation.yield(.toolResult(
+                                toolCallId: pending.toolCallId,
+                                content: result.content,
+                                isError: result.isError
+                            ))
+
+                            executedToolResults.append(ExecutedToolResult(
+                                toolCallId: pending.toolCallId,
+                                content: result.content,
+                                isError: result.isError
+                            ))
+
+                            if result.isError {
+                                throw NativeLLMError(
+                                    code: .toolExecutionFailed,
+                                    message: "Tool '\(pending.name)' failed: \(result.content)",
+                                    statusCode: nil,
+                                    retryAfterSeconds: nil
+                                )
+                            }
+                        }
+
+                        currentRequest = Self.makeFollowUpRequest(
+                            from: currentRequest,
+                            assistantText: accumulatedAssistantText,
+                            toolUses: pendingToolUses,
+                            toolResults: executedToolResults
+                        )
+                    }
+
+                    throw NativeLLMError(
+                        code: .cancelled,
+                        message: "Native loop cancelled",
+                        statusCode: nil,
+                        retryAfterSeconds: nil
+                    )
+                } catch is CancellationError {
+                    continuation.finish(throwing: NativeLLMError(
+                        code: .cancelled,
+                        message: "Native loop cancelled",
+                        statusCode: nil,
+                        retryAfterSeconds: nil
+                    ))
+                } catch let error as NativeLLMError {
+                    continuation.finish(throwing: error)
+                } catch {
+                    continuation.finish(throwing: NativeLLMError(
+                        code: .unknown,
+                        message: error.localizedDescription,
+                        statusCode: nil,
+                        retryAfterSeconds: nil
+                    ))
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+}
+
+private extension NativeAgentLoopService {
+    private static func makeToolSignature(for toolUses: [PendingToolUse]) -> String {
+        toolUses
+            .map { "\($0.name)|\($0.inputJSON)" }
+            .joined(separator: "||")
+    }
+
+    private static func parseToolArguments(from rawInputJSON: String) throws -> [String: Any] {
+        let trimmed = rawInputJSON.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [:] }
+
+        guard let data = trimmed.data(using: .utf8) else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "tool input is not valid UTF-8",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        let object: Any
+        do {
+            object = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "tool input is not valid JSON object",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        guard let dictionary = object as? [String: Any] else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "tool input JSON must be an object",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        return dictionary
+    }
+
+    private static func makeFollowUpRequest(
+        from request: NativeLLMRequest,
+        assistantText: String,
+        toolUses: [PendingToolUse],
+        toolResults: [ExecutedToolResult]
+    ) -> NativeLLMRequest {
+        var messages = request.messages
+
+        var assistantContents: [NativeLLMMessageContent] = []
+        if !assistantText.isEmpty {
+            assistantContents.append(.text(assistantText))
+        }
+        assistantContents.append(contentsOf: toolUses.map { tool in
+            .toolUse(toolCallId: tool.toolCallId, name: tool.name, inputJSON: tool.inputJSON)
+        })
+        if !assistantContents.isEmpty {
+            messages.append(NativeLLMMessage(role: .assistant, contents: assistantContents))
+        }
+
+        let toolResultContents: [NativeLLMMessageContent] = toolResults.map { result in
+            .toolResult(
+                toolCallId: result.toolCallId,
+                content: result.content,
+                isError: result.isError
+            )
+        }
+        if !toolResultContents.isEmpty {
+            messages.append(NativeLLMMessage(role: .user, contents: toolResultContents))
+        }
+
+        return NativeLLMRequest(
+            provider: request.provider,
+            model: request.model,
+            apiKey: request.apiKey,
+            systemPrompt: request.systemPrompt,
+            messages: messages,
+            tools: request.tools,
+            maxTokens: request.maxTokens,
+            temperature: request.temperature,
+            endpointURL: request.endpointURL,
+            timeoutSeconds: request.timeoutSeconds,
+            anthropicVersion: request.anthropicVersion
+        )
     }
 }

--- a/DochiTests/NativeAgentLoopServiceTests.swift
+++ b/DochiTests/NativeAgentLoopServiceTests.swift
@@ -1,13 +1,14 @@
 import XCTest
 @testable import Dochi
 
+@MainActor
 final class NativeAgentLoopServiceTests: XCTestCase {
     func testNativeAgentLoopServiceRoutesToMatchingProviderAdapter() async throws {
-        let anthropicAdapter = StubNativeLLMProviderAdapter(
+        let anthropicAdapter = StaticNativeLLMProviderAdapter(
             provider: .anthropic,
             events: [.partial("anthropic"), .done(text: "anthropic")]
         )
-        let openAIAdapter = StubNativeLLMProviderAdapter(
+        let openAIAdapter = StaticNativeLLMProviderAdapter(
             provider: .openai,
             events: [.partial("openai"), .done(text: "openai")]
         )
@@ -23,7 +24,7 @@ final class NativeAgentLoopServiceTests: XCTestCase {
 
     func testNativeAgentLoopServiceReturnsUnsupportedProviderError() async {
         let service = NativeAgentLoopService(adapters: [
-            StubNativeLLMProviderAdapter(
+            StaticNativeLLMProviderAdapter(
                 provider: .anthropic,
                 events: [.done(text: nil)]
             ),
@@ -37,6 +38,128 @@ final class NativeAgentLoopServiceTests: XCTestCase {
         } catch {
             XCTFail("Unexpected error type: \(error)")
         }
+    }
+
+    func testNativeAgentLoopServiceExecutesToolAndReruns() async throws {
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(toolCallId: "", content: "created")
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { request in
+            if request.messages.containsToolResult(toolCallId: "tool_1") {
+                return [.partial("완료"), .done(text: "완료")]
+            }
+            return [
+                .toolUse(toolCallId: "tool_1", toolName: "calendar.create", toolInputJSON: "{\"title\":\"회의\"}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService
+        )
+
+        let events = try await collectEvents(from: service.run(request: makeRequest(provider: .anthropic)))
+
+        XCTAssertEqual(events.map(\.kind), [.toolUse, .toolResult, .partial, .done])
+        XCTAssertEqual(toolService.executeCallCount, 1)
+        XCTAssertEqual(toolService.lastExecutedName, "calendar.create")
+        XCTAssertEqual(toolService.lastArguments?["title"] as? String, "회의")
+
+        XCTAssertEqual(adapter.capturedRequests.count, 2)
+        XCTAssertTrue(adapter.capturedRequests[1].messages.containsToolUse(toolCallId: "tool_1"))
+        XCTAssertTrue(adapter.capturedRequests[1].messages.containsToolResult(toolCallId: "tool_1"))
+    }
+
+    func testNativeAgentLoopServiceExecutesMultiToolCallsBeforeRerun() async throws {
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(toolCallId: "", content: "ok")
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { request in
+            if request.messages.toolResultCount >= 2 {
+                return [.done(text: "done")]
+            }
+            return [
+                .toolUse(toolCallId: "tool_1", toolName: "calendar.create", toolInputJSON: "{\"title\":\"A\"}"),
+                .toolUse(toolCallId: "tool_2", toolName: "calculator", toolInputJSON: "{\"expression\":\"1+1\"}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService
+        )
+
+        let events = try await collectEvents(from: service.run(request: makeRequest(provider: .anthropic)))
+
+        XCTAssertEqual(events.map(\.kind), [.toolUse, .toolUse, .toolResult, .toolResult, .done])
+        XCTAssertEqual(toolService.executeCallCount, 2)
+        XCTAssertEqual(adapter.capturedRequests.count, 2)
+        XCTAssertEqual(adapter.capturedRequests[1].messages.toolResultCount, 2)
+    }
+
+    func testNativeAgentLoopServiceBlocksRepeatedToolSignatureWithGuard() async {
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(toolCallId: "", content: "ok")
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { _ in
+            [
+                .toolUse(toolCallId: "tool_1", toolName: "calendar.create", toolInputJSON: "{\"title\":\"A\"}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService,
+            guardPolicy: NativeAgentLoopGuardPolicy(
+                maxIterations: 8,
+                maxRepeatedSignatures: 1
+            )
+        )
+
+        let result = await collectEventsAndError(from: service.run(request: makeRequest(provider: .anthropic)))
+
+        XCTAssertEqual(toolService.executeCallCount, 1)
+        XCTAssertEqual(result.events.map(\.kind), [.toolUse, .toolResult, .toolUse])
+        guard let error = result.error as? NativeLLMError else {
+            return XCTFail("Expected NativeLLMError")
+        }
+        XCTAssertEqual(error.code, .loopGuardTriggered)
+    }
+
+    func testNativeAgentLoopServiceTerminatesOnToolError() async {
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(
+            toolCallId: "",
+            content: "permission denied",
+            isError: true
+        )
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { _ in
+            [
+                .toolUse(toolCallId: "tool_1", toolName: "shell.execute", toolInputJSON: "{\"cmd\":\"rm -rf /\"}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService
+        )
+
+        let result = await collectEventsAndError(from: service.run(request: makeRequest(provider: .anthropic)))
+
+        XCTAssertEqual(result.events.map(\.kind), [.toolUse, .toolResult])
+        XCTAssertEqual(result.events.last?.isToolResultError, true)
+        XCTAssertEqual(toolService.executeCallCount, 1)
+        XCTAssertEqual(adapter.capturedRequests.count, 1)
+
+        guard let error = result.error as? NativeLLMError else {
+            return XCTFail("Expected NativeLLMError")
+        }
+        XCTAssertEqual(error.code, .toolExecutionFailed)
     }
 }
 
@@ -59,9 +182,23 @@ private extension NativeAgentLoopServiceTests {
         }
         return events
     }
+
+    func collectEventsAndError(
+        from stream: AsyncThrowingStream<NativeLLMStreamEvent, Error>
+    ) async -> (events: [NativeLLMStreamEvent], error: Error?) {
+        var events: [NativeLLMStreamEvent] = []
+        do {
+            for try await event in stream {
+                events.append(event)
+            }
+            return (events, nil)
+        } catch {
+            return (events, error)
+        }
+    }
 }
 
-private struct StubNativeLLMProviderAdapter: NativeLLMProviderAdapter {
+private struct StaticNativeLLMProviderAdapter: NativeLLMProviderAdapter {
     let provider: LLMProvider
     let events: [NativeLLMStreamEvent]
 
@@ -71,6 +208,67 @@ private struct StubNativeLLMProviderAdapter: NativeLLMProviderAdapter {
                 continuation.yield(event)
             }
             continuation.finish()
+        }
+    }
+}
+
+private final class CapturingNativeLLMProviderAdapter: @unchecked Sendable, NativeLLMProviderAdapter {
+    typealias EventBuilder = @Sendable (NativeLLMRequest) throws -> [NativeLLMStreamEvent]
+
+    let provider: LLMProvider
+    private let eventBuilder: EventBuilder
+    private(set) var capturedRequests: [NativeLLMRequest] = []
+
+    init(provider: LLMProvider, eventBuilder: @escaping EventBuilder) {
+        self.provider = provider
+        self.eventBuilder = eventBuilder
+    }
+
+    func stream(request: NativeLLMRequest) -> AsyncThrowingStream<NativeLLMStreamEvent, Error> {
+        capturedRequests.append(request)
+        return AsyncThrowingStream { continuation in
+            do {
+                let events = try eventBuilder(request)
+                for event in events {
+                    continuation.yield(event)
+                }
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+    }
+}
+
+private extension Array where Element == NativeLLMMessage {
+    var toolResultCount: Int {
+        reduce(into: 0) { count, message in
+            count += message.contents.filter {
+                if case .toolResult = $0 { return true }
+                return false
+            }.count
+        }
+    }
+
+    func containsToolResult(toolCallId: String) -> Bool {
+        contains { message in
+            message.contents.contains {
+                if case .toolResult(let id, _, _) = $0 {
+                    return id == toolCallId
+                }
+                return false
+            }
+        }
+    }
+
+    func containsToolUse(toolCallId: String) -> Bool {
+        contains { message in
+            message.contents.contains {
+                if case .toolUse(let id, _, _) = $0 {
+                    return id == toolCallId
+                }
+                return false
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement `NativeAgentLoopService` tool loop orchestration: `tool_use -> execute -> tool_result -> rerun`
- add configurable loop guards (`maxIterations`, `maxRepeatedSignatures`) and deterministic termination on tool failures
- wire tool execution through `BuiltInToolServiceProtocol` (including MCP-prefixed tools through existing built-in routing)
- extend native message model to persist assistant `tool_use` blocks for provider follow-up calls
- update Anthropic adapter encoder to serialize assistant `tool_use` content blocks
- add integration-style tests for single/multi tool calls, repeated-signature guard, and tool-error termination

## UX Planning
- skipped for this issue: `#321` is runtime loop/architecture work with no user-facing screen change

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/NativeAgentLoopServiceTests -only-testing:DochiTests/AnthropicNativeLLMProviderAdapterTests`

## Spec Impact
- none (runtime implementation aligned to existing native rewrite track)

Closes #321
