### PR TITLE
feat: extract RpcError into dedicated module and expand error handling

### DIFF
--- a/dochi-agent-runtime/.gitignore
+++ b/dochi-agent-runtime/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+dist-test/
 *.tsbuildinfo

--- a/dochi-agent-runtime/package.json
+++ b/dochi-agent-runtime/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "dev": "ts-node src/index.ts",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/tests/",
+    "test:typecheck": "tsc --noEmit"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/dochi-agent-runtime/src/errors/rpc-error.ts
+++ b/dochi-agent-runtime/src/errors/rpc-error.ts
@@ -1,0 +1,57 @@
+import type { JsonRpcError } from "../handlers/types";
+
+// JSON-RPC 2.0 standard error codes
+export const PARSE_ERROR = -32700;
+export const INVALID_REQUEST = -32600;
+export const METHOD_NOT_FOUND = -32601;
+export const INVALID_PARAMS = -32602;
+export const INTERNAL_ERROR = -32603;
+
+// Dochi-specific error codes
+export const SESSION_NOT_FOUND = -32001;
+export const SESSION_ALREADY_CLOSED = -32002;
+export const RUNTIME_NOT_READY = -32003;
+export const SESSION_LIMIT_EXCEEDED = -32004;
+export const TOOL_NOT_FOUND = -32010;
+export const TOOL_EXECUTION_FAILED = -32011;
+export const TOOL_TIMEOUT = -32012;
+export const TOOL_PERMISSION_DENIED = -32013;
+export const TOOL_HOOK_BLOCKED = -32014;
+export const APPROVAL_NOT_FOUND = -32020;
+export const CONTEXT_NOT_FOUND = -32030;
+
+/**
+ * Structured RPC error class for type-safe error handling in handlers.
+ *
+ * Throw `new RpcError(code, message)` from any handler to produce a
+ * well-formed JSON-RPC error response. The `rpc-server` catches these
+ * via `instanceof RpcError` and maps them directly to {@link JsonRpcError}.
+ *
+ * @example
+ * ```ts
+ * throw new RpcError(SESSION_NOT_FOUND, `Session not found: ${id}`);
+ * throw new RpcError(TOOL_TIMEOUT, "Timed out", { toolCallId, elapsed });
+ * ```
+ */
+export class RpcError extends Error {
+  readonly code: number;
+  readonly data?: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(message);
+    this.name = "RpcError";
+    this.code = code;
+    this.data = data;
+    // Restore prototype chain broken by extending built-in Error
+    Object.setPrototypeOf(this, RpcError.prototype);
+  }
+
+  /** Convert to the JSON-RPC error envelope shape. */
+  toJsonRpcError(): JsonRpcError {
+    const err: JsonRpcError = { code: this.code, message: this.message };
+    if (this.data !== undefined) {
+      err.data = this.data;
+    }
+    return err;
+  }
+}

--- a/dochi-agent-runtime/src/handlers/approval.ts
+++ b/dochi-agent-runtime/src/handlers/approval.ts
@@ -1,7 +1,7 @@
 import * as crypto from "crypto";
 import type * as net from "net";
 import type { ApprovalResolveParams, ApprovalResolveAck } from "./types";
-import { TOOL_PERMISSION_DENIED } from "./types";
+import { TOOL_PERMISSION_DENIED, APPROVAL_NOT_FOUND, RpcError } from "../errors/rpc-error";
 
 /** Tracks a pending approval awaiting user decision from the app. */
 interface PendingApproval {
@@ -109,8 +109,11 @@ export function requestApproval(
 export function handleApprovalResolve(params: ApprovalResolveParams): ApprovalResolveAck {
   const pending = pendingApprovals.get(params.approvalId);
   if (!pending) {
-    console.error(`[approval] received resolve for unknown approvalId: ${params.approvalId}`);
-    return { received: false, approvalId: params.approvalId };
+    throw new RpcError(
+      APPROVAL_NOT_FOUND,
+      `No pending approval for approvalId: ${params.approvalId}`,
+      { approvalId: params.approvalId },
+    );
   }
 
   clearTimeout(pending.timer);

--- a/dochi-agent-runtime/src/handlers/runtime.ts
+++ b/dochi-agent-runtime/src/handlers/runtime.ts
@@ -1,10 +1,11 @@
 import * as crypto from "crypto";
-import {
-  type InitializeParams,
-  type InitializeResult,
-  type HealthResult,
-  type ShutdownResult,
+import type {
+  InitializeParams,
+  InitializeResult,
+  HealthResult,
+  ShutdownResult,
 } from "./types";
+import { RpcError, RUNTIME_NOT_READY, INVALID_PARAMS } from "../errors/rpc-error";
 import { getActiveSessionCount } from "./session";
 import { flushAllAudit } from "./hooks";
 
@@ -13,6 +14,13 @@ let lastError: string | null = null;
 let runtimeSessionId: string | null = null;
 
 export function handleInitialize(params: InitializeParams): InitializeResult {
+  if (!params.runtimeVersion || !params.configProfile) {
+    throw new RpcError(
+      INVALID_PARAMS,
+      "runtime.initialize requires runtimeVersion and configProfile",
+    );
+  }
+
   runtimeSessionId = crypto.randomUUID();
   console.error(
     `[runtime] initialized: version=${params.runtimeVersion} profile=${params.configProfile} sessionId=${runtimeSessionId}`

--- a/dochi-agent-runtime/src/handlers/session.ts
+++ b/dochi-agent-runtime/src/handlers/session.ts
@@ -1,24 +1,34 @@
 import * as crypto from "crypto";
+import type {
+  SessionOpenParams,
+  SessionOpenResult,
+  SessionRunParams,
+  SessionRunResult,
+  SessionInterruptParams,
+  SessionInterruptResult,
+  SessionCloseParams,
+  SessionCloseResult,
+  SessionListResult,
+  SessionEntry,
+} from "./types";
 import {
-  type SessionOpenParams,
-  type SessionOpenResult,
-  type SessionRunParams,
-  type SessionRunResult,
-  type SessionInterruptParams,
-  type SessionInterruptResult,
-  type SessionCloseParams,
-  type SessionCloseResult,
-  type SessionListResult,
-  type SessionEntry,
+  RpcError,
   SESSION_NOT_FOUND,
   SESSION_ALREADY_CLOSED,
-  RpcError,
-} from "./types";
+  INVALID_PARAMS,
+} from "../errors/rpc-error";
 
 // In-memory session store
 const sessions = new Map<string, SessionEntry>();
 
 export function handleSessionOpen(params: SessionOpenParams): SessionOpenResult {
+  if (!params.workspaceId || !params.agentId || !params.conversationId || !params.userId) {
+    throw new RpcError(
+      INVALID_PARAMS,
+      "session.open requires workspaceId, agentId, conversationId, and userId",
+    );
+  }
+
   // Build lookup key (deviceId excluded for cross-device resume — Issue #291)
   // Uses `:` separator — must match Swift SessionResumeService.normalizeSessionKey
   const lookupKey = `${params.workspaceId}:${params.agentId}:${params.conversationId}`;

--- a/dochi-agent-runtime/src/handlers/tool.ts
+++ b/dochi-agent-runtime/src/handlers/tool.ts
@@ -5,7 +5,7 @@ import type {
   ToolResultParams,
   ToolResultAck,
 } from "./types";
-import { TOOL_TIMEOUT } from "./types";
+import { TOOL_TIMEOUT, TOOL_NOT_FOUND, RpcError } from "../errors/rpc-error";
 
 /** Tracks a pending tool dispatch awaiting a result from the app. */
 interface PendingToolDispatch {
@@ -93,8 +93,11 @@ export function dispatchToolToApp(
 export function handleToolResult(params: ToolResultParams): ToolResultAck {
   const pending = pendingDispatches.get(params.toolCallId);
   if (!pending) {
-    console.error(`[tool] received result for unknown toolCallId: ${params.toolCallId}`);
-    return { received: false, toolCallId: params.toolCallId };
+    throw new RpcError(
+      TOOL_NOT_FOUND,
+      `No pending tool dispatch for toolCallId: ${params.toolCallId}`,
+      { toolCallId: params.toolCallId },
+    );
   }
 
   clearTimeout(pending.timer);

--- a/dochi-agent-runtime/src/handlers/types.ts
+++ b/dochi-agent-runtime/src/handlers/types.ts
@@ -179,53 +179,27 @@ export interface ApprovalResolveAck {
   approvalId: string;
 }
 
-// JSON-RPC error codes (standard)
-export const PARSE_ERROR = -32700;
-export const INVALID_REQUEST = -32600;
-export const METHOD_NOT_FOUND = -32601;
-export const INVALID_PARAMS = -32602;
-export const INTERNAL_ERROR = -32603;
-
-// Dochi-specific error codes
-export const SESSION_NOT_FOUND = -32001;
-export const SESSION_ALREADY_CLOSED = -32002;
-export const RUNTIME_NOT_READY = -32003;
-export const SESSION_LIMIT_EXCEEDED = -32004;
-export const TOOL_NOT_FOUND = -32010;
-export const TOOL_EXECUTION_FAILED = -32011;
-export const TOOL_TIMEOUT = -32012;
-export const TOOL_PERMISSION_DENIED = -32013;
-export const TOOL_HOOK_BLOCKED = -32014;
-
-/**
- * Structured RPC error class for type-safe error handling in handlers.
- *
- * Throw `new RpcError(code, message)` from any handler to produce a
- * well-formed JSON-RPC error response. The `rpc-server` catches these
- * via `instanceof RpcError` and maps them directly to {@link JsonRpcError}.
- */
-export class RpcError extends Error {
-  readonly code: number;
-  readonly data?: unknown;
-
-  constructor(code: number, message: string, data?: unknown) {
-    super(message);
-    this.name = "RpcError";
-    this.code = code;
-    this.data = data;
-    // Restore prototype chain broken by extending built-in Error
-    Object.setPrototypeOf(this, RpcError.prototype);
-  }
-
-  /** Convert to the JSON-RPC error envelope shape. */
-  toJsonRpcError(): JsonRpcError {
-    const err: JsonRpcError = { code: this.code, message: this.message };
-    if (this.data !== undefined) {
-      err.data = this.data;
-    }
-    return err;
-  }
-}
+// Re-export RpcError class and all error codes from the canonical module.
+// Handlers may import from either location; the errors module is the source of truth.
+export {
+  RpcError,
+  PARSE_ERROR,
+  INVALID_REQUEST,
+  METHOD_NOT_FOUND,
+  INVALID_PARAMS,
+  INTERNAL_ERROR,
+  SESSION_NOT_FOUND,
+  SESSION_ALREADY_CLOSED,
+  RUNTIME_NOT_READY,
+  SESSION_LIMIT_EXCEEDED,
+  TOOL_NOT_FOUND,
+  TOOL_EXECUTION_FAILED,
+  TOOL_TIMEOUT,
+  TOOL_PERMISSION_DENIED,
+  TOOL_HOOK_BLOCKED,
+  APPROVAL_NOT_FOUND,
+  CONTEXT_NOT_FOUND,
+} from "../errors/rpc-error";
 
 // Context snapshot types
 

--- a/dochi-agent-runtime/src/rpc-server.ts
+++ b/dochi-agent-runtime/src/rpc-server.ts
@@ -1,14 +1,13 @@
 import * as net from "net";
 import * as fs from "fs";
 import * as crypto from "crypto";
+import type { JsonRpcRequest, JsonRpcResponse } from "./handlers/types";
 import {
-  type JsonRpcRequest,
-  type JsonRpcResponse,
+  RpcError,
   METHOD_NOT_FOUND,
   PARSE_ERROR,
   INTERNAL_ERROR,
-  RpcError,
-} from "./handlers/types";
+} from "./errors/rpc-error";
 import {
   handleInitialize,
   handleHealth,
@@ -43,9 +42,11 @@ import {
   handleContextPush,
   handleContextResolve,
 } from "./handlers/context";
-import {
-  TOOL_HOOK_BLOCKED,
-} from "./handlers/types";
+import type {
+  ContextPushParams,
+  ContextResolveParams,
+} from "./handlers/context";
+import { TOOL_HOOK_BLOCKED } from "./errors/rpc-error";
 import type {
   SessionOpenParams,
   SessionRunParams,
@@ -53,8 +54,6 @@ import type {
   SessionCloseParams,
   ToolResultParams,
   ApprovalResolveParams,
-  ContextPushParams,
-  ContextResolveParams,
 } from "./handlers/types";
 
 type Handler = (params?: Record<string, unknown>) => unknown;

--- a/dochi-agent-runtime/tests/rpc-error.test.ts
+++ b/dochi-agent-runtime/tests/rpc-error.test.ts
@@ -1,0 +1,163 @@
+import { describe, it } from "node:test";
+import * as assert from "node:assert/strict";
+import {
+  RpcError,
+  PARSE_ERROR,
+  METHOD_NOT_FOUND,
+  INTERNAL_ERROR,
+  SESSION_NOT_FOUND,
+  SESSION_ALREADY_CLOSED,
+  INVALID_PARAMS,
+  TOOL_NOT_FOUND,
+  TOOL_TIMEOUT,
+  APPROVAL_NOT_FOUND,
+  CONTEXT_NOT_FOUND,
+} from "../src/errors/rpc-error";
+
+describe("RpcError", () => {
+  it("should be an instance of Error", () => {
+    const err = new RpcError(-32000, "test error");
+    assert.ok(err instanceof Error);
+  });
+
+  it("should be an instance of RpcError", () => {
+    const err = new RpcError(-32000, "test error");
+    assert.ok(err instanceof RpcError);
+  });
+
+  it("should have correct name", () => {
+    const err = new RpcError(-32000, "test error");
+    assert.equal(err.name, "RpcError");
+  });
+
+  it("should store code and message", () => {
+    const err = new RpcError(SESSION_NOT_FOUND, "Session not found: abc-123");
+    assert.equal(err.code, SESSION_NOT_FOUND);
+    assert.equal(err.message, "Session not found: abc-123");
+  });
+
+  it("should store optional data field", () => {
+    const data = { sessionId: "abc-123", extra: 42 };
+    const err = new RpcError(SESSION_NOT_FOUND, "Not found", data);
+    assert.deepEqual(err.data, data);
+  });
+
+  it("should have undefined data when not provided", () => {
+    const err = new RpcError(-32000, "test error");
+    assert.equal(err.data, undefined);
+  });
+
+  it("should produce correct stack trace", () => {
+    const err = new RpcError(-32000, "test error");
+    assert.ok(err.stack);
+    assert.ok(err.stack.includes("RpcError"));
+  });
+
+  describe("toJsonRpcError()", () => {
+    it("should return code and message without data", () => {
+      const err = new RpcError(METHOD_NOT_FOUND, "Method not found: foo.bar");
+      const jsonErr = err.toJsonRpcError();
+      assert.deepEqual(jsonErr, {
+        code: METHOD_NOT_FOUND,
+        message: "Method not found: foo.bar",
+      });
+    });
+
+    it("should include data field when present", () => {
+      const data = { detail: "extra info" };
+      const err = new RpcError(INTERNAL_ERROR, "Something broke", data);
+      const jsonErr = err.toJsonRpcError();
+      assert.deepEqual(jsonErr, {
+        code: INTERNAL_ERROR,
+        message: "Something broke",
+        data: { detail: "extra info" },
+      });
+    });
+
+    it("should include data even when data is null", () => {
+      const err = new RpcError(-32000, "test", null);
+      const jsonErr = err.toJsonRpcError();
+      assert.deepEqual(jsonErr, {
+        code: -32000,
+        message: "test",
+        data: null,
+      });
+    });
+
+    it("should exclude data when data is undefined", () => {
+      const err = new RpcError(-32000, "test");
+      const jsonErr = err.toJsonRpcError();
+      assert.ok(!("data" in jsonErr));
+    });
+  });
+
+  describe("prototype chain", () => {
+    it("should pass instanceof checks after Object.setPrototypeOf", () => {
+      const err = new RpcError(-32000, "test");
+      // Verify the prototype chain fix works
+      assert.ok(err instanceof RpcError);
+      assert.ok(err instanceof Error);
+      assert.ok(Object.getPrototypeOf(err) === RpcError.prototype);
+    });
+
+    it("should be catchable as RpcError in try/catch", () => {
+      let caught = false;
+      try {
+        throw new RpcError(SESSION_NOT_FOUND, "not found");
+      } catch (e) {
+        if (e instanceof RpcError) {
+          caught = true;
+          assert.equal(e.code, SESSION_NOT_FOUND);
+        }
+      }
+      assert.ok(caught, "RpcError should be caught by instanceof check");
+    });
+
+    it("should be distinguishable from plain Error", () => {
+      const rpcErr = new RpcError(-32000, "rpc");
+      const plainErr = new Error("plain");
+      assert.ok(rpcErr instanceof RpcError);
+      assert.ok(!(plainErr instanceof RpcError));
+    });
+  });
+
+  describe("error codes", () => {
+    it("standard JSON-RPC codes should be negative", () => {
+      assert.ok(PARSE_ERROR < 0);
+      assert.ok(METHOD_NOT_FOUND < 0);
+      assert.ok(INTERNAL_ERROR < 0);
+      assert.ok(INVALID_PARAMS < 0);
+    });
+
+    it("Dochi-specific codes should be in -32xxx range", () => {
+      const dochiCodes = [
+        SESSION_NOT_FOUND,
+        SESSION_ALREADY_CLOSED,
+        TOOL_NOT_FOUND,
+        TOOL_TIMEOUT,
+        APPROVAL_NOT_FOUND,
+        CONTEXT_NOT_FOUND,
+      ];
+      for (const code of dochiCodes) {
+        assert.ok(code >= -32999 && code <= -32000, `Code ${code} should be in -32xxx range`);
+      }
+    });
+
+    it("standard and Dochi codes should not overlap", () => {
+      const standardCodes = [PARSE_ERROR, METHOD_NOT_FOUND, INTERNAL_ERROR, INVALID_PARAMS];
+      const dochiCodes = [
+        SESSION_NOT_FOUND,
+        SESSION_ALREADY_CLOSED,
+        TOOL_NOT_FOUND,
+        TOOL_TIMEOUT,
+        APPROVAL_NOT_FOUND,
+        CONTEXT_NOT_FOUND,
+      ];
+      for (const sc of standardCodes) {
+        for (const dc of dochiCodes) {
+          assert.notEqual(sc, dc, `Standard code ${sc} overlaps with Dochi code ${dc}`);
+        }
+      }
+    });
+  });
+});

--- a/dochi-agent-runtime/tsconfig.test.json
+++ b/dochi-agent-runtime/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist-test",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- Extract `RpcError` class and all JSON-RPC error codes into dedicated `errors/rpc-error.ts` module with re-exports from `types.ts` for backward compatibility
- Add new Dochi-specific error codes: `APPROVAL_NOT_FOUND` (-32020), `CONTEXT_NOT_FOUND` (-32030)
- Convert silent error returns to structured `throw new RpcError(...)` in `handleToolResult`, `handleApprovalResolve`, `handleInitialize`, and `handleSessionOpen`
- Add `INVALID_PARAMS` validation guards to `runtime.initialize` and `session.open`
- Fix pre-existing `ContextPushParams` type conflict between `types.ts` and `context.ts`
- Add test infrastructure (`tsconfig.test.json`, `npm test` script) and 17 unit tests for `RpcError`

Closes #299

## Test plan
- [x] `npm run test:typecheck` passes (tsc --noEmit clean)
- [x] `npm run build` passes (tsc production build)
- [x] `npm test` passes (17/17 RpcError unit tests)
- [ ] Manual: verify `session.run` with invalid session returns structured JSON-RPC error
- [ ] Manual: verify `tool.result` with unknown toolCallId returns `-32010` error code
- [ ] Manual: verify `approval.resolve` with unknown approvalId returns `-32020` error code

🤖 Generated with [Claude Code](https://claude.com/claude-code)