### PR TITLE
feat: move SessionMappingService file I/O to background actor (#298)

### DIFF
--- a/Dochi/Services/Protocols/SessionMappingServiceProtocol.swift
+++ b/Dochi/Services/Protocols/SessionMappingServiceProtocol.swift
@@ -7,6 +7,11 @@ import Foundation
 /// identifies a logical session; `deviceId` is excluded from lookup to
 /// support cross-device resume.
 ///
+/// All methods are synchronous -- reads operate on in-memory state, and
+/// mutating methods update in-memory state immediately then schedule a
+/// background disk write. Call `flushPendingSave()` when you need to
+/// guarantee the on-disk file is up to date (e.g. in tests or at shutdown).
+///
 /// @MainActor required: session state is shared across services
 /// (SessionResumeService, CrossDeviceResumeService) which are all
 /// MainActor-isolated. Keeping this protocol on MainActor prevents
@@ -23,10 +28,10 @@ protocol SessionMappingServiceProtocol {
     /// Find a mapping by its Dochi session ID.
     func findBySessionId(_ sessionId: String) -> SessionMapping?
 
-    /// Insert a new mapping and persist.
+    /// Insert a new mapping and persist (background write).
     func insert(_ mapping: SessionMapping)
 
-    /// Update the status of a mapping by session ID.
+    /// Update the status of a mapping by session ID (background write).
     func updateStatus(sessionId: String, status: SessionMappingStatus)
 
     /// Update the device ID for a session mapping (cross-device resume).
@@ -35,7 +40,7 @@ protocol SessionMappingServiceProtocol {
     /// reflects the current device for audit and future lookups.
     func updateDeviceId(sessionId: String, newDeviceId: String)
 
-    /// Touch the last-active timestamp for a session.
+    /// Touch the last-active timestamp for a session (background write).
     func touch(sessionId: String)
 
     /// Return all mappings (for session.list).
@@ -44,6 +49,12 @@ protocol SessionMappingServiceProtocol {
     /// Return only active mappings.
     var activeMappings: [SessionMapping] { get }
 
-    /// Remove closed/interrupted mappings older than the given interval.
+    /// Remove closed/interrupted mappings older than the given interval (background write).
     func pruneStale(olderThan interval: TimeInterval)
+
+    /// Wait for any pending background save to complete.
+    ///
+    /// Call this in tests before asserting on-disk state, or during app
+    /// shutdown to guarantee data is flushed.
+    func flushPendingSave() async
 }

--- a/Dochi/Services/Runtime/SessionMappingService.swift
+++ b/Dochi/Services/Runtime/SessionMappingService.swift
@@ -1,36 +1,117 @@
 import Foundation
 
-/// File-based session mapping persistence.
+/// Dedicated actor for session mapping file I/O.
 ///
-/// Stores Dochi ↔ SDK session ID mappings so sessions can be resumed
-/// after runtime restart. Data is stored as JSON at:
-/// `~/Library/Application Support/Dochi/session_mappings.json`
-@MainActor
-final class SessionMappingService: SessionMappingServiceProtocol {
-    private let fileURL: URL
-    private var store: SessionMappingStore
-    private var lookupIndex: [SessionLookupKey: Int] = [:]
+/// Isolates all disk reads and writes to a background executor so that
+/// `SessionMappingService` (which lives on `@MainActor`) never blocks the
+/// main thread with file operations. Encoding and decoding are also performed
+/// here because `JSONEncoder`/`JSONDecoder` can be non-trivial for large stores.
+actor SessionMappingIO {
 
-    private static let encoder: JSONEncoder = {
+    private let fileURL: URL
+
+    private let encoder: JSONEncoder = {
         let e = JSONEncoder()
         e.dateEncodingStrategy = .iso8601
         e.outputFormatting = [.prettyPrinted, .sortedKeys]
         return e
     }()
 
-    private static let decoder: JSONDecoder = {
+    private let decoder: JSONDecoder = {
         let d = JSONDecoder()
         d.dateDecodingStrategy = .iso8601
         return d
     }()
 
+    init(fileURL: URL) {
+        self.fileURL = fileURL
+    }
+
+    /// Read and decode the session mapping store from disk.
+    /// Returns `nil` if the file does not exist.
+    func read() throws -> SessionMappingStore? {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+        let data = try Data(contentsOf: fileURL)
+        return try decoder.decode(SessionMappingStore.self, from: data)
+    }
+
+    /// Encode and write the session mapping store to disk atomically.
+    func write(_ store: SessionMappingStore) throws {
+        let dir = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let data = try encoder.encode(store)
+        try data.write(to: fileURL, options: .atomic)
+    }
+}
+
+// MARK: - SessionMappingService
+
+/// File-based session mapping persistence with async I/O.
+///
+/// Stores Dochi <-> SDK session ID mappings so sessions can be resumed
+/// after runtime restart. Data is stored as JSON at:
+/// `~/Library/Application Support/Dochi/session_mappings.json`
+///
+/// ## Async I/O Architecture (Issue #298)
+///
+/// All file I/O is delegated to `SessionMappingIO`, a dedicated background
+/// actor that keeps disk operations off the main thread:
+///
+/// - **Reads** are served from the in-memory `store` (synchronous, zero-cost).
+/// - **Writes** are coalesced: each mutation schedules a background save via
+///   `scheduleSave()`. If multiple mutations occur within a short window, only
+///   the last snapshot is written, reducing unnecessary disk traffic.
+/// - **Initial load** is `async` via the `create(baseURL:)` factory method,
+///   which reads the file on the IO actor before returning a fully-initialized
+///   service. A synchronous `init` is retained for backward compatibility
+///   (tests that create ephemeral instances with small or empty stores).
+@MainActor
+final class SessionMappingService: SessionMappingServiceProtocol {
+    private let io: SessionMappingIO
+    private var store: SessionMappingStore
+    private var lookupIndex: [SessionLookupKey: Int] = [:]
+
+    /// The currently-scheduled coalesced save task, if any.
+    private var pendingSaveTask: Task<Void, Never>?
+
+    // MARK: - Initialization
+
+    /// Async factory: loads existing data from disk on a background actor,
+    /// then returns a fully-initialized service on the main actor.
+    ///
+    /// Preferred for production use -- file I/O never touches the main thread.
+    static func create(baseURL: URL? = nil) async -> SessionMappingService {
+        let fileURL = Self.resolveFileURL(baseURL: baseURL)
+        let io = SessionMappingIO(fileURL: fileURL)
+
+        var store = SessionMappingStore()
+        do {
+            if let loaded = try await io.read() {
+                store = loaded
+                Log.runtime.info("Loaded \(store.mappings.count) session mapping(s)")
+            }
+        } catch {
+            Log.runtime.error("Failed to load session mappings: \(error.localizedDescription)")
+        }
+        return SessionMappingService(io: io, store: store)
+    }
+
+    /// Synchronous initializer -- retained for backward compatibility and tests.
+    ///
+    /// Performs a **synchronous** file read on the calling thread. In production,
+    /// prefer `SessionMappingService.create(baseURL:)` to keep the main thread free.
     init(baseURL: URL? = nil) {
-        let base = baseURL ?? FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        ).first!.appendingPathComponent("Dochi")
-        self.fileURL = base.appendingPathComponent("session_mappings.json")
+        let fileURL = Self.resolveFileURL(baseURL: baseURL)
+        self.io = SessionMappingIO(fileURL: fileURL)
         self.store = SessionMappingStore()
-        load()
+        loadSync(fileURL: fileURL)
+    }
+
+    /// Internal initializer used by the async factory.
+    private init(io: SessionMappingIO, store: SessionMappingStore) {
+        self.io = io
+        self.store = store
+        rebuildIndex()
     }
 
     // MARK: - CRUD
@@ -62,7 +143,7 @@ final class SessionMappingService: SessionMappingServiceProtocol {
     func insert(_ mapping: SessionMapping) {
         store.mappings.append(mapping)
         rebuildIndex()
-        save()
+        scheduleSave()
     }
 
     /// Update the status of a mapping by session ID.
@@ -73,7 +154,7 @@ final class SessionMappingService: SessionMappingServiceProtocol {
         store.mappings[idx].status = status
         store.mappings[idx].lastActiveAt = Date()
         rebuildIndex()
-        save()
+        scheduleSave()
     }
 
     /// Update the device ID for a session mapping (cross-device resume).
@@ -86,7 +167,7 @@ final class SessionMappingService: SessionMappingServiceProtocol {
         }
         store.mappings[idx].deviceId = newDeviceId
         store.mappings[idx].lastActiveAt = Date()
-        save()
+        scheduleSave()
     }
 
     /// Touch the last-active timestamp for a session.
@@ -96,7 +177,7 @@ final class SessionMappingService: SessionMappingServiceProtocol {
             return
         }
         store.mappings[idx].lastActiveAt = Date()
-        save()
+        scheduleSave()
     }
 
     /// Return all mappings (for session.list).
@@ -116,14 +197,30 @@ final class SessionMappingService: SessionMappingServiceProtocol {
             mapping.status != .active && mapping.lastActiveAt < cutoff
         }
         rebuildIndex()
-        save()
+        scheduleSave()
     }
 
-    // MARK: - Persistence
+    /// Wait for any pending background save to complete.
+    ///
+    /// Useful in tests to ensure persistence has flushed before asserting
+    /// on-disk state, and during app shutdown to avoid data loss.
+    func flushPendingSave() async {
+        await pendingSaveTask?.value
+    }
 
-    private func load() {
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: fileURL.path) else {
+    // MARK: - Persistence (private)
+
+    /// Resolve the JSON file URL from an optional base directory.
+    private static func resolveFileURL(baseURL: URL?) -> URL {
+        let base = baseURL ?? FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask
+        ).first!.appendingPathComponent("Dochi")
+        return base.appendingPathComponent("session_mappings.json")
+    }
+
+    /// Synchronous load for the backward-compatible `init(baseURL:)`.
+    private func loadSync(fileURL: URL) {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
             store = SessionMappingStore()
             rebuildIndex()
             return
@@ -131,7 +228,9 @@ final class SessionMappingService: SessionMappingServiceProtocol {
 
         do {
             let data = try Data(contentsOf: fileURL)
-            store = try Self.decoder.decode(SessionMappingStore.self, from: data)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            store = try decoder.decode(SessionMappingStore.self, from: data)
             Log.runtime.info("Loaded \(self.store.mappings.count) session mapping(s)")
         } catch {
             Log.runtime.error("Failed to load session mappings: \(error.localizedDescription)")
@@ -140,14 +239,26 @@ final class SessionMappingService: SessionMappingServiceProtocol {
         rebuildIndex()
     }
 
-    private func save() {
-        do {
-            let dir = fileURL.deletingLastPathComponent()
-            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            let data = try Self.encoder.encode(store)
-            try data.write(to: fileURL, options: .atomic)
-        } catch {
-            Log.runtime.error("Failed to save session mappings: \(error.localizedDescription)")
+    /// Schedule a coalesced background save.
+    ///
+    /// Cancels any previously-scheduled save and starts a new one after a
+    /// brief yield, so rapid mutations (e.g. `insert` + `updateStatus` in
+    /// the same run-loop tick) produce only a single disk write.
+    private func scheduleSave() {
+        pendingSaveTask?.cancel()
+        let snapshot = store
+        let ioActor = io
+        pendingSaveTask = Task {
+            // Yield to allow further mutations in the same run-loop iteration
+            // to coalesce before we actually write.
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+
+            do {
+                try await ioActor.write(snapshot)
+            } catch {
+                Log.runtime.error("Failed to save session mappings: \(error.localizedDescription)")
+            }
         }
     }
 

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -2041,4 +2041,8 @@ final class MockSessionMappingService: SessionMappingServiceProtocol {
             mapping.status != .active && mapping.lastActiveAt < cutoff
         }
     }
+
+    func flushPendingSave() async {
+        // No-op for mock -- in-memory only, no pending saves.
+    }
 }

--- a/DochiTests/SessionMappingTests.swift
+++ b/DochiTests/SessionMappingTests.swift
@@ -215,17 +215,20 @@ final class SessionMappingTests: XCTestCase {
         XCTAssertEqual(service.activeMappings[0].sessionId, "s-1")
     }
 
-    // MARK: - Persistence
+    // MARK: - Persistence (async I/O -- Issue #298)
 
     @MainActor
-    func testPersistenceRoundTrip() {
+    func testPersistenceRoundTrip() async {
         // Insert with first service instance
         let service1 = SessionMappingService(baseURL: tempDir)
         service1.insert(makeMapping(sessionId: "s-1", sdkSessionId: "sdk-1"))
         service1.insert(makeMapping(sessionId: "s-2", sdkSessionId: "sdk-2",
                                     conversationId: "c-2"))
 
-        // Create second instance — should load from file
+        // Flush the coalesced background save before reading from disk
+        await service1.flushPendingSave()
+
+        // Create second instance -- should load from file
         let service2 = SessionMappingService(baseURL: tempDir)
         XCTAssertEqual(service2.allMappings.count, 2)
         XCTAssertNotNil(service2.findBySessionId("s-1"))
@@ -233,10 +236,12 @@ final class SessionMappingTests: XCTestCase {
     }
 
     @MainActor
-    func testPersistenceAfterStatusUpdate() {
+    func testPersistenceAfterStatusUpdate() async {
         let service1 = SessionMappingService(baseURL: tempDir)
         service1.insert(makeMapping(sessionId: "s-1", sdkSessionId: "sdk-1"))
         service1.updateStatus(sessionId: "s-1", status: .closed)
+
+        await service1.flushPendingSave()
 
         let service2 = SessionMappingService(baseURL: tempDir)
         let mapping = service2.findBySessionId("s-1")
@@ -278,7 +283,7 @@ final class SessionMappingTests: XCTestCase {
         service.insert(makeMapping(sessionId: "s-1", sdkSessionId: "sdk-1"))
         service.updateStatus(sessionId: "s-1", status: .closed)
 
-        // Same key but session is closed — should not reuse
+        // Same key but session is closed -- should not reuse
         let found = service.findActive(
             workspaceId: "ws-1", agentId: "a-1",
             conversationId: "c-1"
@@ -303,10 +308,12 @@ final class SessionMappingTests: XCTestCase {
     }
 
     @MainActor
-    func testUpdateDeviceIdPersists() {
+    func testUpdateDeviceIdPersists() async {
         let service1 = SessionMappingService(baseURL: tempDir)
         service1.insert(makeMapping(sessionId: "s-1", sdkSessionId: "sdk-1", deviceId: "device-A"))
         service1.updateDeviceId(sessionId: "s-1", newDeviceId: "device-B")
+
+        await service1.flushPendingSave()
 
         // Reload from disk
         let service2 = SessionMappingService(baseURL: tempDir)
@@ -319,7 +326,7 @@ final class SessionMappingTests: XCTestCase {
         let service = SessionMappingService(baseURL: tempDir)
         service.insert(makeMapping(sessionId: "s-1", sdkSessionId: "sdk-1", deviceId: "device-A"))
 
-        // Update nonexistent session — should be a no-op
+        // Update nonexistent session -- should be a no-op
         service.updateDeviceId(sessionId: "nonexistent", newDeviceId: "device-B")
 
         let mapping = service.findBySessionId("s-1")
@@ -356,6 +363,113 @@ final class SessionMappingTests: XCTestCase {
 
         // Active sessions are never pruned
         XCTAssertEqual(service.allMappings.count, 1)
+    }
+
+    // MARK: - Async Factory (Issue #298)
+
+    @MainActor
+    func testAsyncCreateLoadsFromDisk() async {
+        // Seed data using sync init
+        let seeder = SessionMappingService(baseURL: tempDir)
+        seeder.insert(makeMapping(sessionId: "s-1", sdkSessionId: "sdk-1"))
+        seeder.insert(makeMapping(sessionId: "s-2", sdkSessionId: "sdk-2",
+                                  conversationId: "c-2"))
+        await seeder.flushPendingSave()
+
+        // Load via async factory -- file I/O runs on background actor
+        let service = await SessionMappingService.create(baseURL: tempDir)
+        XCTAssertEqual(service.allMappings.count, 2)
+        XCTAssertNotNil(service.findBySessionId("s-1"))
+        XCTAssertNotNil(service.findBySessionId("s-2"))
+    }
+
+    @MainActor
+    func testAsyncCreateEmptyDirectory() async {
+        let emptyDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SessionMappingTests-empty-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: emptyDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: emptyDir) }
+
+        let service = await SessionMappingService.create(baseURL: emptyDir)
+        XCTAssertEqual(service.allMappings.count, 0)
+    }
+
+    @MainActor
+    func testAsyncCreateHandlesCorruptFile() async {
+        // Write corrupt data to the expected file path
+        let fileURL = tempDir.appendingPathComponent("session_mappings.json")
+        try? "not valid json".data(using: .utf8)?.write(to: fileURL)
+
+        // Should gracefully fall back to empty store
+        let service = await SessionMappingService.create(baseURL: tempDir)
+        XCTAssertEqual(service.allMappings.count, 0)
+    }
+
+    // MARK: - Coalesced Save (Issue #298)
+
+    @MainActor
+    func testCoalescedSaveWritesLatestSnapshot() async {
+        let service = SessionMappingService(baseURL: tempDir)
+
+        // Rapid mutations -- only the final state should be persisted
+        service.insert(makeMapping(sessionId: "s-1", sdkSessionId: "sdk-1"))
+        service.insert(makeMapping(sessionId: "s-2", sdkSessionId: "sdk-2",
+                                   conversationId: "c-2"))
+        service.updateStatus(sessionId: "s-1", status: .closed)
+
+        await service.flushPendingSave()
+
+        // Verify on-disk state matches final in-memory state
+        let reloaded = SessionMappingService(baseURL: tempDir)
+        XCTAssertEqual(reloaded.allMappings.count, 2)
+
+        let m1 = reloaded.findBySessionId("s-1")
+        XCTAssertEqual(m1?.status, .closed)
+
+        let m2 = reloaded.findBySessionId("s-2")
+        XCTAssertEqual(m2?.status, .active)
+    }
+
+    @MainActor
+    func testFlushPendingSaveIsNoOpWhenNoPending() async {
+        let service = SessionMappingService(baseURL: tempDir)
+        // Should not crash or hang when there is nothing to flush
+        await service.flushPendingSave()
+    }
+
+    // MARK: - SessionMappingIO Actor (Issue #298)
+
+    func testIOActorReadWriteRoundTrip() async throws {
+        let fileURL = tempDir.appendingPathComponent("io_test.json")
+        let io = SessionMappingIO(fileURL: fileURL)
+
+        // Initially nil (file does not exist)
+        let initial = try await io.read()
+        XCTAssertNil(initial)
+
+        // Write a store
+        let mapping = makeMapping(sessionId: "s-io", sdkSessionId: "sdk-io")
+        let store = SessionMappingStore(mappings: [mapping], version: 1)
+        try await io.write(store)
+
+        // Read it back
+        let loaded = try await io.read()
+        XCTAssertNotNil(loaded)
+        XCTAssertEqual(loaded?.mappings.count, 1)
+        XCTAssertEqual(loaded?.mappings[0].sessionId, "s-io")
+    }
+
+    func testIOActorCreatesIntermediateDirectories() async throws {
+        let nestedDir = tempDir
+            .appendingPathComponent("nested")
+            .appendingPathComponent("deep")
+        let fileURL = nestedDir.appendingPathComponent("session_mappings.json")
+        let io = SessionMappingIO(fileURL: fileURL)
+
+        let store = SessionMappingStore(mappings: [], version: 1)
+        try await io.write(store)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL.path))
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Introduce `SessionMappingIO` actor to isolate all disk reads/writes off the main thread, preventing UI jank as session count grows
- Add async factory `SessionMappingService.create(baseURL:)` that loads data on the IO actor before returning a fully-initialized service
- Replace synchronous `save()` with coalesced `scheduleSave()` that batches rapid mutations into a single background write via Task cancellation
- Add `flushPendingSave()` to protocol for deterministic test assertions and graceful app shutdown

## Changes
- **`SessionMappingIO` actor** (new): dedicated background executor for JSON encode/decode and file read/write
- **`SessionMappingService`**: delegates I/O to `SessionMappingIO`, keeps synchronous in-memory reads, coalesced background writes
- **Protocol**: adds `flushPendingSave() async` requirement; docs updated to reflect background write semantics
- **Mock**: adds no-op `flushPendingSave()` implementation
- **Tests**: updated persistence roundtrip tests to use `flushPendingSave()`; added 7 new tests for async factory, coalesced save, IO actor round-trip, corrupt file handling

## Architecture

```
┌─────────────────────────────┐
│   SessionMappingService     │  @MainActor
│   (in-memory store + index) │
│                             │
│  insert() ──┬──► scheduleSave()
│  update() ──┘       │
│                     ▼
│              ┌──────────────┐
│              │ Task (coalesce)│
│              └──────┬───────┘
│                     │ await
│              ┌──────▼───────┐
│              │SessionMappingIO│  actor (background)
│              │  .write(store)│
│              └──────────────┘
└─────────────────────────────┘
```

## Test plan
- [x] All 30 `SessionMappingTests` pass (including 7 new async I/O tests)
- [x] All 15 `SessionMappingProtocolTests` pass (mock conforms to updated protocol)
- [x] All 17 `SessionResumeTests` pass (no caller changes needed)
- [x] All 37 `CrossDeviceResumeTests` pass (no caller changes needed)
- [x] Full test suite: 2407 tests, 0 unit test failures

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)