### PR TITLE
[Native Rewrite][Phase 1] Anthropic adapter incremental SSE parser (#339)

### DIFF
--- a/Dochi/Services/NativeLLM/AnthropicNativeLLMProviderAdapter.swift
+++ b/Dochi/Services/NativeLLM/AnthropicNativeLLMProviderAdapter.swift
@@ -2,6 +2,24 @@ import Foundation
 
 protocol NativeLLMHTTPClient: Sendable {
     func send(_ request: URLRequest) async throws -> (data: Data, response: HTTPURLResponse)
+    func sendStreaming(_ request: URLRequest) async throws -> (lineStream: AsyncThrowingStream<String, Error>, response: HTTPURLResponse)
+}
+
+extension NativeLLMHTTPClient {
+    func sendStreaming(_ request: URLRequest) async throws -> (lineStream: AsyncThrowingStream<String, Error>, response: HTTPURLResponse) {
+        let (data, response) = try await send(request)
+        let payload = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+        let lines = payload.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).map(String.init)
+        return (
+            lineStream: AsyncThrowingStream { continuation in
+                for line in lines {
+                    continuation.yield(line)
+                }
+                continuation.finish()
+            },
+            response: response
+        )
+    }
 }
 
 struct URLSessionNativeLLMHTTPClient: NativeLLMHTTPClient {
@@ -23,6 +41,38 @@ struct URLSessionNativeLLMHTTPClient: NativeLLMHTTPClient {
         }
         return (data, response)
     }
+
+    func sendStreaming(_ request: URLRequest) async throws -> (lineStream: AsyncThrowingStream<String, Error>, response: HTTPURLResponse) {
+        let (bytes, rawResponse) = try await session.bytes(for: request)
+        guard let response = rawResponse as? HTTPURLResponse else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "Invalid HTTP response from Anthropic",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        let lineStream = AsyncThrowingStream<String, Error> { continuation in
+            let task = Task {
+                do {
+                    for try await line in bytes.lines {
+                        try Task.checkCancellation()
+                        continuation.yield(line.replacingOccurrences(of: "\r", with: ""))
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+
+        return (lineStream: lineStream, response: response)
+    }
 }
 
 struct AnthropicNativeLLMProviderAdapter: NativeLLMProviderAdapter {
@@ -39,9 +89,10 @@ struct AnthropicNativeLLMProviderAdapter: NativeLLMProviderAdapter {
             let task = Task {
                 do {
                     let urlRequest = try Self.makeURLRequest(from: request)
-                    let (data, response) = try await httpClient.send(urlRequest)
+                    let (lineStream, response) = try await httpClient.sendStreaming(urlRequest)
 
                     guard (200...299).contains(response.statusCode) else {
+                        let data = try await Self.collectStreamBodyData(lineStream)
                         let mappedError = Self.mapHTTPError(
                             statusCode: response.statusCode,
                             data: data,
@@ -51,15 +102,51 @@ struct AnthropicNativeLLMProviderAdapter: NativeLLMProviderAdapter {
                         throw mappedError
                     }
 
-                    let events = try Self.parseStreamEvents(from: data)
+                    var accumulator = Self.SSEEventAccumulator()
+                    var toolBuffers: [Int: Self.ToolUseBuffer] = [:]
                     var emittedDone = false
-                    for event in events {
-                        continuation.yield(event)
-                        if event.kind == .done {
-                            emittedDone = true
+
+                    for try await rawLine in lineStream {
+                        try Task.checkCancellation()
+                        if let event = accumulator.append(line: rawLine.replacingOccurrences(of: "\r", with: "")) {
+                            let mapped = try Self.mapSSEEvent(event, toolBuffers: &toolBuffers)
+                            for mappedEvent in mapped {
+                                continuation.yield(mappedEvent)
+                                if mappedEvent.kind == .done {
+                                    emittedDone = true
+                                }
+                                if mappedEvent.kind == .error, let error = mappedEvent.error {
+                                    throw error
+                                }
+                            }
+                            if emittedDone {
+                                break
+                            }
                         }
-                        if event.kind == .error, let error = event.error {
-                            throw error
+                    }
+
+                    if !emittedDone, let pending = accumulator.flush() {
+                        let mapped = try Self.mapSSEEvent(pending, toolBuffers: &toolBuffers)
+                        for mappedEvent in mapped {
+                            continuation.yield(mappedEvent)
+                            if mappedEvent.kind == .done {
+                                emittedDone = true
+                            }
+                            if mappedEvent.kind == .error, let error = mappedEvent.error {
+                                throw error
+                            }
+                        }
+                    }
+
+                    if !toolBuffers.isEmpty {
+                        for index in toolBuffers.keys.sorted() {
+                            if let tool = toolBuffers[index] {
+                                continuation.yield(.toolUse(
+                                    toolCallId: tool.toolCallId,
+                                    toolName: tool.toolName,
+                                    toolInputJSON: tool.inputJSON
+                                ))
+                            }
                         }
                     }
 
@@ -1277,6 +1364,16 @@ private extension AnthropicNativeLLMProviderAdapter {
             return value
         }
         return .object([:])
+    }
+
+    static func collectStreamBodyData(
+        _ lineStream: AsyncThrowingStream<String, Error>
+    ) async throws -> Data {
+        var lines: [String] = []
+        for try await line in lineStream {
+            lines.append(line)
+        }
+        return Data(lines.joined(separator: "\n").utf8)
     }
 
     static func mapHTTPError(

--- a/DochiTests/AnthropicNativeLLMProviderAdapterTests.swift
+++ b/DochiTests/AnthropicNativeLLMProviderAdapterTests.swift
@@ -132,6 +132,86 @@ final class AnthropicNativeLLMProviderAdapterTests: XCTestCase {
             XCTFail("Unexpected error type: \(error)")
         }
     }
+
+    func testAnthropicAdapterEmitsPartialBeforeStreamCompletion() async throws {
+        let streamLines = [
+            "event: content_block_delta",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"partial-now\"}}",
+            "",
+            ": heartbeat",
+            ": heartbeat",
+            ": heartbeat",
+            ": heartbeat",
+            ": heartbeat",
+            "event: message_stop",
+            "data: {\"type\":\"message_stop\"}",
+            "",
+        ]
+        let httpClient = MockNativeLLMHTTPClient(
+            statusCode: 200,
+            headers: [:],
+            body: Data(),
+            streamLines: streamLines,
+            streamLineDelayNanoseconds: 25_000_000
+        )
+        let adapter = AnthropicNativeLLMProviderAdapter(httpClient: httpClient)
+        let request = makeRequest(provider: .anthropic, apiKey: "test-key")
+
+        let stream = adapter.stream(request: request)
+        var iterator = stream.makeAsyncIterator()
+        let startedAt = Date()
+
+        let first = try await iterator.next()
+        let firstLatency = Date().timeIntervalSince(startedAt)
+        let second = try await iterator.next()
+        let totalLatency = Date().timeIntervalSince(startedAt)
+
+        XCTAssertEqual(first?.kind, .partial)
+        XCTAssertEqual(first?.text, "partial-now")
+        XCTAssertLessThan(firstLatency, totalLatency)
+        XCTAssertGreaterThan(totalLatency - firstLatency, 0.05)
+        XCTAssertEqual(second?.kind, .done)
+        XCTAssertEqual(await httpClient.sendStreamingCallCount, 1)
+        XCTAssertEqual(await httpClient.sendCallCount, 0)
+    }
+
+    func testAnthropicAdapterCancelsNetworkStreamWhenConsumerStopsEarly() async throws {
+        let streamLines = [
+            "event: content_block_delta",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"first\"}}",
+            "",
+            ": heartbeat",
+            ": heartbeat",
+            ": heartbeat",
+            ": heartbeat",
+            "event: message_stop",
+            "data: {\"type\":\"message_stop\"}",
+            "",
+        ]
+        let httpClient = MockNativeLLMHTTPClient(
+            statusCode: 200,
+            headers: [:],
+            body: Data(),
+            streamLines: streamLines,
+            streamLineDelayNanoseconds: 30_000_000
+        )
+        let adapter = AnthropicNativeLLMProviderAdapter(httpClient: httpClient)
+        let request = makeRequest(provider: .anthropic, apiKey: "test-key")
+
+        let firstEventTask = Task<NativeLLMStreamEvent?, Error> {
+            for try await event in adapter.stream(request: request) {
+                return event
+            }
+            return nil
+        }
+
+        let first = try await firstEventTask.value
+        XCTAssertEqual(first?.kind, .partial)
+        XCTAssertEqual(first?.text, "first")
+
+        try await Task.sleep(nanoseconds: 80_000_000)
+        XCTAssertTrue(await httpClient.didCancelStream())
+    }
 }
 
 private extension AnthropicNativeLLMProviderAdapterTests {

--- a/DochiTests/NativeLLMProviderAdapterTestSupport.swift
+++ b/DochiTests/NativeLLMProviderAdapterTestSupport.swift
@@ -6,26 +6,91 @@ actor MockNativeLLMHTTPClient: NativeLLMHTTPClient {
     private let headers: [String: String]
     private let body: Data
     private let stubbedError: Error?
+    private let streamLines: [String]?
+    private let streamLineDelayNanoseconds: UInt64
     private(set) var lastRequest: URLRequest?
+    private(set) var streamCancelled = false
+    private(set) var sendCallCount = 0
+    private(set) var sendStreamingCallCount = 0
 
     init(
         statusCode: Int,
         headers: [String: String],
         body: Data,
-        stubbedError: Error? = nil
+        stubbedError: Error? = nil,
+        streamLines: [String]? = nil,
+        streamLineDelayNanoseconds: UInt64 = 0
     ) {
         self.statusCode = statusCode
         self.headers = headers
         self.body = body
         self.stubbedError = stubbedError
+        self.streamLines = streamLines
+        self.streamLineDelayNanoseconds = streamLineDelayNanoseconds
     }
 
     func send(_ request: URLRequest) async throws -> (data: Data, response: HTTPURLResponse) {
+        sendCallCount += 1
         lastRequest = request
         if let stubbedError {
             throw stubbedError
         }
 
+        let response = try makeResponse(for: request)
+        return (body, response)
+    }
+
+    func sendStreaming(_ request: URLRequest) async throws -> (lineStream: AsyncThrowingStream<String, Error>, response: HTTPURLResponse) {
+        sendStreamingCallCount += 1
+        lastRequest = request
+        if let stubbedError {
+            throw stubbedError
+        }
+
+        let response = try makeResponse(for: request)
+        let payload = String(data: body, encoding: .utf8) ?? String(decoding: body, as: UTF8.self)
+        let resolvedLines = streamLines ?? payload
+            .split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+            .map(String.init)
+        let lineDelay = streamLineDelayNanoseconds
+
+        let lineStream = AsyncThrowingStream<String, Error> { continuation in
+            let producer = Task {
+                do {
+                    for line in resolvedLines {
+                        try Task.checkCancellation()
+                        if lineDelay > 0 {
+                            try await Task.sleep(nanoseconds: lineDelay)
+                        }
+                        continuation.yield(line)
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { termination in
+                producer.cancel()
+                guard case .cancelled = termination else { return }
+                Task { await self.markStreamCancelled() }
+            }
+        }
+
+        return (lineStream, response)
+    }
+
+    func capturedRequest() -> URLRequest? {
+        lastRequest
+    }
+
+    func didCancelStream() -> Bool {
+        streamCancelled
+    }
+
+    private func makeResponse(for request: URLRequest) throws -> HTTPURLResponse {
         guard let url = request.url,
               let response = HTTPURLResponse(
                 url: url,
@@ -40,10 +105,10 @@ actor MockNativeLLMHTTPClient: NativeLLMHTTPClient {
                 retryAfterSeconds: nil
             )
         }
-        return (body, response)
+        return response
     }
 
-    func capturedRequest() -> URLRequest? {
-        lastRequest
+    private func markStreamCancelled() {
+        streamCancelled = true
     }
 }


### PR DESCRIPTION
## Summary
- switched Anthropic streaming path from buffered body parsing to incremental streaming via `URLSession.bytes(for:)`
- added `NativeLLMHTTPClient.sendStreaming` with URLSession implementation and data-based fallback
- updated Anthropic adapter loop to parse SSE events line-by-line and emit partial/tool_use events before response completion
- preserved interrupt behavior by cancelling stream producer task on termination
- extended native HTTP mock to simulate incremental lines + cancellation signal
- added regression tests for
  - partial emission before stream completion
  - network stream cancellation when consumer stops early

## Test Evidence
- attempted:
  - `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/AnthropicNativeLLMProviderAdapterTests`
- current status:
  - blocked by unrelated baseline compile regression in `Dochi/Services/Runtime/ToolDispatchHandler.swift` (Swift 6 sending diagnostics)
  - follow-up issue created: #384

## Spec Impact
- no spec document changes required (adapter implementation + test updates)

Closes #339
