### PR TITLE
[Native Rewrite][Phase 3] Split orchestration summarize service and add contract tests (#350)

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -260,6 +260,7 @@ struct DochiApp: App {
 
         let controlPlaneTokenManager = ControlPlaneTokenManager()
         self.controlPlaneTokenManager = controlPlaneTokenManager
+        let orchestrationSummaryService = OrchestrationSummaryService()
         self.controlPlaneService = LocalControlPlaneService(
             methodHandler: { method, params in
                 await Self.handleControlPlaneMethod(
@@ -268,7 +269,8 @@ struct DochiApp: App {
                     viewModel: viewModel,
                     toolService: toolService,
                     externalToolManager: externalToolManager,
-                    tokenManager: controlPlaneTokenManager
+                    tokenManager: controlPlaneTokenManager,
+                    orchestrationSummaryService: orchestrationSummaryService
                 )
             },
             authTokenProvider: { controlPlaneTokenManager.currentToken() }
@@ -748,7 +750,8 @@ struct DochiApp: App {
         viewModel: DochiViewModel,
         toolService: BuiltInToolService,
         externalToolManager: ExternalToolSessionManagerProtocol,
-        tokenManager: ControlPlaneTokenManager
+        tokenManager: ControlPlaneTokenManager,
+        orchestrationSummaryService: any OrchestrationSummaryServiceProtocol
     ) async -> LocalControlPlaneMethodResult {
         switch method {
         case "app.ping":
@@ -937,13 +940,21 @@ struct DochiApp: App {
             return await handleBridgeOrchestratorExecute(params: params, externalToolManager: externalToolManager)
 
         case "bridge.orchestrator.status":
-            return await handleBridgeOrchestratorStatus(params: params, externalToolManager: externalToolManager)
+            return await handleBridgeOrchestratorStatus(
+                params: params,
+                externalToolManager: externalToolManager,
+                orchestrationSummaryService: orchestrationSummaryService
+            )
 
         case "bridge.orchestrator.interrupt":
             return await handleBridgeOrchestratorInterrupt(params: params, externalToolManager: externalToolManager)
 
         case "bridge.orchestrator.summarize":
-            return await handleBridgeOrchestratorSummarize(params: params, externalToolManager: externalToolManager)
+            return await handleBridgeOrchestratorSummarize(
+                params: params,
+                externalToolManager: externalToolManager,
+                orchestrationSummaryService: orchestrationSummaryService
+            )
 
         case "bridge.repo.list":
             return await handleBridgeRepositoryList(externalToolManager: externalToolManager)
@@ -1733,12 +1744,6 @@ struct DochiApp: App {
         case failed(LocalControlPlaneMethodResult)
     }
 
-    private struct OrchestrationOutputSummary {
-        let resultKind: String
-        let summary: String
-        let highlights: [String]
-    }
-
     nonisolated private static func resolveOrchestrationTarget(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
@@ -1785,7 +1790,8 @@ struct DochiApp: App {
 
     nonisolated private static func handleBridgeOrchestratorStatus(
         params: [String: Any],
-        externalToolManager: ExternalToolSessionManagerProtocol
+        externalToolManager: ExternalToolSessionManagerProtocol,
+        orchestrationSummaryService: any OrchestrationSummaryServiceProtocol
     ) async -> LocalControlPlaneMethodResult {
         let resolutionResult = await resolveOrchestrationTarget(
             params: params,
@@ -1801,7 +1807,7 @@ struct DochiApp: App {
 
         let lines = max(1, min(500, params["lines"] as? Int ?? 120))
         let output = await externalToolManager.captureOutput(sessionId: resolution.runtimeSessionId, lines: lines)
-        let summary = summarizeOrchestrationOutput(output)
+        let contract = orchestrationSummaryService.makeStatusContract(outputLines: output)
         let sessionPayload = await MainActor.run { () -> UncheckedJSONObject? in
             guard let payload = bridgeSessionPayload(sessionId: resolution.runtimeSessionId, manager: externalToolManager) else {
                 return nil
@@ -1817,9 +1823,9 @@ struct DochiApp: App {
             "selection": resolution.selection.map(serializeOrchestrationSelection(_:)) ?? NSNull(),
             "line_count": output.count,
             "output_lines": output,
-            "result_kind": summary.resultKind,
-            "summary": summary.summary,
-            "highlights": summary.highlights,
+            "result_kind": contract.resultKind,
+            "summary": contract.summary,
+            "highlights": contract.highlights,
         ])
     }
 
@@ -1864,7 +1870,8 @@ struct DochiApp: App {
 
     nonisolated private static func handleBridgeOrchestratorSummarize(
         params: [String: Any],
-        externalToolManager: ExternalToolSessionManagerProtocol
+        externalToolManager: ExternalToolSessionManagerProtocol,
+        orchestrationSummaryService: any OrchestrationSummaryServiceProtocol
     ) async -> LocalControlPlaneMethodResult {
         let resolutionResult = await resolveOrchestrationTarget(
             params: params,
@@ -1880,7 +1887,7 @@ struct DochiApp: App {
 
         let lines = max(1, min(500, params["lines"] as? Int ?? 160))
         let output = await externalToolManager.captureOutput(sessionId: resolution.runtimeSessionId, lines: lines)
-        let summary = summarizeOrchestrationOutput(output)
+        let contract = orchestrationSummaryService.makeSummarizeContract(outputLines: output)
         let sessionPayload = await MainActor.run { () -> UncheckedJSONObject? in
             guard let payload = bridgeSessionPayload(sessionId: resolution.runtimeSessionId, manager: externalToolManager) else {
                 return nil
@@ -1892,12 +1899,12 @@ struct DochiApp: App {
             "session": sessionPayload?.value ?? NSNull(),
             "selection": resolution.selection.map(serializeOrchestrationSelection(_:)) ?? NSNull(),
             "line_count": output.count,
-            "result_kind": summary.resultKind,
-            "summary": summary.summary,
-            "highlights": summary.highlights,
+            "result_kind": contract.resultKind,
+            "summary": contract.summary,
+            "highlights": contract.highlights,
             "context_reflection": [
-                "conversation_summary": "[external-cli:\(summary.resultKind)] \(summary.summary)",
-                "memory_candidate": summary.highlights.joined(separator: " | "),
+                "conversation_summary": contract.contextReflection.conversationSummary,
+                "memory_candidate": contract.contextReflection.memoryCandidate,
             ],
         ])
     }
@@ -2074,79 +2081,6 @@ struct DochiApp: App {
             payload["selected_session"] = NSNull()
         }
         return payload
-    }
-
-    nonisolated private static func summarizeOrchestrationOutput(
-        _ lines: [String]
-    ) -> OrchestrationOutputSummary {
-        let normalized = lines
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        guard !normalized.isEmpty else {
-            return OrchestrationOutputSummary(
-                resultKind: "unknown",
-                summary: "최근 출력이 없어 작업 결과를 판별할 수 없습니다.",
-                highlights: []
-            )
-        }
-
-        let recent = Array(normalized.suffix(80))
-        let failureKeywords = ["error", "failed", "exception", "traceback", "panic", "fatal", "test failed", "build failed"]
-        let successKeywords = ["success", "completed", "done", "passed", "all checks passed", "merged"]
-
-        let lowered = recent.map { $0.lowercased() }
-        let hasFailure = lowered.contains(where: { line in
-            failureKeywords.contains(where: { line.contains($0) })
-        })
-        let hasSuccess = lowered.contains(where: { line in
-            successKeywords.contains(where: { line.contains($0) })
-        })
-
-        let resultKind: String
-        if hasFailure {
-            resultKind = "failed"
-        } else if hasSuccess {
-            resultKind = "succeeded"
-        } else {
-            resultKind = "running"
-        }
-
-        var highlights: [String] = []
-        for line in recent.reversed() {
-            if highlights.count >= 3 { break }
-            let loweredLine = line.lowercased()
-            let shouldInclude =
-                failureKeywords.contains(where: { loweredLine.contains($0) }) ||
-                successKeywords.contains(where: { loweredLine.contains($0) }) ||
-                loweredLine.contains("warning") ||
-                loweredLine.contains("todo")
-            if shouldInclude {
-                highlights.append(line)
-            }
-        }
-        if highlights.isEmpty, let last = recent.last {
-            highlights = [last]
-        } else {
-            highlights.reverse()
-        }
-
-        let headline: String
-        switch resultKind {
-        case "failed":
-            headline = "실패 신호가 감지되었습니다."
-        case "succeeded":
-            headline = "성공 신호가 확인되었습니다."
-        default:
-            headline = "작업이 진행 중이거나 최종 상태가 불명확합니다."
-        }
-        let detail = highlights.joined(separator: " | ")
-        let summary = detail.isEmpty ? headline : "\(headline) 핵심 출력: \(detail)"
-
-        return OrchestrationOutputSummary(
-            resultKind: resultKind,
-            summary: summary,
-            highlights: highlights
-        )
     }
 
     nonisolated private static func formatSessionManagementKPISummary(

--- a/Dochi/Services/ControlPlane/OrchestrationSummaryService.swift
+++ b/Dochi/Services/ControlPlane/OrchestrationSummaryService.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+struct OrchestrationSummaryService: OrchestrationSummaryServiceProtocol, Sendable {
+    let policy: OrchestrationSummaryPolicy
+
+    init(policy: OrchestrationSummaryPolicy = .default) {
+        self.policy = policy
+    }
+
+    func summarize(outputLines: [String]) -> OrchestrationOutputSummary {
+        let normalizedLines = outputLines
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !normalizedLines.isEmpty else {
+            let summary = "최근 출력이 없어 작업 결과를 판별할 수 없습니다."
+            return OrchestrationOutputSummary(
+                resultKind: .unknown,
+                summary: summary,
+                highlights: [],
+                contextReflection: OrchestrationContextReflection(
+                    conversationSummary: "[external-cli:unknown] \(summary)",
+                    memoryCandidate: ""
+                )
+            )
+        }
+
+        let recent = Array(normalizedLines.suffix(max(1, policy.maxRecentLineCount)))
+        let failureKeywords = lowercasedKeywords(policy.failureKeywords)
+        let successKeywords = lowercasedKeywords(policy.successKeywords)
+        let highlightKeywords = lowercasedKeywords(policy.highlightKeywords)
+
+        let loweredLines = recent.map { $0.lowercased() }
+        let hasFailure = loweredLines.contains(where: { line in
+            failureKeywords.contains(where: { line.contains($0) })
+        })
+        let hasSuccess = loweredLines.contains(where: { line in
+            successKeywords.contains(where: { line.contains($0) })
+        })
+
+        let resultKind: OrchestrationResultKind
+        if hasFailure {
+            resultKind = .failed
+        } else if hasSuccess {
+            resultKind = .succeeded
+        } else {
+            resultKind = .running
+        }
+
+        let highlights = extractHighlights(
+            from: recent,
+            failureKeywords: failureKeywords,
+            successKeywords: successKeywords,
+            highlightKeywords: highlightKeywords,
+            maxHighlights: max(1, policy.maxHighlights)
+        )
+
+        let headline: String
+        switch resultKind {
+        case .failed:
+            headline = "실패 신호가 감지되었습니다."
+        case .succeeded:
+            headline = "성공 신호가 확인되었습니다."
+        case .running, .unknown:
+            headline = "작업이 진행 중이거나 최종 상태가 불명확합니다."
+        }
+
+        let detail = highlights.joined(separator: " | ")
+        let summary = detail.isEmpty ? headline : "\(headline) 핵심 출력: \(detail)"
+        let contextReflection = OrchestrationContextReflection(
+            conversationSummary: "[external-cli:\(resultKind.rawValue)] \(summary)",
+            memoryCandidate: highlights.joined(separator: " | ")
+        )
+
+        return OrchestrationOutputSummary(
+            resultKind: resultKind,
+            summary: summary,
+            highlights: highlights,
+            contextReflection: contextReflection
+        )
+    }
+
+    func makeStatusContract(outputLines: [String]) -> OrchestrationStatusContractPayload {
+        let summary = summarize(outputLines: outputLines)
+        return OrchestrationStatusContractPayload(
+            resultKind: summary.resultKind.rawValue,
+            summary: summary.summary,
+            highlights: summary.highlights
+        )
+    }
+
+    func makeSummarizeContract(outputLines: [String]) -> OrchestrationSummarizeContractPayload {
+        let summary = summarize(outputLines: outputLines)
+        return OrchestrationSummarizeContractPayload(
+            resultKind: summary.resultKind.rawValue,
+            summary: summary.summary,
+            highlights: summary.highlights,
+            contextReflection: summary.contextReflection
+        )
+    }
+
+    private func extractHighlights(
+        from lines: [String],
+        failureKeywords: [String],
+        successKeywords: [String],
+        highlightKeywords: [String],
+        maxHighlights: Int
+    ) -> [String] {
+        var highlights: [String] = []
+        for line in lines.reversed() {
+            if highlights.count >= maxHighlights { break }
+            let loweredLine = line.lowercased()
+            let shouldInclude =
+                failureKeywords.contains(where: { loweredLine.contains($0) }) ||
+                successKeywords.contains(where: { loweredLine.contains($0) }) ||
+                highlightKeywords.contains(where: { loweredLine.contains($0) })
+            if shouldInclude {
+                highlights.append(line)
+            }
+        }
+
+        if highlights.isEmpty, let lastLine = lines.last {
+            return [lastLine]
+        }
+
+        return highlights.reversed()
+    }
+
+    private func lowercasedKeywords(_ keywords: [String]) -> [String] {
+        keywords
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/Dochi/Services/Protocols/OrchestrationSummaryServiceProtocol.swift
+++ b/Dochi/Services/Protocols/OrchestrationSummaryServiceProtocol.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+enum OrchestrationResultKind: String, Sendable {
+    case unknown
+    case running
+    case succeeded
+    case failed
+}
+
+struct OrchestrationContextReflection: Sendable, Equatable {
+    let conversationSummary: String
+    let memoryCandidate: String
+}
+
+struct OrchestrationOutputSummary: Sendable, Equatable {
+    let resultKind: OrchestrationResultKind
+    let summary: String
+    let highlights: [String]
+    let contextReflection: OrchestrationContextReflection
+}
+
+struct OrchestrationStatusContractPayload: Sendable, Equatable {
+    let resultKind: String
+    let summary: String
+    let highlights: [String]
+}
+
+struct OrchestrationSummarizeContractPayload: Sendable, Equatable {
+    let resultKind: String
+    let summary: String
+    let highlights: [String]
+    let contextReflection: OrchestrationContextReflection
+}
+
+struct OrchestrationSummaryPolicy: Sendable, Equatable {
+    let failureKeywords: [String]
+    let successKeywords: [String]
+    let highlightKeywords: [String]
+    let maxRecentLineCount: Int
+    let maxHighlights: Int
+
+    static let `default` = OrchestrationSummaryPolicy(
+        failureKeywords: ["error", "failed", "exception", "traceback", "panic", "fatal", "test failed", "build failed"],
+        successKeywords: ["success", "completed", "done", "passed", "all checks passed", "merged"],
+        highlightKeywords: ["warning", "todo"],
+        maxRecentLineCount: 80,
+        maxHighlights: 3
+    )
+}
+
+protocol OrchestrationSummaryServiceProtocol: Sendable {
+    func summarize(outputLines: [String]) -> OrchestrationOutputSummary
+    func makeStatusContract(outputLines: [String]) -> OrchestrationStatusContractPayload
+    func makeSummarizeContract(outputLines: [String]) -> OrchestrationSummarizeContractPayload
+}

--- a/DochiTests/OrchestrationSummaryServiceTests.swift
+++ b/DochiTests/OrchestrationSummaryServiceTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import Dochi
+
+final class OrchestrationSummaryServiceTests: XCTestCase {
+
+    func testSummarizeReturnsUnknownWhenOutputIsEmpty() {
+        let service = OrchestrationSummaryService()
+
+        let summary = service.summarize(outputLines: [])
+
+        XCTAssertEqual(summary.resultKind, .unknown)
+        XCTAssertEqual(summary.highlights, [])
+        XCTAssertEqual(summary.summary, "최근 출력이 없어 작업 결과를 판별할 수 없습니다.")
+        XCTAssertEqual(summary.contextReflection.conversationSummary, "[external-cli:unknown] 최근 출력이 없어 작업 결과를 판별할 수 없습니다.")
+        XCTAssertEqual(summary.contextReflection.memoryCandidate, "")
+    }
+
+    func testSummarizePrefersFailureWhenBothSignalsExist() {
+        let service = OrchestrationSummaryService()
+        let output = [
+            "build completed successfully",
+            "error: failed to compile runtime bridge",
+        ]
+
+        let summary = service.summarize(outputLines: output)
+
+        XCTAssertEqual(summary.resultKind, .failed)
+        XCTAssertEqual(summary.highlights, output)
+        XCTAssertTrue(summary.summary.contains("실패 신호가 감지되었습니다."))
+    }
+
+    func testSummarizeReturnsRunningWhenNoSuccessOrFailureKeyword() {
+        let service = OrchestrationSummaryService()
+        let output = [
+            "processing step 1/4",
+            "still working on indexing",
+        ]
+
+        let summary = service.summarize(outputLines: output)
+
+        XCTAssertEqual(summary.resultKind, .running)
+        XCTAssertEqual(summary.highlights, ["still working on indexing"])
+        XCTAssertTrue(summary.summary.contains("진행 중이거나 최종 상태가 불명확합니다."))
+    }
+
+    func testSummarizeAllowsCustomPolicyKeywords() {
+        let policy = OrchestrationSummaryPolicy(
+            failureKeywords: ["catastrophic"],
+            successKeywords: ["ship it"],
+            highlightKeywords: ["checkpoint"],
+            maxRecentLineCount: 20,
+            maxHighlights: 2
+        )
+        let service = OrchestrationSummaryService(policy: policy)
+        let output = [
+            "step checkpoint reached",
+            "Ship It now",
+        ]
+
+        let summary = service.summarize(outputLines: output)
+
+        XCTAssertEqual(summary.resultKind, .succeeded)
+        XCTAssertEqual(summary.highlights, output)
+        XCTAssertTrue(summary.summary.contains("성공 신호가 확인되었습니다."))
+    }
+
+    func testStatusContractPayloadMatchesStatusSchema() {
+        let service = OrchestrationSummaryService()
+        let output = [
+            "warning: flaky path",
+            "all checks passed",
+        ]
+
+        let payload = service.makeStatusContract(outputLines: output)
+
+        XCTAssertEqual(payload.resultKind, "succeeded")
+        XCTAssertEqual(payload.highlights, output)
+        XCTAssertTrue(payload.summary.contains("성공 신호가 확인되었습니다."))
+    }
+
+    func testSummarizeContractPayloadSnapshotForConversationAndMemoryReflection() {
+        let service = OrchestrationSummaryService()
+        let output = [
+            "step: compile",
+            "warning: flaky test",
+            "build failed with exit code 1",
+        ]
+
+        let payload = service.makeSummarizeContract(outputLines: output)
+
+        XCTAssertEqual(payload.resultKind, "failed")
+        XCTAssertEqual(payload.summary, "실패 신호가 감지되었습니다. 핵심 출력: warning: flaky test | build failed with exit code 1")
+        XCTAssertEqual(payload.highlights, ["warning: flaky test", "build failed with exit code 1"])
+        XCTAssertEqual(payload.contextReflection.conversationSummary, "[external-cli:failed] 실패 신호가 감지되었습니다. 핵심 출력: warning: flaky test | build failed with exit code 1")
+        XCTAssertEqual(payload.contextReflection.memoryCandidate, "warning: flaky test | build failed with exit code 1")
+    }
+}


### PR DESCRIPTION
## Summary
- extracted inline orchestrator summarize heuristic from DochiApp into OrchestrationSummaryService
- introduced configurable OrchestrationSummaryPolicy and contract payload builders for bridge.orchestrator.status / bridge.orchestrator.summarize
- switched control-plane handlers to use the new service so DochiApp no longer owns summary keyword logic
- added OrchestrationSummaryServiceTests covering success/failure/running/unknown boundaries and snapshot-style checks for conversation/memory reflection payload

## Test Evidence
- xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/OrchestrationSummaryServiceTests
- xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/CLICommandSurfaceTests

## Spec Impact
- no spec document changes required (implementation-only refactor + test coverage)

Closes #350
