### PR TITLE
feat: extract SessionMappingServiceProtocol for testable DI

### DIFF
--- a/Dochi/Services/Protocols/SessionMappingServiceProtocol.swift
+++ b/Dochi/Services/Protocols/SessionMappingServiceProtocol.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Protocol for session mapping persistence and lookup.
+///
+/// Maps Dochi session keys to SDK session IDs so sessions can be resumed.
+/// The composite key (`workspaceId + agentId + conversationId`) uniquely
+/// identifies a logical session; `deviceId` is excluded from lookup to
+/// support cross-device resume.
+///
+/// @MainActor required: session state is shared across services
+/// (SessionResumeService, CrossDeviceResumeService) which are all
+/// MainActor-isolated. Keeping this protocol on MainActor prevents
+/// data races without additional locking.
+@MainActor
+protocol SessionMappingServiceProtocol {
+    /// Look up an existing active mapping by composite key (deviceId excluded for cross-device resume).
+    func findActive(
+        workspaceId: String,
+        agentId: String,
+        conversationId: String
+    ) -> SessionMapping?
+
+    /// Find a mapping by its Dochi session ID.
+    func findBySessionId(_ sessionId: String) -> SessionMapping?
+
+    /// Insert a new mapping and persist.
+    func insert(_ mapping: SessionMapping)
+
+    /// Update the status of a mapping by session ID.
+    func updateStatus(sessionId: String, status: SessionMappingStatus)
+
+    /// Update the device ID for a session mapping (cross-device resume).
+    ///
+    /// Called when a session is resumed from a different device so the mapping
+    /// reflects the current device for audit and future lookups.
+    func updateDeviceId(sessionId: String, newDeviceId: String)
+
+    /// Touch the last-active timestamp for a session.
+    func touch(sessionId: String)
+
+    /// Return all mappings (for session.list).
+    var allMappings: [SessionMapping] { get }
+
+    /// Return only active mappings.
+    var activeMappings: [SessionMapping] { get }
+
+    /// Remove closed/interrupted mappings older than the given interval.
+    func pruneStale(olderThan interval: TimeInterval)
+}

--- a/Dochi/Services/Runtime/CrossDeviceResumeService.swift
+++ b/Dochi/Services/Runtime/CrossDeviceResumeService.swift
@@ -16,7 +16,7 @@ final class CrossDeviceResumeService: CrossDeviceResumeServiceProtocol {
 
     // MARK: - Dependencies
 
-    private let sessionMappingService: SessionMappingService
+    private let sessionMappingService: any SessionMappingServiceProtocol
     private let bridge: any RuntimeBridgeProtocol
 
     // MARK: - State
@@ -26,7 +26,7 @@ final class CrossDeviceResumeService: CrossDeviceResumeServiceProtocol {
     // MARK: - Init
 
     init(
-        sessionMappingService: SessionMappingService,
+        sessionMappingService: any SessionMappingServiceProtocol,
         bridge: any RuntimeBridgeProtocol
     ) {
         self.sessionMappingService = sessionMappingService

--- a/Dochi/Services/Runtime/SessionMappingService.swift
+++ b/Dochi/Services/Runtime/SessionMappingService.swift
@@ -6,7 +6,7 @@ import Foundation
 /// after runtime restart. Data is stored as JSON at:
 /// `~/Library/Application Support/Dochi/session_mappings.json`
 @MainActor
-final class SessionMappingService {
+final class SessionMappingService: SessionMappingServiceProtocol {
     private let fileURL: URL
     private var store: SessionMappingStore
     private var lookupIndex: [SessionLookupKey: Int] = [:]

--- a/Dochi/Services/Session/SessionResumeService.swift
+++ b/Dochi/Services/Session/SessionResumeService.swift
@@ -22,14 +22,14 @@ final class SessionResumeService: SessionResumeServiceProtocol {
 
     // MARK: - Dependencies
 
-    private let sessionMappingService: SessionMappingService
+    private let sessionMappingService: any SessionMappingServiceProtocol
     private let leaseService: any ExecutionLeaseServiceProtocol
     private let channelMapper: ChannelSessionMapper
 
     // MARK: - Init
 
     init(
-        sessionMappingService: SessionMappingService,
+        sessionMappingService: any SessionMappingServiceProtocol,
         leaseService: any ExecutionLeaseServiceProtocol,
         channelMapper: ChannelSessionMapper
     ) {

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -1951,3 +1951,94 @@ final class MockShadowSubAgentOrchestrator: ShadowSubAgentOrchestratorProtocol {
         currentState = .idle
     }
 }
+
+// MARK: - MockSessionMappingService (#297)
+
+@MainActor
+final class MockSessionMappingService: SessionMappingServiceProtocol {
+    var mappings: [SessionMapping] = []
+
+    var findActiveCallCount = 0
+    var findBySessionIdCallCount = 0
+    var insertCallCount = 0
+    var updateStatusCallCount = 0
+    var updateDeviceIdCallCount = 0
+    var touchCallCount = 0
+    var pruneStaleCallCount = 0
+
+    var lastInsertedMapping: SessionMapping?
+    var lastUpdatedSessionId: String?
+    var lastUpdatedStatus: SessionMappingStatus?
+    var lastUpdatedDeviceId: String?
+    var lastTouchedSessionId: String?
+    var lastPruneInterval: TimeInterval?
+
+    func findActive(
+        workspaceId: String,
+        agentId: String,
+        conversationId: String
+    ) -> SessionMapping? {
+        findActiveCallCount += 1
+        return mappings.first { mapping in
+            mapping.workspaceId == workspaceId
+            && mapping.agentId == agentId
+            && mapping.conversationId == conversationId
+            && mapping.status == .active
+        }
+    }
+
+    func findBySessionId(_ sessionId: String) -> SessionMapping? {
+        findBySessionIdCallCount += 1
+        return mappings.first { $0.sessionId == sessionId }
+    }
+
+    func insert(_ mapping: SessionMapping) {
+        insertCallCount += 1
+        lastInsertedMapping = mapping
+        mappings.append(mapping)
+    }
+
+    func updateStatus(sessionId: String, status: SessionMappingStatus) {
+        updateStatusCallCount += 1
+        lastUpdatedSessionId = sessionId
+        lastUpdatedStatus = status
+        if let idx = mappings.firstIndex(where: { $0.sessionId == sessionId }) {
+            mappings[idx].status = status
+            mappings[idx].lastActiveAt = Date()
+        }
+    }
+
+    func updateDeviceId(sessionId: String, newDeviceId: String) {
+        updateDeviceIdCallCount += 1
+        lastUpdatedDeviceId = newDeviceId
+        if let idx = mappings.firstIndex(where: { $0.sessionId == sessionId }) {
+            mappings[idx].deviceId = newDeviceId
+            mappings[idx].lastActiveAt = Date()
+        }
+    }
+
+    func touch(sessionId: String) {
+        touchCallCount += 1
+        lastTouchedSessionId = sessionId
+        if let idx = mappings.firstIndex(where: { $0.sessionId == sessionId }) {
+            mappings[idx].lastActiveAt = Date()
+        }
+    }
+
+    var allMappings: [SessionMapping] {
+        mappings
+    }
+
+    var activeMappings: [SessionMapping] {
+        mappings.filter { $0.status == .active }
+    }
+
+    func pruneStale(olderThan interval: TimeInterval) {
+        pruneStaleCallCount += 1
+        lastPruneInterval = interval
+        let cutoff = Date().addingTimeInterval(-interval)
+        mappings.removeAll { mapping in
+            mapping.status != .active && mapping.lastActiveAt < cutoff
+        }
+    }
+}

--- a/DochiTests/SessionMappingProtocolTests.swift
+++ b/DochiTests/SessionMappingProtocolTests.swift
@@ -1,0 +1,406 @@
+import XCTest
+@testable import Dochi
+
+/// Tests for SessionMappingServiceProtocol extraction (Issue #297).
+///
+/// Validates:
+/// - MockSessionMappingService correctly implements the protocol
+/// - SessionResumeService accepts protocol-based DI (MockSessionMappingService)
+/// - CrossDeviceResumeService accepts protocol-based DI (MockSessionMappingService)
+/// - Mock call tracking works correctly for test assertions
+final class SessionMappingProtocolTests: XCTestCase {
+
+    // MARK: - MockSessionMappingService CRUD
+
+    @MainActor
+    func testMockInsertAndFindActive() {
+        let mock = MockSessionMappingService()
+        let mapping = makeMapping(sessionId: "s-1")
+        mock.insert(mapping)
+
+        XCTAssertEqual(mock.insertCallCount, 1)
+        XCTAssertEqual(mock.lastInsertedMapping?.sessionId, "s-1")
+
+        let found = mock.findActive(
+            workspaceId: "ws-1",
+            agentId: "a-1",
+            conversationId: "c-1"
+        )
+        XCTAssertEqual(mock.findActiveCallCount, 1)
+        XCTAssertNotNil(found)
+        XCTAssertEqual(found?.sessionId, "s-1")
+    }
+
+    @MainActor
+    func testMockFindBySessionId() {
+        let mock = MockSessionMappingService()
+        mock.insert(makeMapping(sessionId: "s-1"))
+
+        let found = mock.findBySessionId("s-1")
+        XCTAssertEqual(mock.findBySessionIdCallCount, 1)
+        XCTAssertNotNil(found)
+
+        let notFound = mock.findBySessionId("nonexistent")
+        XCTAssertNil(notFound)
+        XCTAssertEqual(mock.findBySessionIdCallCount, 2)
+    }
+
+    @MainActor
+    func testMockUpdateStatus() {
+        let mock = MockSessionMappingService()
+        mock.insert(makeMapping(sessionId: "s-1"))
+
+        mock.updateStatus(sessionId: "s-1", status: .closed)
+
+        XCTAssertEqual(mock.updateStatusCallCount, 1)
+        XCTAssertEqual(mock.lastUpdatedSessionId, "s-1")
+        XCTAssertEqual(mock.lastUpdatedStatus, .closed)
+
+        let mapping = mock.findBySessionId("s-1")
+        XCTAssertEqual(mapping?.status, .closed)
+    }
+
+    @MainActor
+    func testMockUpdateDeviceId() {
+        let mock = MockSessionMappingService()
+        mock.insert(makeMapping(sessionId: "s-1", deviceId: "device-A"))
+
+        mock.updateDeviceId(sessionId: "s-1", newDeviceId: "device-B")
+
+        XCTAssertEqual(mock.updateDeviceIdCallCount, 1)
+        XCTAssertEqual(mock.lastUpdatedDeviceId, "device-B")
+
+        let mapping = mock.findBySessionId("s-1")
+        XCTAssertEqual(mapping?.deviceId, "device-B")
+    }
+
+    @MainActor
+    func testMockTouch() {
+        let mock = MockSessionMappingService()
+        let original = makeMapping(sessionId: "s-1")
+        mock.insert(original)
+
+        mock.touch(sessionId: "s-1")
+
+        XCTAssertEqual(mock.touchCallCount, 1)
+        XCTAssertEqual(mock.lastTouchedSessionId, "s-1")
+
+        let updated = mock.findBySessionId("s-1")
+        XCTAssertNotNil(updated)
+        XCTAssertGreaterThanOrEqual(updated!.lastActiveAt, original.lastActiveAt)
+    }
+
+    @MainActor
+    func testMockAllAndActiveMappings() {
+        let mock = MockSessionMappingService()
+        mock.insert(makeMapping(sessionId: "s-1", conversationId: "c-1"))
+        mock.insert(makeMapping(sessionId: "s-2", conversationId: "c-2"))
+        mock.updateStatus(sessionId: "s-2", status: .closed)
+
+        XCTAssertEqual(mock.allMappings.count, 2)
+        XCTAssertEqual(mock.activeMappings.count, 1)
+        XCTAssertEqual(mock.activeMappings[0].sessionId, "s-1")
+    }
+
+    @MainActor
+    func testMockFindActiveReturnsNilForClosed() {
+        let mock = MockSessionMappingService()
+        mock.insert(makeMapping(sessionId: "s-1"))
+        mock.updateStatus(sessionId: "s-1", status: .closed)
+
+        let found = mock.findActive(
+            workspaceId: "ws-1",
+            agentId: "a-1",
+            conversationId: "c-1"
+        )
+        XCTAssertNil(found)
+    }
+
+    @MainActor
+    func testMockPruneStale() {
+        let mock = MockSessionMappingService()
+        var oldMapping = makeMapping(sessionId: "s-old", conversationId: "c-old")
+        oldMapping.status = .closed
+        oldMapping.lastActiveAt = Date(timeIntervalSinceNow: -100000)
+        mock.insert(oldMapping)
+
+        mock.insert(makeMapping(sessionId: "s-new", conversationId: "c-new"))
+
+        mock.pruneStale(olderThan: 86400)
+
+        XCTAssertEqual(mock.pruneStaleCallCount, 1)
+        XCTAssertEqual(mock.lastPruneInterval, 86400)
+        XCTAssertEqual(mock.allMappings.count, 1)
+        XCTAssertEqual(mock.allMappings[0].sessionId, "s-new")
+    }
+
+    // MARK: - CrossDeviceResumeService with Mock DI
+
+    @MainActor
+    func testCrossDeviceResumeWithMockMapping() async {
+        let mockMapping = MockSessionMappingService()
+        let mockBridge = MockRuntimeBridgeService()
+        mockBridge.runtimeState = .ready
+
+        let service = CrossDeviceResumeService(
+            sessionMappingService: mockMapping,
+            bridge: mockBridge
+        )
+
+        // Insert an active mapping
+        mockMapping.insert(makeMapping(sessionId: "s-1", deviceId: "mac-home"))
+
+        let result = await service.resolveSession(
+            workspaceId: "ws-1",
+            agentId: "a-1",
+            conversationId: "c-1",
+            userId: "u-1",
+            deviceId: "mac-office"
+        )
+
+        // Should resume cross-device
+        if case .resumed(let sessionId, _, let previousDeviceId) = result {
+            XCTAssertEqual(sessionId, "s-1")
+            XCTAssertEqual(previousDeviceId, "mac-home")
+        } else {
+            XCTFail("Expected .resumed but got \(result)")
+        }
+
+        // Mock should track the calls
+        XCTAssertEqual(mockMapping.findActiveCallCount, 1)
+        XCTAssertEqual(mockMapping.updateDeviceIdCallCount, 1)
+        XCTAssertEqual(mockMapping.lastUpdatedDeviceId, "mac-office")
+        XCTAssertEqual(mockBridge.openCallCount, 0)
+    }
+
+    @MainActor
+    func testCrossDeviceResumeCreatesNewSessionWithMockMapping() async {
+        let mockMapping = MockSessionMappingService()
+        let mockBridge = MockRuntimeBridgeService()
+        mockBridge.runtimeState = .ready
+        mockBridge.stubbedOpenResult = SessionOpenResult(
+            sessionId: "new-s-1",
+            sdkSessionId: "new-sdk-1",
+            created: true
+        )
+
+        let service = CrossDeviceResumeService(
+            sessionMappingService: mockMapping,
+            bridge: mockBridge
+        )
+
+        // No existing mapping
+        let result = await service.resolveSession(
+            workspaceId: "ws-1",
+            agentId: "a-1",
+            conversationId: "c-1",
+            userId: "u-1",
+            deviceId: "mac-home"
+        )
+
+        if case .created(let sessionId, let sdkSessionId) = result {
+            XCTAssertEqual(sessionId, "new-s-1")
+            XCTAssertEqual(sdkSessionId, "new-sdk-1")
+        } else {
+            XCTFail("Expected .created but got \(result)")
+        }
+
+        // Mock should have been called to insert the new mapping
+        XCTAssertEqual(mockMapping.insertCallCount, 1)
+        XCTAssertEqual(mockMapping.lastInsertedMapping?.sessionId, "new-s-1")
+        XCTAssertEqual(mockBridge.openCallCount, 1)
+    }
+
+    @MainActor
+    func testCrossDeviceResumeSameDeviceWithMockMapping() async {
+        let mockMapping = MockSessionMappingService()
+        let mockBridge = MockRuntimeBridgeService()
+        mockBridge.runtimeState = .ready
+
+        let service = CrossDeviceResumeService(
+            sessionMappingService: mockMapping,
+            bridge: mockBridge
+        )
+
+        // Insert an active mapping from the same device
+        mockMapping.insert(makeMapping(sessionId: "s-1", deviceId: "mac-home"))
+
+        let result = await service.resolveSession(
+            workspaceId: "ws-1",
+            agentId: "a-1",
+            conversationId: "c-1",
+            userId: "u-1",
+            deviceId: "mac-home"
+        )
+
+        // Should resume on same device
+        if case .resumed(let sessionId, _, let previousDeviceId) = result {
+            XCTAssertEqual(sessionId, "s-1")
+            XCTAssertNil(previousDeviceId)
+        } else {
+            XCTFail("Expected .resumed but got \(result)")
+        }
+
+        // touch should have been called (same device)
+        XCTAssertEqual(mockMapping.touchCallCount, 1)
+        XCTAssertEqual(mockMapping.lastTouchedSessionId, "s-1")
+        // updateDeviceId should NOT have been called (same device)
+        XCTAssertEqual(mockMapping.updateDeviceIdCallCount, 0)
+    }
+
+    @MainActor
+    func testCrossDeviceResumeUserIdMismatchWithMock() async {
+        let mockMapping = MockSessionMappingService()
+        let mockBridge = MockRuntimeBridgeService()
+        mockBridge.runtimeState = .ready
+        mockBridge.stubbedOpenResult = SessionOpenResult(
+            sessionId: "new-s-1",
+            sdkSessionId: "new-sdk-1",
+            created: true
+        )
+
+        let service = CrossDeviceResumeService(
+            sessionMappingService: mockMapping,
+            bridge: mockBridge
+        )
+
+        // Insert mapping owned by user-1
+        mockMapping.insert(makeMapping(sessionId: "s-1", userId: "user-1", deviceId: "mac-home"))
+
+        // Different user tries to resume
+        let result = await service.resolveSession(
+            workspaceId: "ws-1",
+            agentId: "a-1",
+            conversationId: "c-1",
+            userId: "user-2",
+            deviceId: "attacker-device"
+        )
+
+        // Should create a new session (hijack prevention)
+        if case .created(let sessionId, _) = result {
+            XCTAssertEqual(sessionId, "new-s-1")
+        } else {
+            XCTFail("Expected .created (hijack prevention) but got \(result)")
+        }
+
+        // Original mapping should be untouched
+        XCTAssertEqual(mockMapping.touchCallCount, 0)
+        XCTAssertEqual(mockMapping.updateDeviceIdCallCount, 0)
+    }
+
+    // MARK: - SessionResumeService with Mock DI
+
+    @MainActor
+    func testSessionResumeServiceAcceptsMockMapping() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionMappingProtocolTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let mockMapping = MockSessionMappingService()
+        let mockLease = MockExecutionLeaseService()
+        let channelMapper = ChannelSessionMapper(baseURL: tempDir)
+        let deviceId = UUID()
+        mockLease.setNextDeviceId(deviceId)
+
+        let service = SessionResumeService(
+            sessionMappingService: mockMapping,
+            leaseService: mockLease,
+            channelMapper: channelMapper
+        )
+
+        // No existing mapping -> should create new session
+        let request = SessionResumeRequest(
+            sourceChannel: .voice,
+            workspaceId: UUID(),
+            agentId: "a-1",
+            conversationId: "c-1",
+            userId: "u-1",
+            requestingDeviceId: deviceId
+        )
+
+        let result = try await service.resumeSession(request)
+
+        if case .newSession(_, _, let reason) = result {
+            XCTAssertEqual(reason, .sessionNotFound)
+        } else {
+            XCTFail("Expected .newSession but got \(result)")
+        }
+
+        // Mock mapping should have been called to insert the new mapping
+        XCTAssertEqual(mockMapping.insertCallCount, 1)
+        XCTAssertEqual(mockLease.acquireCallCount, 1)
+    }
+
+    @MainActor
+    func testSessionResumeCanResumeWithMockMapping() {
+        let mockMapping = MockSessionMappingService()
+        let mockLease = MockExecutionLeaseService()
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionMappingProtocolTests-canResume-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let channelMapper = ChannelSessionMapper(baseURL: tempDir)
+
+        let service = SessionResumeService(
+            sessionMappingService: mockMapping,
+            leaseService: mockLease,
+            channelMapper: channelMapper
+        )
+
+        // No mappings -> canResume should be false
+        XCTAssertFalse(service.canResume(conversationId: "c-1"))
+
+        // Insert a mapping -> canResume should be true
+        mockMapping.insert(makeMapping(sessionId: "s-1", conversationId: "c-1"))
+        XCTAssertTrue(service.canResume(conversationId: "c-1"))
+    }
+
+    // MARK: - Protocol Conformance Verification
+
+    @MainActor
+    func testConcreteServiceConformsToProtocol() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionMappingProtocolTests-conformance-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Verify that the concrete service can be assigned to the protocol type
+        let concrete = SessionMappingService(baseURL: tempDir)
+        let _: any SessionMappingServiceProtocol = concrete
+
+        concrete.insert(makeMapping(sessionId: "s-1"))
+        let found = concrete.findActive(
+            workspaceId: "ws-1",
+            agentId: "a-1",
+            conversationId: "c-1"
+        )
+        XCTAssertNotNil(found)
+    }
+
+    // MARK: - Helpers
+
+    private func makeMapping(
+        sessionId: String,
+        sdkSessionId: String = "sdk-1",
+        workspaceId: String = "ws-1",
+        agentId: String = "a-1",
+        conversationId: String = "c-1",
+        userId: String = "u-1",
+        deviceId: String = "d-1"
+    ) -> SessionMapping {
+        SessionMapping(
+            sessionId: sessionId,
+            sdkSessionId: sdkSessionId,
+            workspaceId: workspaceId,
+            agentId: agentId,
+            conversationId: conversationId,
+            userId: userId,
+            deviceId: deviceId,
+            status: .active,
+            createdAt: Date(),
+            lastActiveAt: Date()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `SessionMappingServiceProtocol` from concrete `SessionMappingService` to enable mock injection in tests
- Update `SessionResumeService` and `CrossDeviceResumeService` to accept `any SessionMappingServiceProtocol` (protocol-based DI)
- Add `MockSessionMappingService` to `DochiTests/Mocks/MockServices.swift` with full call tracking
- Add 15 unit tests in `SessionMappingProtocolTests` covering mock CRUD, protocol DI injection into `CrossDeviceResumeService` and `SessionResumeService`, and concrete conformance verification

Closes #297

## Test plan
- [x] All 15 new `SessionMappingProtocolTests` pass
- [x] All 23 existing `SessionMappingTests` pass (no regression)
- [x] All 17 existing `CrossDeviceResumeTests` pass (no regression)
- [x] All 37 existing `SessionResumeTests` pass (no regression)
- [x] Clean build succeeds
- [x] `MockSessionMappingService` correctly implements all protocol methods with call tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)