### PR TITLE
fix: [Native Rewrite][Phase 2] native loop usage metrics integration

### DIFF
--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -1393,7 +1393,8 @@ final class DochiViewModel {
             let result = await processNativeAgentLoop(
                 input: input,
                 provider: target.provider,
-                model: target.model
+                model: target.model,
+                wasFallback: index > 0
             )
 
             switch result {
@@ -1430,10 +1431,16 @@ final class DochiViewModel {
     private func processNativeAgentLoop(
         input _: String,
         provider: LLMProvider,
-        model: String
+        model: String,
+        wasFallback: Bool
     ) async -> NativeLoopAttemptResult {
         var fallbackReason: String?
         var cancelled = false
+        let startedAt = Date()
+        var firstPartialLatency: TimeInterval?
+        var doneInputTokens: Int?
+        var doneOutputTokens: Int?
+        var didReceiveDoneEvent = false
 
         do {
             let request = try buildNativeLLMRequestFromConversation(
@@ -1459,6 +1466,9 @@ final class DochiViewModel {
                 case .partial:
                     processingSubState = .streaming
                     if let delta = event.text {
+                        if firstPartialLatency == nil, !delta.isEmpty {
+                            firstPartialLatency = Date().timeIntervalSince(startedAt)
+                        }
                         accumulatedText += delta
                         streamingText = accumulatedText
                     }
@@ -1479,9 +1489,21 @@ final class DochiViewModel {
                     appendToolResultMessage(toolResult)
 
                 case .done:
+                    didReceiveDoneEvent = true
+                    doneInputTokens = event.inputTokens
+                    doneOutputTokens = event.outputTokens
                     let finalText = event.text ?? accumulatedText
+                    let totalLatency = Date().timeIntervalSince(startedAt)
+                    let metadata = buildNativeMessageMetadata(
+                        provider: provider,
+                        model: model,
+                        inputTokens: doneInputTokens,
+                        outputTokens: doneOutputTokens,
+                        totalLatency: totalLatency,
+                        wasFallback: wasFallback
+                    )
                     if !finalText.isEmpty {
-                        appendAssistantMessage(finalText)
+                        appendAssistantMessage(finalText, metadata: metadata)
                     }
                     streamingText = ""
                     processingSubState = .complete
@@ -1528,10 +1550,33 @@ final class DochiViewModel {
         }
 
         // Clean up
-        if !streamingText.isEmpty {
-            appendAssistantMessage(streamingText)
+        let totalLatency = Date().timeIntervalSince(startedAt)
+        if !didReceiveDoneEvent, !streamingText.isEmpty {
+            let metadata = buildNativeMessageMetadata(
+                provider: provider,
+                model: model,
+                inputTokens: doneInputTokens,
+                outputTokens: doneOutputTokens,
+                totalLatency: totalLatency,
+                wasFallback: wasFallback
+            )
+            appendAssistantMessage(streamingText, metadata: metadata)
             streamingText = ""
         }
+
+        if doneInputTokens == nil && doneOutputTokens == nil {
+            Log.runtime.debug("Native loop usage unavailable for \(provider.rawValue)/\(model); recording nil token metrics")
+        }
+
+        recordNativeExchangeMetrics(
+            provider: provider,
+            model: model,
+            inputTokens: doneInputTokens,
+            outputTokens: doneOutputTokens,
+            firstByteLatency: firstPartialLatency,
+            totalLatency: totalLatency,
+            wasFallback: wasFallback
+        )
         return .success
     }
 
@@ -3402,6 +3447,54 @@ final class DochiViewModel {
         let memoryInfo = buildMemoryContextInfo()
         currentConversation?.messages.append(Message(role: .assistant, content: text, metadata: metadata, toolExecutionRecords: toolExecutionRecords, memoryContextInfo: memoryInfo.hasAnyMemory ? memoryInfo : nil, ragContextInfo: ragLastContextInfo))
         currentConversation?.updatedAt = Date()
+    }
+
+    private func buildNativeMessageMetadata(
+        provider: LLMProvider,
+        model: String,
+        inputTokens: Int?,
+        outputTokens: Int?,
+        totalLatency: TimeInterval,
+        wasFallback: Bool
+    ) -> MessageMetadata {
+        MessageMetadata(
+            provider: provider.rawValue,
+            model: model,
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            totalLatency: totalLatency,
+            wasFallback: wasFallback
+        )
+    }
+
+    private func recordNativeExchangeMetrics(
+        provider: LLMProvider,
+        model: String,
+        inputTokens: Int?,
+        outputTokens: Int?,
+        firstByteLatency: TimeInterval?,
+        totalLatency: TimeInterval,
+        wasFallback: Bool
+    ) {
+        let totalTokens: Int?
+        if inputTokens == nil && outputTokens == nil {
+            totalTokens = nil
+        } else {
+            totalTokens = (inputTokens ?? 0) + (outputTokens ?? 0)
+        }
+
+        metricsCollector.record(ExchangeMetrics(
+            provider: provider.rawValue,
+            model: model,
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            totalTokens: totalTokens,
+            firstByteLatency: firstByteLatency,
+            totalLatency: totalLatency,
+            timestamp: Date(),
+            wasFallback: wasFallback,
+            agentName: settings.activeAgentName
+        ))
     }
 
     private func appendToolResultMessage(_ result: ToolResult) {

--- a/DochiTests/NativeSessionRoutingTests.swift
+++ b/DochiTests/NativeSessionRoutingTests.swift
@@ -282,6 +282,92 @@ final class NativeSessionRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testNativeLoopRecordsUsageMetricsFromDoneEvent() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+
+        let adapter = StubNativeProviderAdapter(
+            provider: .openai,
+            eventsPerRequest: [[.done(text: "usage-response", inputTokens: 21, outputTokens: 8)]]
+        )
+        let nativeService = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: MockBuiltInToolService()
+        )
+
+        let keychain = MockKeychainService()
+        keychain.store[LLMProvider.openai.keychainAccount] = "openai-test-key"
+        let metricsCollector = MetricsCollector()
+        let usageStore = MockUsageStore()
+        metricsCollector.usageStore = usageStore
+
+        let viewModel = makeViewModel(
+            bridge: bridge,
+            provider: .openai,
+            nativeLoopService: nativeService,
+            keychainService: keychain,
+            metricsCollector: metricsCollector
+        )
+        viewModel.inputText = "hello"
+        viewModel.sendMessage()
+
+        try await Task.sleep(for: .milliseconds(260))
+
+        XCTAssertEqual(metricsCollector.recentMetrics.count, 1)
+        XCTAssertEqual(metricsCollector.recentMetrics.last?.inputTokens, 21)
+        XCTAssertEqual(metricsCollector.recentMetrics.last?.outputTokens, 8)
+
+        try await Task.sleep(for: .milliseconds(80))
+        XCTAssertEqual(usageStore.recordedMetrics.count, 1)
+        XCTAssertEqual(usageStore.recordedMetrics.last?.inputTokens, 21)
+        XCTAssertEqual(usageStore.recordedMetrics.last?.outputTokens, 8)
+
+        let assistantMessage = try XCTUnwrap(viewModel.currentConversation?.messages.last(where: { $0.role == .assistant }))
+        XCTAssertEqual(assistantMessage.metadata?.inputTokens, 21)
+        XCTAssertEqual(assistantMessage.metadata?.outputTokens, 8)
+    }
+
+    @MainActor
+    func testNativeLoopRecordsNilUsageWhenProviderDoesNotReturnUsage() async throws {
+        let bridge = MockRuntimeBridgeService()
+        bridge.runtimeState = .ready
+
+        let adapter = StubNativeProviderAdapter(
+            provider: .ollama,
+            eventsPerRequest: [[.done(text: "no-usage-response")]]
+        )
+        let nativeService = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: MockBuiltInToolService()
+        )
+
+        let metricsCollector = MetricsCollector()
+        let usageStore = MockUsageStore()
+        metricsCollector.usageStore = usageStore
+
+        let viewModel = makeViewModel(
+            bridge: bridge,
+            provider: .ollama,
+            nativeLoopService: nativeService,
+            metricsCollector: metricsCollector
+        )
+        viewModel.inputText = "hello"
+        viewModel.sendMessage()
+
+        try await Task.sleep(for: .milliseconds(260))
+
+        XCTAssertEqual(metricsCollector.recentMetrics.count, 1)
+        XCTAssertNil(metricsCollector.recentMetrics.last?.inputTokens)
+        XCTAssertNil(metricsCollector.recentMetrics.last?.outputTokens)
+
+        try await Task.sleep(for: .milliseconds(80))
+        XCTAssertEqual(usageStore.recordedMetrics.count, 1)
+        XCTAssertNil(usageStore.recordedMetrics.last?.inputTokens)
+        XCTAssertNil(usageStore.recordedMetrics.last?.outputTokens)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
     func testTelegramMessageUsesNativeLoopAndSkipsRuntimeBridge() async {
         let bridge = MockRuntimeBridgeService()
         bridge.runtimeState = .ready
@@ -328,10 +414,12 @@ final class NativeSessionRoutingTests: XCTestCase {
         toolService: MockBuiltInToolService? = nil,
         model: String? = nil,
         keychainService: MockKeychainService? = nil,
-        settingsTransform: ((AppSettings) -> Void)? = nil
+        settingsTransform: ((AppSettings) -> Void)? = nil,
+        metricsCollector: MetricsCollector? = nil
     ) -> DochiViewModel {
         let resolvedToolService = toolService ?? MockBuiltInToolService()
         let resolvedKeychainService = keychainService ?? MockKeychainService()
+        let resolvedMetricsCollector = metricsCollector ?? MetricsCollector()
         let settings = AppSettings()
         settings.nativeAgentLoopEnabled = true
         settings.llmProvider = provider.rawValue
@@ -356,6 +444,7 @@ final class NativeSessionRoutingTests: XCTestCase {
             soundService: MockSoundService(),
             settings: settings,
             sessionContext: SessionContext(workspaceId: UUID()),
+            metricsCollector: resolvedMetricsCollector,
             runtimeBridge: bridge,
             nativeAgentLoopService: nativeLoopService,
             modelRouter: router


### PR DESCRIPTION
## Summary
- Collect native loop `done.inputTokens`/`done.outputTokens` in `processNativeAgentLoop`
- Persist native exchange usage through `MetricsCollector.record(...)` so UsageStore/dashboard receives token data on native path
- Attach per-message native metadata (`provider/model/tokens/latency/fallback`) when assistant message is appended
- Define missing-usage fallback as `nil` token recording (no estimation, no error), with explicit runtime log
- Add native session routing tests for both usage-present and usage-missing providers

## Spec Impact
- Implements #358 acceptance:
  - native done usage forwarded to metrics/usage store
  - usage-missing responses keep previous behavior without errors
  - regression tests added for both branches

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/NativeSessionRoutingTests`
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests`

Closes #358
