### PR TITLE
fix: use @unchecked Sendable box for TaskGroup timeout race (#305)

### DIFF
--- a/Dochi/Services/Runtime/ToolDispatchHandler.swift
+++ b/Dochi/Services/Runtime/ToolDispatchHandler.swift
@@ -282,13 +282,15 @@ final class ToolDispatchHandler {
         arguments: [String: Any],
         timeout: TimeInterval
     ) async -> ToolResult {
-        nonisolated(unsafe) let sendableArgs = arguments
-        nonisolated(unsafe) let sendableToolService = toolService
+        // Box non-Sendable captures so they satisfy TaskGroup's `sending` requirement.
+        // Safe because execute() hops to MainActor via protocol, and
+        // only one child task accesses these values.
+        let ctx = ToolExecutionContext(toolService: toolService, arguments: arguments)
 
         return await withTaskGroup(of: ToolResult.self) { group in
-            // Child 1 — tool execution (auto-hops to MainActor via protocol requirement)
+            // Child 1 — tool execution (hops to MainActor via protocol requirement)
             group.addTask {
-                await sendableToolService.execute(name: toolName, arguments: sendableArgs)
+                await ctx.toolService.execute(name: toolName, arguments: ctx.arguments)
             }
 
             // Child 2 — timeout sentinel
@@ -444,4 +446,14 @@ extension Dictionary where Key == String, Value == AnyCodableValue {
     func toNativeDict() -> [String: Any] {
         mapValues { $0.toNative() }
     }
+}
+
+// MARK: - Sendable Box for TaskGroup Captures
+
+/// Wraps non-Sendable values needed by TaskGroup child tasks.
+/// Safe because the wrapped tool service is @MainActor-isolated and
+/// the child task hops to MainActor before access.
+struct ToolExecutionContext: @unchecked Sendable {
+    let toolService: any BuiltInToolServiceProtocol
+    let arguments: [String: Any]
 }


### PR DESCRIPTION
## Summary
- Replace `nonisolated(unsafe)` captures in `executeWithTimeout` with `ToolExecutionContext` (`@unchecked Sendable` struct) to satisfy Swift 6 strict concurrency's `sending` requirement on `TaskGroup.addTask` closures
- The previous PR #382 introduced the TaskGroup pattern but used `nonisolated(unsafe)` which fails Swift 6's `sending` parameter check
- `ToolExecutionContext` wraps the non-Sendable `BuiltInToolServiceProtocol` and `[String: Any]` arguments, making the TaskGroup pattern compile-safe

## Test plan
- [x] All 36 ToolDispatchTests pass (including 6 executeWithTimeout race tests)
- [x] `testExecuteWithTimeout_FastExecution_ReturnsNormally` -- fast tool returns normally
- [x] `testExecuteWithTimeout_SlowExecution_ReturnsTimeout` -- slow tool triggers timeout
- [x] `testExecuteWithTimeout_ReturnsWithinExpectedTime` -- returns within 2s, not 60s
- [x] `testExecuteWithTimeout_ConcurrentCallsDoNotInterfere` -- concurrent calls isolated
- [x] `xcodebuild build` passes with no Swift 6 concurrency errors

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)