### PR TITLE
feat: introduce RpcError class for type-safe error handling (#299)

### DIFF
--- a/dochi-agent-runtime/src/handlers/session.ts
+++ b/dochi-agent-runtime/src/handlers/session.ts
@@ -12,6 +12,7 @@ import {
   type SessionEntry,
   SESSION_NOT_FOUND,
   SESSION_ALREADY_CLOSED,
+  RpcError,
 } from "./types";
 
 // In-memory session store
@@ -63,10 +64,10 @@ export function handleSessionOpen(params: SessionOpenParams): SessionOpenResult 
 export function handleSessionRun(params: SessionRunParams): SessionRunResult {
   const entry = sessions.get(params.sessionId);
   if (!entry) {
-    throw { code: SESSION_NOT_FOUND, message: `Session not found: ${params.sessionId}` };
+    throw new RpcError(SESSION_NOT_FOUND, `Session not found: ${params.sessionId}`);
   }
   if (entry.status !== "active") {
-    throw { code: SESSION_ALREADY_CLOSED, message: `Session is ${entry.status}: ${params.sessionId}` };
+    throw new RpcError(SESSION_ALREADY_CLOSED, `Session is ${entry.status}: ${params.sessionId}`);
   }
 
   entry.lastActiveAt = new Date().toISOString();
@@ -78,7 +79,7 @@ export function handleSessionRun(params: SessionRunParams): SessionRunResult {
 export function handleSessionInterrupt(params: SessionInterruptParams): SessionInterruptResult {
   const entry = sessions.get(params.sessionId);
   if (!entry) {
-    throw { code: SESSION_NOT_FOUND, message: `Session not found: ${params.sessionId}` };
+    throw new RpcError(SESSION_NOT_FOUND, `Session not found: ${params.sessionId}`);
   }
 
   entry.status = "interrupted";
@@ -91,7 +92,7 @@ export function handleSessionInterrupt(params: SessionInterruptParams): SessionI
 export function handleSessionClose(params: SessionCloseParams): SessionCloseResult {
   const entry = sessions.get(params.sessionId);
   if (!entry) {
-    throw { code: SESSION_NOT_FOUND, message: `Session not found: ${params.sessionId}` };
+    throw new RpcError(SESSION_NOT_FOUND, `Session not found: ${params.sessionId}`);
   }
 
   entry.status = "closed";

--- a/dochi-agent-runtime/src/handlers/types.ts
+++ b/dochi-agent-runtime/src/handlers/types.ts
@@ -197,6 +197,36 @@ export const TOOL_TIMEOUT = -32012;
 export const TOOL_PERMISSION_DENIED = -32013;
 export const TOOL_HOOK_BLOCKED = -32014;
 
+/**
+ * Structured RPC error class for type-safe error handling in handlers.
+ *
+ * Throw `new RpcError(code, message)` from any handler to produce a
+ * well-formed JSON-RPC error response. The `rpc-server` catches these
+ * via `instanceof RpcError` and maps them directly to {@link JsonRpcError}.
+ */
+export class RpcError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(message);
+    this.name = "RpcError";
+    this.code = code;
+    this.data = data;
+    // Restore prototype chain broken by extending built-in Error
+    Object.setPrototypeOf(this, RpcError.prototype);
+  }
+
+  /** Convert to the JSON-RPC error envelope shape. */
+  toJsonRpcError(): JsonRpcError {
+    const err: JsonRpcError = { code: this.code, message: this.message };
+    if (this.data !== undefined) {
+      err.data = this.data;
+    }
+    return err;
+  }
+}
+
 // Context snapshot types
 
 export interface ContextPushParams {

--- a/dochi-agent-runtime/src/rpc-server.ts
+++ b/dochi-agent-runtime/src/rpc-server.ts
@@ -7,6 +7,7 @@ import {
   METHOD_NOT_FOUND,
   PARSE_ERROR,
   INTERNAL_ERROR,
+  RpcError,
 } from "./handlers/types";
 import {
   handleInitialize,
@@ -91,14 +92,12 @@ function processRequest(request: JsonRpcRequest): JsonRpcResponse {
     const result = handler(request.params);
     return { jsonrpc: "2.0", id: request.id, result };
   } catch (err) {
-    // Support structured error objects { code, message } from handlers
-    if (typeof err === "object" && err !== null && "code" in err && "message" in err) {
-      const structured = err as { code: number; message: string };
-      setLastError(structured.message);
+    if (err instanceof RpcError) {
+      setLastError(err.message);
       return {
         jsonrpc: "2.0",
         id: request.id,
-        error: { code: structured.code, message: structured.message },
+        error: err.toJsonRpcError(),
       };
     }
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

- Introduce `RpcError extends Error` class in `types.ts` with `code: number`, `message: string`, `data?: unknown` fields and a `toJsonRpcError()` helper
- Replace duck-typed `typeof err === "object" && "code" in err` check in `rpc-server.ts` with clean `instanceof RpcError` pattern
- Convert all 4 `throw { code, message }` plain object throws in `session.ts` to `throw new RpcError(code, message)`

Closes #299

## Changes

| File | What changed |
|---|---|
| `handlers/types.ts` | Added `RpcError` class with `code`, `data?`, and `toJsonRpcError()` |
| `handlers/session.ts` | 4x `throw {...}` → `throw new RpcError(...)` |
| `rpc-server.ts` | Error catch uses `instanceof RpcError` instead of duck typing |

## Design decisions

- **Location**: `RpcError` lives in `types.ts` alongside `JsonRpcError` interface and error code constants, keeping the error type system cohesive
- **`Object.setPrototypeOf`**: Required for correct `instanceof` behavior when extending built-in `Error` in TypeScript (ES2022 target)
- **`toJsonRpcError()`**: Convenience method that converts to the `JsonRpcError` interface shape, including optional `data` field only when present
- **`data?: unknown`**: Supports future use cases where handlers may attach structured metadata to error responses

## Test plan

- [x] `npx tsc --noEmit` passes (only pre-existing `ContextPushParams` type mismatch remains, unrelated to this PR)
- [x] Verified all `throw { code, message }` patterns are replaced (0 remaining via grep)
- [x] Error handling behavior is semantically identical: same error codes, same messages, same JSON-RPC response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)