### PR TITLE
feat: [Native Rewrite][Phase 4] wire live native latency metrics to gate

### DIFF
--- a/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
+++ b/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
@@ -37,6 +37,7 @@ final class NativeAgentLoopService {
     private let adapters: [LLMProvider: any NativeLLMProviderAdapter]
     private let toolService: (any BuiltInToolServiceProtocol)?
     private let hookPipeline: HookPipeline
+    private let runtimeMetrics: (any RuntimeMetricsProtocol)?
     private let guardPolicy: NativeAgentLoopGuardPolicy
     private var memoryPipeline: (any MemoryPipelineProtocol)?
     private(set) var auditLog: [ToolAuditEvent] = []
@@ -45,6 +46,7 @@ final class NativeAgentLoopService {
         adapters: [any NativeLLMProviderAdapter],
         toolService: (any BuiltInToolServiceProtocol)? = nil,
         hookPipeline: HookPipeline = HookPipeline(),
+        runtimeMetrics: (any RuntimeMetricsProtocol)? = nil,
         memoryPipeline: (any MemoryPipelineProtocol)? = nil,
         guardPolicy: NativeAgentLoopGuardPolicy = .default
     ) {
@@ -55,6 +57,7 @@ final class NativeAgentLoopService {
         self.adapters = map
         self.toolService = toolService
         self.hookPipeline = hookPipeline
+        self.runtimeMetrics = runtimeMetrics
         self.memoryPipeline = memoryPipeline
         self.guardPolicy = guardPolicy
     }
@@ -101,6 +104,8 @@ final class NativeAgentLoopService {
                     var iteration = 0
                     var lastToolSignature: String?
                     var repeatedSignatureCount = 0
+                    let runStartedAt = Date()
+                    var didRecordFirstPartial = false
 
                     while !Task.isCancelled {
                         iteration += 1
@@ -127,6 +132,18 @@ final class NativeAgentLoopService {
                             case .partial:
                                 if let text = event.text {
                                     accumulatedAssistantText += text
+                                    if !didRecordFirstPartial, !text.isEmpty {
+                                        didRecordFirstPartial = true
+                                        let firstPartialLatencyMs = Date().timeIntervalSince(runStartedAt) * 1000
+                                        runtimeMetrics?.recordHistogram(
+                                            name: MetricName.firstPartialLatencyMs,
+                                            labels: Self.metricLabels(
+                                                provider: currentRequest.provider.rawValue,
+                                                sessionId: resolvedHookContext.sessionId
+                                            ),
+                                            value: firstPartialLatencyMs
+                                        )
+                                    }
                                 }
                                 continuation.yield(event)
 
@@ -293,6 +310,15 @@ final class NativeAgentLoopService {
                             ))
 
                             let latencyMs = Int(Date().timeIntervalSince(startTime) * 1000)
+                            runtimeMetrics?.recordHistogram(
+                                name: MetricName.toolLatencyMs,
+                                labels: Self.metricLabels(
+                                    provider: currentRequest.provider.rawValue,
+                                    sessionId: resolvedHookContext.sessionId,
+                                    toolName: pending.name
+                                ),
+                                value: Double(latencyMs)
+                            )
                             _ = hookPipeline.runPostHooks(
                                 context: toolHookContext,
                                 result: result,
@@ -390,6 +416,21 @@ private extension NativeAgentLoopService {
             workspaceId: workspaceId,
             agentId: context.agentId
         )
+    }
+
+    private static func metricLabels(
+        provider: String,
+        sessionId: String,
+        toolName: String? = nil
+    ) -> [String: String] {
+        var labels: [String: String] = [
+            "provider": provider,
+            "session": sessionId
+        ]
+        if let toolName, !toolName.isEmpty {
+            labels["tool"] = toolName
+        }
+        return labels
     }
 
     private static func makeToolSignature(for toolUses: [PendingToolUse]) -> String {

--- a/DochiTests/NativeAgentLoopServiceTests.swift
+++ b/DochiTests/NativeAgentLoopServiceTests.swift
@@ -63,6 +63,115 @@ final class NativeAgentLoopServiceTests: XCTestCase {
         }
     }
 
+    func testNativeAgentLoopServiceRecordsFirstPartialLatencyMetric() async throws {
+        let runtimeMetrics = MockRuntimeMetrics()
+        let adapter = StaticNativeLLMProviderAdapter(
+            provider: .anthropic,
+            events: [.partial("hello"), .done(text: "hello")]
+        )
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            runtimeMetrics: runtimeMetrics
+        )
+
+        _ = try await collectEvents(
+            from: service.run(
+                request: makeRequest(provider: .anthropic),
+                hookContext: NativeAgentLoopHookContext(
+                    sessionId: "session-metric-1",
+                    workspaceId: "workspace-1",
+                    agentId: "도치"
+                )
+            )
+        )
+
+        let keys = runtimeMetrics.histogramValues.keys.filter { $0.hasPrefix(MetricName.firstPartialLatencyMs) }
+        XCTAssertEqual(keys.count, 1)
+        let key = try XCTUnwrap(keys.first)
+        XCTAssertTrue(key.contains("provider=anthropic"))
+        XCTAssertTrue(key.contains("session=session-metric-1"))
+        XCTAssertFalse(key.contains("tool="))
+    }
+
+    func testNativeAgentLoopServiceRecordsToolLatencyMetricWithStandardLabels() async throws {
+        let runtimeMetrics = MockRuntimeMetrics()
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(toolCallId: "", content: "ok")
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { request in
+            if request.messages.containsToolResult(toolCallId: "tool_1") {
+                return [.done(text: "done")]
+            }
+            return [
+                .toolUse(toolCallId: "tool_1", toolName: "calendar.create", toolInputJSON: "{\"title\":\"회의\"}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService,
+            runtimeMetrics: runtimeMetrics
+        )
+
+        _ = try await collectEvents(
+            from: service.run(
+                request: makeRequest(provider: .anthropic),
+                hookContext: NativeAgentLoopHookContext(
+                    sessionId: "session-metric-2",
+                    workspaceId: "workspace-2",
+                    agentId: "도치"
+                )
+            )
+        )
+
+        let keys = runtimeMetrics.histogramValues.keys.filter { $0.hasPrefix(MetricName.toolLatencyMs) }
+        XCTAssertEqual(keys.count, 1)
+        let key = try XCTUnwrap(keys.first)
+        XCTAssertTrue(key.contains("provider=anthropic"))
+        XCTAssertTrue(key.contains("session=session-metric-2"))
+        XCTAssertTrue(key.contains("tool=calendar.create"))
+    }
+
+    func testNativeAgentLoopServiceLiveMetricsAppearInSnapshotForGate() async throws {
+        let runtimeMetrics = RuntimeMetrics()
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(toolCallId: "", content: "created")
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { request in
+            if request.messages.containsToolResult(toolCallId: "tool_1") {
+                return [.partial("완료"), .done(text: "완료")]
+            }
+            return [
+                .toolUse(toolCallId: "tool_1", toolName: "calendar.create", toolInputJSON: "{\"title\":\"회의\"}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService,
+            runtimeMetrics: runtimeMetrics
+        )
+
+        _ = try await collectEvents(
+            from: service.run(
+                request: makeRequest(provider: .anthropic),
+                hookContext: NativeAgentLoopHookContext(
+                    sessionId: "session-metric-3",
+                    workspaceId: "workspace-3",
+                    agentId: "도치"
+                )
+            )
+        )
+
+        let snapshot = runtimeMetrics.snapshot()
+        let firstPartialHistograms = snapshot.histograms.values.filter { $0.name == MetricName.firstPartialLatencyMs }
+        let toolLatencyHistograms = snapshot.histograms.values.filter { $0.name == MetricName.toolLatencyMs }
+        XCTAssertFalse(firstPartialHistograms.isEmpty)
+        XCTAssertFalse(toolLatencyHistograms.isEmpty)
+    }
+
     func testNativeAgentLoopServiceExecutesToolAndReruns() async throws {
         let toolService = MockBuiltInToolService()
         toolService.stubbedResult = ToolResult(toolCallId: "", content: "created")


### PR DESCRIPTION
## Summary
- Inject `RuntimeMetricsProtocol` into `NativeAgentLoopService` and record live-path histograms
  - `dochi_first_partial_latency_ms` on first streaming partial
  - `dochi_tool_latency_ms` on each tool execution completion
- Standardize metric labels around `provider`, `session`, and optional `tool` for consistent snapshot aggregation
- Add native-loop tests for:
  - first-partial metric emission + label assertions
  - tool-latency metric emission + label assertions
  - live-path metrics surfacing in `RuntimeMetrics.snapshot()` for gate consumption

## Spec Impact
- Implements #355 work items on live runtime instrumentation and label standardization
- Adds a live-path regression scenario proving gate-consumable histogram output from real native loop execution

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/NativeAgentLoopServiceTests`
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests`

Closes #355
