### PR TITLE
fix: replace executeWithTimeout with continuation-based race pattern (#305)

### DIFF
--- a/Dochi/Services/Runtime/ToolDispatchHandler.swift
+++ b/Dochi/Services/Runtime/ToolDispatchHandler.swift
@@ -276,29 +276,37 @@ final class ToolDispatchHandler {
         return approved
     }
 
-    private func executeWithTimeout(
+    func executeWithTimeout(
         toolName: String,
         toolCallId: String,
         arguments: [String: Any],
         timeout: TimeInterval
     ) async -> ToolResult {
-        let executionTask = Task { @MainActor in
-            await self.toolService.execute(name: toolName, arguments: arguments)
+        let raceGuard = ExecutionRaceGuard()
+        return await withCheckedContinuation { continuation in
+            let executionTask = Task { @MainActor [toolService] in
+                let result = await toolService.execute(name: toolName, arguments: arguments)
+                if raceGuard.tryWin() {
+                    continuation.resume(returning: result)
+                }
+            }
+            let timeoutTask = Task {
+                try? await Task.sleep(for: .seconds(timeout))
+                if raceGuard.tryWin() {
+                    let result = ToolResult(
+                        toolCallId: toolCallId,
+                        content: "Tool '\(toolName)' timed out after \(Int(timeout))s",
+                        isError: true
+                    )
+                    continuation.resume(returning: result)
+                    executionTask.cancel()
+                }
+            }
+            Task { @MainActor in
+                _ = await executionTask.result
+                timeoutTask.cancel()
+            }
         }
-
-        let timeoutTask = Task {
-            try await Task.sleep(for: .seconds(timeout))
-            executionTask.cancel()
-            return ToolResult(
-                toolCallId: toolCallId,
-                content: "Tool '\(toolName)' timed out after \(Int(timeout))s",
-                isError: true
-            )
-        }
-
-        let result = await executionTask.value
-        timeoutTask.cancel()
-        return result
     }
 
     private func sendToolResult(
@@ -436,5 +444,18 @@ extension AnyCodableValue {
 extension Dictionary where Key == String, Value == AnyCodableValue {
     func toNativeDict() -> [String: Any] {
         mapValues { $0.toNative() }
+    }
+}
+
+// MARK: - ExecutionRaceGuard
+
+private final class ExecutionRaceGuard: Sendable {
+    private let state = OSAllocatedUnfairLock(initialState: false)
+    func tryWin() -> Bool {
+        state.withLock { won in
+            if won { return false }
+            won = true
+            return true
+        }
     }
 }

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -213,6 +213,7 @@ final class MockBuiltInToolService: BuiltInToolServiceProtocol {
     var enabledNames: [String] = []
     var resetCallCount = 0
     var lastPreferredToolGroups: [String]?
+    var executeDelay: TimeInterval = 0
 
     var nonBaselineToolSummaries: [(name: String, description: String, category: ToolCategory)] = []
     var allToolInfos: [ToolInfo] = []
@@ -231,6 +232,9 @@ final class MockBuiltInToolService: BuiltInToolServiceProtocol {
         executeCallCount += 1
         lastExecutedName = name
         lastArguments = arguments
+        if executeDelay > 0 {
+            try? await Task.sleep(for: .seconds(executeDelay))
+        }
         return stubbedResult
     }
 

--- a/DochiTests/ToolDispatchTests.swift
+++ b/DochiTests/ToolDispatchTests.swift
@@ -303,4 +303,45 @@ final class ToolDispatchTests: XCTestCase {
         XCTAssertEqual(bridge.configureToolDispatchCallCount, 1)
         XCTAssertNotNil(bridge.lastToolService)
     }
+
+    // MARK: - executeWithTimeout (Continuation Race Pattern)
+
+    @MainActor
+    func testExecuteWithTimeoutReturnsResultWhenFast() async {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-fast", content: "fast result")
+        mockToolService.executeDelay = 0
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+        let result = await handler.executeWithTimeout(toolName: "test.tool", toolCallId: "tc-fast", arguments: [:], timeout: 5)
+        XCTAssertFalse(result.isError)
+        XCTAssertEqual(result.content, "fast result")
+        XCTAssertEqual(mockToolService.executeCallCount, 1)
+    }
+
+    @MainActor
+    func testExecuteWithTimeoutReturnsTimeoutWhenSlow() async {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-slow", content: "should not see this")
+        mockToolService.executeDelay = 10
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+        let start = Date()
+        let result = await handler.executeWithTimeout(toolName: "slow.tool", toolCallId: "tc-slow", arguments: [:], timeout: 0.2)
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertTrue(result.isError)
+        XCTAssertTrue(result.content.contains("timed out"))
+        XCTAssertTrue(result.content.contains("slow.tool"))
+        XCTAssertLessThan(elapsed, 2.0)
+    }
+
+    @MainActor
+    func testExecuteWithTimeoutPassesArgumentsCorrectly() async {
+        let mockToolService = MockBuiltInToolService()
+        mockToolService.stubbedResult = ToolResult(toolCallId: "tc-args", content: "done")
+        let handler = ToolDispatchHandler(toolService: mockToolService)
+        let args: [String: Any] = ["key": "value", "count": 42]
+        let _ = await handler.executeWithTimeout(toolName: "args.tool", toolCallId: "tc-args", arguments: args, timeout: 5)
+        XCTAssertEqual(mockToolService.lastExecutedName, "args.tool")
+        XCTAssertEqual(mockToolService.lastArguments?["key"] as? String, "value")
+        XCTAssertEqual(mockToolService.lastArguments?["count"] as? Int, 42)
+    }
 }


### PR DESCRIPTION
## Summary
- Replace the two-Task race pattern in `ToolDispatchHandler.executeWithTimeout` with a `withCheckedContinuation` + `ExecutionRaceGuard` approach
- The previous implementation awaited `executionTask.value` which blocked indefinitely when a tool hung, because `cancel()` is cooperative and does not guarantee termination
- The new `ExecutionRaceGuard` (using `OSAllocatedUnfairLock`) ensures exactly one of the two racing Tasks resumes the continuation; the loser is cancelled

## Changes
- `Dochi/Services/Runtime/ToolDispatchHandler.swift`: Replaced `executeWithTimeout` implementation with continuation-based race pattern; changed access from `private` to `func` (internal) for testability; added `ExecutionRaceGuard` Sendable class
- `DochiTests/Mocks/MockServices.swift`: Added `executeDelay` property to `MockBuiltInToolService` for timeout simulation in tests
- `DochiTests/ToolDispatchTests.swift`: Added 3 tests for the new timeout behavior (fast result, slow timeout, argument forwarding)

## Test plan
- [x] `testExecuteWithTimeoutReturnsResultWhenFast` — fast execution returns normally before timeout
- [x] `testExecuteWithTimeoutReturnsTimeoutWhenSlow` — 10s delay with 0.2s timeout returns timeout error in < 2s
- [x] `testExecuteWithTimeoutPassesArgumentsCorrectly` — arguments forwarded to tool service correctly
- [x] All 23 ToolDispatchTests pass (verified in isolated worktree build)

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)