### PR TITLE
fix: register runSession continuation before RPC send (#301)

### DIFF
--- a/Dochi/Services/Runtime/RuntimeBridgeService.swift
+++ b/Dochi/Services/Runtime/RuntimeBridgeService.swift
@@ -32,7 +32,8 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
     private var nextRequestId = 1
 
     /// Active session event stream continuations, keyed by sessionId.
-    private var sessionContinuations: [String: AsyncThrowingStream<BridgeEvent, Error>.Continuation] = [:]
+    /// Internal (not private) for @testable access in unit tests.
+    var sessionContinuations: [String: AsyncThrowingStream<BridgeEvent, Error>.Continuation] = [:]
 
     /// Handler for tool dispatch requests from the runtime.
     private(set) var toolDispatchHandler: ToolDispatchHandler?
@@ -213,40 +214,47 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
 
     func runSession(params: SessionRunParams) -> AsyncThrowingStream<BridgeEvent, Error> {
         let sessionId = params.sessionId
-        return AsyncThrowingStream { continuation in
+
+        // Use makeStream so the continuation is available synchronously.
+        // Register it in sessionContinuations **before** any RPC is sent,
+        // eliminating the race where an early notification from the runtime
+        // arrives before the continuation was stored (issue #301).
+        let (stream, continuation) = AsyncThrowingStream<BridgeEvent, Error>.makeStream()
+
+        sessionContinuations[sessionId] = continuation
+        continuation.onTermination = { @Sendable _ in
             Task { @MainActor [weak self] in
-                guard let self else {
-                    continuation.finish()
-                    return
-                }
-
-                self.sessionContinuations[sessionId] = continuation
-                continuation.onTermination = { @Sendable _ in
-                    Task { @MainActor [weak self] in
-                        self?.sessionContinuations.removeValue(forKey: sessionId)
-                    }
-                }
-
-                do {
-                    // Push context snapshot to runtime before session.run
-                    if let ref = params.contextSnapshotRef,
-                       let snapshot = self.snapshotStore.resolve(ref) {
-                        try await self.pushContextSnapshot(snapshot: snapshot, ref: ref)
-                    }
-
-                    let rpcParams: [String: AnyCodableValue] = [
-                        "sessionId": .string(params.sessionId),
-                        "input": .string(params.input),
-                        "contextSnapshotRef": params.contextSnapshotRef.map { .string($0) } ?? .null,
-                        "permissionMode": params.permissionMode.map { .string($0) } ?? .null,
-                    ]
-                    let _: SessionRunResult = try await self.sendRpc(method: "session.run", params: rpcParams)
-                    // Ack received — events will arrive via UDS notifications
-                } catch {
-                    continuation.finish(throwing: error)
-                }
+                self?.sessionContinuations.removeValue(forKey: sessionId)
             }
         }
+
+        Task { @MainActor [weak self] in
+            guard let self else {
+                continuation.finish()
+                return
+            }
+
+            do {
+                // Push context snapshot to runtime before session.run
+                if let ref = params.contextSnapshotRef,
+                   let snapshot = self.snapshotStore.resolve(ref) {
+                    try await self.pushContextSnapshot(snapshot: snapshot, ref: ref)
+                }
+
+                let rpcParams: [String: AnyCodableValue] = [
+                    "sessionId": .string(params.sessionId),
+                    "input": .string(params.input),
+                    "contextSnapshotRef": params.contextSnapshotRef.map { .string($0) } ?? .null,
+                    "permissionMode": params.permissionMode.map { .string($0) } ?? .null,
+                ]
+                let _: SessionRunResult = try await self.sendRpc(method: "session.run", params: rpcParams)
+                // Ack received -- events will arrive via UDS notifications
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+
+        return stream
     }
 
     func interruptSession(sessionId: String) async throws -> SessionInterruptResult {
@@ -470,7 +478,9 @@ final class RuntimeBridgeService: RuntimeBridgeProtocol {
 
     // MARK: - Notification Handling
 
-    private func handleNotification(_ notification: JsonRpcNotification) {
+    /// Route a JSON-RPC notification to the appropriate handler.
+    /// Internal (not private) for @testable access in unit tests.
+    func handleNotification(_ notification: JsonRpcNotification) {
         guard notification.method == "bridge.event",
               let params = notification.params else { return }
 

--- a/Dochi/Services/Tools/BuiltInToolService.swift
+++ b/Dochi/Services/Tools/BuiltInToolService.swift
@@ -614,6 +614,9 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
 
             case .serverNotFound, .executionFailed:
                 break
+
+            case .serverUnavailable(let serverName, _):
+                return "MCP server '\(serverName)' is unavailable."
             }
         }
 

--- a/DochiTests/RuntimeBridgeContinuationTests.swift
+++ b/DochiTests/RuntimeBridgeContinuationTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Dochi
+
+/// Tests for the continuation registration race fix in RuntimeBridgeService (issue #301).
+@MainActor
+final class RuntimeBridgeContinuationTests: XCTestCase {
+
+    func testContinuationRegisteredSynchronouslyOnRunSession() {
+        let service = RuntimeBridgeService(
+            socketPath: "/tmp/test-dochi-\(UUID().uuidString).sock",
+            runtimeExecutablePath: "/dev/null"
+        )
+        let sessionId = "test-session-\(UUID().uuidString)"
+        let params = SessionRunParams(
+            sessionId: sessionId, input: "hello",
+            contextSnapshotRef: nil, permissionMode: nil
+        )
+        XCTAssertNil(service.sessionContinuations[sessionId])
+        let _ = service.runSession(params: params)
+        XCTAssertNotNil(
+            service.sessionContinuations[sessionId],
+            "Continuation must be registered synchronously when runSession returns"
+        )
+    }
+
+    func testEarlyNotificationIsDeliveredToStream() async throws {
+        let service = RuntimeBridgeService(
+            socketPath: "/tmp/test-dochi-\(UUID().uuidString).sock",
+            runtimeExecutablePath: "/dev/null"
+        )
+        let sessionId = "test-session-\(UUID().uuidString)"
+        let stream = service.runSession(params: SessionRunParams(
+            sessionId: sessionId, input: "hello",
+            contextSnapshotRef: nil, permissionMode: nil
+        ))
+        service.handleNotification(JsonRpcNotification(
+            jsonrpc: "2.0", method: "bridge.event", params: [
+                "eventId": .string("evt-001"),
+                "timestamp": .string("2026-02-20T00:00:00Z"),
+                "sessionId": .string(sessionId),
+                "workspaceId": .string("ws-1"),
+                "agentId": .string("agent-1"),
+                "eventType": .string("session.partial"),
+                "payload": .object(["text": .string("Hello")]),
+            ]
+        ))
+        service.handleNotification(JsonRpcNotification(
+            jsonrpc: "2.0", method: "bridge.event", params: [
+                "eventId": .string("evt-002"),
+                "timestamp": .string("2026-02-20T00:00:01Z"),
+                "sessionId": .string(sessionId),
+                "workspaceId": .string("ws-1"),
+                "agentId": .string("agent-1"),
+                "eventType": .string("session.completed"),
+                "payload": .null,
+            ]
+        ))
+        var events: [BridgeEvent] = []
+        for try await event in stream { events.append(event) }
+        XCTAssertGreaterThanOrEqual(events.count, 1)
+        XCTAssertEqual(events.first?.eventType, .sessionPartial)
+        XCTAssertEqual(events.first?.eventId, "evt-001")
+    }
+
+    func testContinuationCleanedUpOnSessionCompleted() async throws {
+        let service = RuntimeBridgeService(
+            socketPath: "/tmp/test-dochi-\(UUID().uuidString).sock",
+            runtimeExecutablePath: "/dev/null"
+        )
+        let sessionId = "test-session-\(UUID().uuidString)"
+        let stream = service.runSession(params: SessionRunParams(
+            sessionId: sessionId, input: "hello",
+            contextSnapshotRef: nil, permissionMode: nil
+        ))
+        XCTAssertNotNil(service.sessionContinuations[sessionId])
+        service.handleNotification(JsonRpcNotification(
+            jsonrpc: "2.0", method: "bridge.event", params: [
+                "eventId": .string("evt-done"),
+                "timestamp": .string("2026-02-20T00:00:00Z"),
+                "sessionId": .string(sessionId),
+                "workspaceId": .null, "agentId": .null,
+                "eventType": .string("session.completed"),
+                "payload": .null,
+            ]
+        ))
+        for try await _ in stream { }
+        XCTAssertNil(service.sessionContinuations[sessionId])
+    }
+
+    func testMultipleSessionsReceiveOwnContinuations() {
+        let service = RuntimeBridgeService(
+            socketPath: "/tmp/test-dochi-\(UUID().uuidString).sock",
+            runtimeExecutablePath: "/dev/null"
+        )
+        let _ = service.runSession(params: SessionRunParams(
+            sessionId: "session-A", input: "a",
+            contextSnapshotRef: nil, permissionMode: nil
+        ))
+        let _ = service.runSession(params: SessionRunParams(
+            sessionId: "session-B", input: "b",
+            contextSnapshotRef: nil, permissionMode: nil
+        ))
+        XCTAssertNotNil(service.sessionContinuations["session-A"])
+        XCTAssertNotNil(service.sessionContinuations["session-B"])
+        XCTAssertEqual(service.sessionContinuations.count, 2)
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix race condition in `RuntimeBridgeService.runSession()`** where the `AsyncThrowingStream` continuation was stored inside a deferred `Task { @MainActor }`, meaning notifications arriving before the task executed would find no continuation and be silently dropped.
- **Switched to `AsyncThrowingStream.makeStream()`** so the continuation is available synchronously and registered in `sessionContinuations` _before_ the RPC `session.run` is sent.
- **Fixed exhaustive switch** in `BuiltInToolService` for `MCPServiceError.serverUnavailable` case.

## Changes

| File | Change |
|---|---|
| `Dochi/Services/Runtime/RuntimeBridgeService.swift` | Refactored `runSession()` to use `makeStream()` pattern; made `sessionContinuations` and `handleNotification` internal for testability |
| `Dochi/Services/Tools/BuiltInToolService.swift` | Added missing `serverUnavailable` case to switch |
| `DochiTests/RuntimeBridgeContinuationTests.swift` | New: 4 unit tests covering synchronous registration, early notification delivery, cleanup on completion, and multi-session isolation |

## Root Cause

The original code used `AsyncThrowingStream { continuation in Task { @MainActor in ... } }`. Because the builder closure is `@Sendable` and runs on a cooperative thread, while the continuation storage happened inside a `@MainActor`-isolated `Task`, there was a window where:

1. `runSession()` returns the stream to the caller
2. The runtime receives the RPC and immediately sends a `bridge.event` notification
3. `handleNotification()` looks up `sessionContinuations[sessionId]` — but finds `nil` because the `Task` hasn't run yet
4. The event is silently dropped

## Fix

```swift
// Before (racy):
return AsyncThrowingStream { continuation in
    Task { @MainActor in
        self.sessionContinuations[sessionId] = continuation  // deferred!
        // ... send RPC
    }
}

// After (safe):
let (stream, continuation) = AsyncThrowingStream<BridgeEvent, Error>.makeStream()
sessionContinuations[sessionId] = continuation  // synchronous!
Task { @MainActor in
    // ... send RPC
}
return stream
```

## Test Plan

- [x] `testContinuationRegisteredSynchronouslyOnRunSession` — verifies continuation exists in the dictionary immediately after `runSession()` returns (no await)
- [x] `testEarlyNotificationIsDeliveredToStream` — simulates an early notification arriving before the RPC Task runs, verifies the event is received
- [x] `testContinuationCleanedUpOnSessionCompleted` — verifies the continuation is removed from the dictionary after `session.completed`
- [x] `testMultipleSessionsReceiveOwnContinuations` — verifies two concurrent sessions each get independent continuations

Closes #301