### PR TITLE
feat: rank tool schemas with preference/history context and coding intent boost

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -5,6 +5,8 @@ import UserNotifications
 final class AppDelegate: NSObject, NSApplicationDelegate {
     /// UsageStore reference for flushing pending data on app termination (C-3).
     var usageStore: UsageStore?
+    /// ToolContextStore reference for flushing pending ranking context on app termination.
+    var toolContextStore: ToolContextStore?
     /// MenuBarManager reference for popover toggle (H-1).
     var menuBarManager: MenuBarManager?
 
@@ -38,6 +40,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let store = usageStore {
             store.flushToDiskSync()
             Log.app.info("UsageStore flushed on app termination")
+        }
+        if let store = toolContextStore {
+            store.flushToDiskSync()
+            Log.app.info("ToolContextStore flushed on app termination")
         }
 
         // Teardown menu bar (H-1)
@@ -94,6 +100,7 @@ struct DochiApp: App {
     private let notificationManager: NotificationManager
     private let modelDownloadManager: ModelDownloadManager
     private let usageStore: UsageStore
+    private let toolContextStore: ToolContextStore
     private let spotlightIndexer: SpotlightIndexer
     private let vectorStore: VectorStore
     private let documentIndexer: DocumentIndexer
@@ -162,6 +169,13 @@ struct DochiApp: App {
         let schedulerService = SchedulerService(settings: settings)
         self.schedulerService = schedulerService
 
+        let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("Dochi")
+        let usageStore = UsageStore(baseURL: appSupportURL)
+        self.usageStore = usageStore
+        let toolContextStore = ToolContextStore(baseURL: appSupportURL)
+        self.toolContextStore = toolContextStore
+
         // Plugin Manager (J-4)
         let pluginManager = PluginManager()
         self.pluginManager = pluginManager
@@ -174,15 +188,12 @@ struct DochiApp: App {
             supabaseService: supabaseService,
             telegramService: telegramService,
             mcpService: mcpService,
+            toolContextStore: toolContextStore,
             delegationManager: delegationManager
         )
         self.toolService = toolService
 
         let metricsCollector = MetricsCollector()
-        let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            .appendingPathComponent("Dochi")
-        let usageStore = UsageStore(baseURL: appSupportURL)
-        self.usageStore = usageStore
         metricsCollector.usageStore = usageStore
         metricsCollector.settings = settings
 
@@ -481,6 +492,7 @@ struct DochiApp: App {
 
                 // Wire UsageStore to AppDelegate for flush on termination (C-3)
                 appDelegate.usageStore = usageStore
+                appDelegate.toolContextStore = toolContextStore
 
                 // Setup menu bar manager (H-1)
                 if appDelegate.menuBarManager == nil {

--- a/Dochi/Models/ToolContextModels.swift
+++ b/Dochi/Models/ToolContextModels.swift
@@ -102,3 +102,17 @@ struct ToolContextFile: Codable, Sendable {
         recentEvents: []
     )
 }
+
+struct ToolRankingContext: Sendable, Equatable {
+    var categoryScores: [String: Double]
+    var toolScores: [String: Double]
+    var preferredCategories: [String]
+    var suppressedCategories: [String]
+
+    static let empty = ToolRankingContext(
+        categoryScores: [:],
+        toolScores: [:],
+        preferredCategories: [],
+        suppressedCategories: []
+    )
+}

--- a/Dochi/Services/Protocols/BuiltInToolServiceProtocol.swift
+++ b/Dochi/Services/Protocols/BuiltInToolServiceProtocol.swift
@@ -21,6 +21,7 @@ protocol BuiltInToolServiceProtocol {
 
     func availableToolSchemas(for permissions: [String]) -> [[String: Any]]
     func availableToolSchemas(for permissions: [String], preferredToolGroups: [String]) -> [[String: Any]]
+    func availableToolSchemas(for permissions: [String], preferredToolGroups: [String], intentHint: String?) -> [[String: Any]]
     func execute(name: String, arguments: [String: Any]) async -> ToolResult
     func enableTools(names: [String])
     func enableToolsTTL(minutes: Int)
@@ -35,6 +36,10 @@ extension BuiltInToolServiceProtocol {
 
     func availableToolSchemas(for permissions: [String], preferredToolGroups _: [String]) -> [[String: Any]] {
         availableToolSchemas(for: permissions)
+    }
+
+    func availableToolSchemas(for permissions: [String], preferredToolGroups: [String], intentHint _: String?) -> [[String: Any]] {
+        availableToolSchemas(for: permissions, preferredToolGroups: preferredToolGroups)
     }
 
     func toolInfo(named name: String) -> ToolInfo? {

--- a/Dochi/Services/Protocols/ToolContextStoreProtocol.swift
+++ b/Dochi/Services/Protocols/ToolContextStoreProtocol.swift
@@ -5,6 +5,13 @@ protocol ToolContextStoreProtocol: Sendable {
     func record(_ event: ToolUsageEvent) async
     func profile(workspaceId: String, agentName: String) async -> ToolContextProfile?
     func userPreference(workspaceId: String) async -> UserToolPreference
+    func rankingContext(workspaceId: String, agentName: String) -> ToolRankingContext
     func updateUserPreference(_ preference: UserToolPreference, workspaceId: String) async
     func flushToDisk() async
+}
+
+extension ToolContextStoreProtocol {
+    func rankingContext(workspaceId _: String, agentName _: String) -> ToolRankingContext {
+        .empty
+    }
 }

--- a/Dochi/Services/ToolContextStore.swift
+++ b/Dochi/Services/ToolContextStore.swift
@@ -19,7 +19,7 @@ final class ToolContextStore: ToolContextStoreProtocol {
     }
 
     func record(_ event: ToolUsageEvent) async {
-        var file = await load()
+        var file = load()
         let profileKey = Self.profileKey(workspaceId: event.workspaceId, agentName: event.agentName)
         var profile = file.profiles[profileKey] ?? ToolContextProfile(
             agentName: event.agentName,
@@ -53,18 +53,35 @@ final class ToolContextStore: ToolContextStoreProtocol {
     }
 
     func profile(workspaceId: String, agentName: String) async -> ToolContextProfile? {
-        let file = await load()
+        let file = load()
         let key = Self.profileKey(workspaceId: workspaceId, agentName: agentName)
         return file.profiles[key]
     }
 
     func userPreference(workspaceId: String) async -> UserToolPreference {
-        let file = await load()
+        let file = load()
         return file.userPreferences[workspaceId] ?? UserToolPreference()
     }
 
+    func rankingContext(workspaceId: String, agentName: String) -> ToolRankingContext {
+        let file = load()
+        let profileKey = Self.profileKey(workspaceId: workspaceId, agentName: agentName)
+        let profile = file.profiles[profileKey]
+        let preference = file.userPreferences[workspaceId] ?? UserToolPreference()
+        let preferred = Self.normalizedCategories(preference.preferredCategories)
+        let suppressedRaw = Self.normalizedCategories(preference.suppressedCategories)
+        let suppressed = suppressedRaw.filter { !preferred.contains($0) }
+
+        return ToolRankingContext(
+            categoryScores: profile?.categoryScores ?? [:],
+            toolScores: profile?.toolScores ?? [:],
+            preferredCategories: preferred,
+            suppressedCategories: suppressed
+        )
+    }
+
     func updateUserPreference(_ preference: UserToolPreference, workspaceId: String) async {
-        var file = await load()
+        var file = load()
         let preferred = Self.normalizedCategories(preference.preferredCategories)
         let suppressedRaw = Self.normalizedCategories(preference.suppressedCategories)
         let suppressed = suppressedRaw.filter { !preferred.contains($0) }
@@ -97,10 +114,30 @@ final class ToolContextStore: ToolContextStoreProtocol {
             Log.storage.error("Failed to save tool context: \(error.localizedDescription)")
         }
     }
+
+    nonisolated func flushToDiskSync() {
+        MainActor.assumeIsolated {
+            guard isDirty else { return }
+            guard let file = cache else { return }
+
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+            do {
+                let data = try encoder.encode(file)
+                try data.write(to: fileURL, options: .atomic)
+                isDirty = false
+                Log.storage.debug("Tool context saved to disk (sync)")
+            } catch {
+                Log.storage.error("Failed to save tool context (sync): \(error.localizedDescription)")
+            }
+        }
+    }
 }
 
 private extension ToolContextStore {
-    func load() async -> ToolContextFile {
+    func load() -> ToolContextFile {
         if let cache {
             return cache
         }

--- a/Dochi/Services/Tools/BuiltInToolService.swift
+++ b/Dochi/Services/Tools/BuiltInToolService.swift
@@ -6,6 +6,7 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
     private let registry = ToolRegistry()
     private let sessionContext: SessionContext
     private let settings: AppSettings
+    private let toolContextStore: (any ToolContextStoreProtocol)?
     private let capabilityRouter = CapabilityRouter()
     private let routingPolicy = ToolRoutingPolicy()
     var confirmationHandler: ToolConfirmationHandler? {
@@ -32,11 +33,13 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
         supabaseService: SupabaseServiceProtocol,
         telegramService: TelegramServiceProtocol,
         mcpService: MCPServiceProtocol,
+        toolContextStore: (any ToolContextStoreProtocol)? = nil,
         delegationManager: DelegationManager? = nil
     ) {
         self.sessionContext = sessionContext
         self.settings = settings
         self.mcpService = mcpService
+        self.toolContextStore = toolContextStore
 
         // Registry meta-tools (baseline, safe)
         registry.register(ToolsListTool(registry: registry))
@@ -300,10 +303,14 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
     }
 
     func availableToolSchemas(for permissions: [String]) -> [[String: Any]] {
-        availableToolSchemas(for: permissions, preferredToolGroups: [])
+        availableToolSchemas(for: permissions, preferredToolGroups: [], intentHint: nil)
     }
 
     func availableToolSchemas(for permissions: [String], preferredToolGroups: [String]) -> [[String: Any]] {
+        availableToolSchemas(for: permissions, preferredToolGroups: preferredToolGroups, intentHint: nil)
+    }
+
+    func availableToolSchemas(for permissions: [String], preferredToolGroups: [String], intentHint: String?) -> [[String: Any]] {
         var schemas: [[String: Any]] = []
         selectedCapabilityLabel = nil
 
@@ -322,7 +329,13 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
             tools = availableTools
         }
 
-        let orderedTools = orderedToolsByPreference(tools, preferredToolGroups: preferredToolGroups)
+        let rankingContext = currentToolRankingContext()
+        let orderedTools = orderedToolsByPreference(
+            tools,
+            preferredToolGroups: preferredToolGroups,
+            rankingContext: rankingContext,
+            intentHint: intentHint
+        )
         for tool in orderedTools {
             // OpenAI requires tool names to match ^[a-zA-Z0-9_-]+$
             let sanitizedName = Self.sanitizeToolName(tool.name)
@@ -355,7 +368,9 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
 
     private func orderedToolsByPreference(
         _ tools: [any BuiltInToolProtocol],
-        preferredToolGroups: [String]
+        preferredToolGroups: [String],
+        rankingContext: ToolRankingContext,
+        intentHint: String?
     ) -> [any BuiltInToolProtocol] {
         var orderedGroups: [String] = []
         var seen: Set<String> = []
@@ -366,16 +381,104 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
                 orderedGroups.append(normalized)
             }
         }
-        guard !orderedGroups.isEmpty else { return tools.sorted { $0.name < $1.name } }
-
         let priorities = Dictionary(uniqueKeysWithValues: orderedGroups.enumerated().map { ($0.element, $0.offset) })
 
         return tools.sorted { lhs, rhs in
-            let lhsPriority = priorities[ToolGroupResolver.group(forToolName: lhs.name)] ?? Int.max
-            let rhsPriority = priorities[ToolGroupResolver.group(forToolName: rhs.name)] ?? Int.max
+            let lhsGroup = ToolGroupResolver.group(forToolName: lhs.name)
+            let rhsGroup = ToolGroupResolver.group(forToolName: rhs.name)
+
+            let lhsPriority = priorities[lhsGroup] ?? Int.max
+            let rhsPriority = priorities[rhsGroup] ?? Int.max
+
+            let lhsScore = rankingScore(
+                for: lhs,
+                group: lhsGroup,
+                priority: lhsPriority,
+                rankingContext: rankingContext,
+                intentHint: intentHint
+            )
+            let rhsScore = rankingScore(
+                for: rhs,
+                group: rhsGroup,
+                priority: rhsPriority,
+                rankingContext: rankingContext,
+                intentHint: intentHint
+            )
+
+            if lhsScore != rhsScore { return lhsScore > rhsScore }
             if lhsPriority != rhsPriority { return lhsPriority < rhsPriority }
             return lhs.name < rhs.name
         }
+    }
+
+    private func rankingScore(
+        for tool: any BuiltInToolProtocol,
+        group: String,
+        priority: Int,
+        rankingContext: ToolRankingContext,
+        intentHint: String?
+    ) -> Double {
+        var score = 0.0
+
+        if priority != Int.max {
+            // Strong boost for explicit per-agent preferred group order.
+            score += Double(max(0, 20 - priority)) * 12.0
+        }
+
+        if rankingContext.preferredCategories.contains(group) {
+            score += 96.0
+        }
+
+        if rankingContext.suppressedCategories.contains(group) {
+            score -= 160.0
+        }
+
+        score += (rankingContext.categoryScores[group] ?? 0.0) * 24.0
+        score += (rankingContext.toolScores[tool.name] ?? 0.0) * 32.0
+        score += intentBoost(toolName: tool.name, group: group, hint: intentHint)
+
+        return score
+    }
+
+    private func intentBoost(toolName: String, group: String, hint: String?) -> Double {
+        guard let hint else { return 0 }
+        let normalized = hint.lowercased()
+        let codingAgentKeywords = [
+            "코딩 에이전트",
+            "에이전트 목록",
+            "에이전트 상태",
+            "코딩 세션",
+            "세션 목록",
+            "coding agent",
+            "agent list",
+            "agent status",
+            "coding session",
+            "session list",
+            "sessions"
+        ]
+        guard codingAgentKeywords.contains(where: { normalized.contains($0) }) else {
+            return 0
+        }
+
+        switch toolName {
+        case "agent.list", "coding.sessions":
+            return 240.0
+        case "agent.check_status", "agent.delegation_status", "coding.session_pause", "coding.session_end":
+            return 180.0
+        default:
+            if group == "agent" || group == "coding" {
+                return 100.0
+            }
+            return 0.0
+        }
+    }
+
+    private func currentToolRankingContext() -> ToolRankingContext {
+        guard let toolContextStore else { return .empty }
+        let workspaceId = sessionContext.workspaceId.uuidString
+        let activeAgentName = settings.activeAgentName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedAgentName = activeAgentName.isEmpty ? ToolUsageEvent.defaultAgentName : activeAgentName
+        return toolContextStore.rankingContext(workspaceId: workspaceId, agentName: resolvedAgentName)
     }
 
     func execute(name: String, arguments: [String: Any]) async -> ToolResult {
@@ -398,6 +501,11 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
             )
         }
 
+        let startedAt = Date()
+        let result: ToolResult
+        let usageToolName: String
+        let usageRisk: ToolCategory
+
         switch route {
         case .builtIn(let tool, let reason):
             logRoutingDecision(
@@ -407,7 +515,9 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
                 risk: tool.category,
                 reason: reason
             )
-            return await executeBuiltInTool(
+            usageToolName = tool.name
+            usageRisk = tool.category
+            result = await executeBuiltInTool(
                 requestedName: name,
                 tool: tool,
                 arguments: arguments
@@ -428,7 +538,9 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
                 risk: risk,
                 reason: reason
             )
-            return await executeMCPTool(
+            usageToolName = requestedName
+            usageRisk = risk
+            result = await executeMCPTool(
                 requestedName: requestedName,
                 originalName: originalName,
                 serverName: serverName,
@@ -437,6 +549,16 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
                 arguments: arguments
             )
         }
+
+        let latencyMs = Int(Date().timeIntervalSince(startedAt) * 1000)
+        recordUsageContext(
+            toolName: usageToolName,
+            risk: usageRisk,
+            result: result,
+            latencyMs: latencyMs
+        )
+
+        return result
     }
 
     func enableTools(names: [String]) {
@@ -621,5 +743,41 @@ final class BuiltInToolService: BuiltInToolServiceProtocol {
         }
 
         return "MCP 도구 실행 실패: \(error.localizedDescription)"
+    }
+
+    private func recordUsageContext(
+        toolName: String,
+        risk: ToolCategory,
+        result: ToolResult,
+        latencyMs: Int
+    ) {
+        guard let toolContextStore else { return }
+
+        let usageDecision: ToolUsageDecision
+        if result.isError {
+            if result.content.contains("거부") {
+                usageDecision = .denied
+            } else {
+                usageDecision = .policyBlocked
+            }
+        } else {
+            usageDecision = (risk == .safe) ? .allowed : .approved
+        }
+
+        let activeAgentName = settings.activeAgentName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedAgentName = activeAgentName.isEmpty ? ToolUsageEvent.defaultAgentName : activeAgentName
+        let usageEvent = ToolUsageEvent(
+            toolName: toolName,
+            category: ToolGroupResolver.group(forToolName: toolName),
+            decision: usageDecision,
+            latencyMs: latencyMs,
+            agentName: resolvedAgentName,
+            workspaceId: sessionContext.workspaceId.uuidString,
+            timestamp: Date()
+        )
+
+        Task { @MainActor in
+            await toolContextStore.record(usageEvent)
+        }
     }
 }

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -2862,7 +2862,9 @@ final class DochiViewModel {
             guard let userId = normalizedUserId(sessionContext.currentUserId) else { return "" }
             return contextService.loadUserMemory(userId: userId) ?? ""
         }()
-        let requestedTools = buildNativeToolDefinitions()
+        let requestedTools = buildNativeToolDefinitions(
+            intentHint: latestUserIntentHint(in: conversation)
+        )
         let shouldDisableToolsForCapability = !capabilities.supportsToolCalling && !requestedTools.isEmpty
         let enabledTools = shouldDisableToolsForCapability ? [] : requestedTools
 
@@ -3017,10 +3019,11 @@ final class DochiViewModel {
         }
     }
 
-    private func buildNativeToolDefinitions() -> [NativeLLMToolDefinition] {
+    private func buildNativeToolDefinitions(intentHint: String?) -> [NativeLLMToolDefinition] {
         let schemas = toolService.availableToolSchemas(
             for: currentAgentPermissions(),
-            preferredToolGroups: currentAgentPreferredToolGroups()
+            preferredToolGroups: currentAgentPreferredToolGroups(),
+            intentHint: intentHint
         )
         selectedCapabilityLabel = toolService.selectedCapabilityLabel
 
@@ -3039,6 +3042,17 @@ final class DochiViewModel {
                 inputSchema: inputSchema
             )
         }
+    }
+
+    private func latestUserIntentHint(in conversation: Conversation) -> String? {
+        for message in conversation.messages.reversed() {
+            guard message.role == .user else { continue }
+            let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
     }
 
     private func nativeEndpointURL(for provider: LLMProvider) -> URL? {

--- a/DochiTests/BuiltInToolServiceCapabilityRouterTests.swift
+++ b/DochiTests/BuiltInToolServiceCapabilityRouterTests.swift
@@ -35,6 +35,32 @@ private final class MockMCPServiceForCapabilityTests: MCPServiceProtocol {
 }
 
 @MainActor
+private final class MockToolContextStoreForCapabilityTests: ToolContextStoreProtocol {
+    var context: ToolRankingContext = .empty
+    private(set) var recordedEvents: [ToolUsageEvent] = []
+
+    func record(_ event: ToolUsageEvent) async {
+        recordedEvents.append(event)
+    }
+
+    func profile(workspaceId _: String, agentName _: String) async -> ToolContextProfile? {
+        nil
+    }
+
+    func userPreference(workspaceId _: String) async -> UserToolPreference {
+        UserToolPreference()
+    }
+
+    func rankingContext(workspaceId _: String, agentName _: String) -> ToolRankingContext {
+        context
+    }
+
+    func updateUserPreference(_: UserToolPreference, workspaceId _: String) async {}
+
+    func flushToDisk() async {}
+}
+
+@MainActor
 final class BuiltInToolServiceCapabilityRouterTests: XCTestCase {
     private static let flagKey = "capabilityRouterV2Enabled"
 
@@ -100,6 +126,66 @@ final class BuiltInToolServiceCapabilityRouterTests: XCTestCase {
         let names = orderedSchemaNames(from: schemas)
 
         XCTAssertEqual(names.first, "open_url")
+    }
+
+    func testRankingContextBoostsPreferredAndHighUsageTools() {
+        let contextStore = MockToolContextStoreForCapabilityTests()
+        contextStore.context = ToolRankingContext(
+            categoryScores: ["agent": 1.2],
+            toolScores: ["agent.list": 2.5],
+            preferredCategories: ["agent"],
+            suppressedCategories: ["finder"]
+        )
+
+        let service = makeService(
+            routerEnabled: false,
+            toolContextStore: contextStore
+        )
+        service.enableTools(names: ["agent.list", "coding.sessions"])
+
+        let schemas = service.availableToolSchemas(
+            for: ["safe", "sensitive"],
+            preferredToolGroups: [],
+            intentHint: nil
+        )
+        let names = orderedSchemaNames(from: schemas)
+
+        XCTAssertLessThan(index(of: "agent-_-list", in: names), index(of: "finder-_-list_dir", in: names))
+    }
+
+    func testCodingAgentIntentBoostPrioritizesAgentAndSessionTools() {
+        let contextStore = MockToolContextStoreForCapabilityTests()
+        let service = makeService(
+            routerEnabled: false,
+            toolContextStore: contextStore
+        )
+        service.enableTools(names: ["agent.list", "coding.sessions"])
+
+        let schemas = service.availableToolSchemas(
+            for: ["safe", "sensitive"],
+            preferredToolGroups: [],
+            intentHint: "코딩 에이전트 목록 확인해줘"
+        )
+        let names = orderedSchemaNames(from: schemas)
+
+        let agentIndex = index(of: "agent-_-list", in: names)
+        let sessionIndex = index(of: "coding-_-sessions", in: names)
+        let finderIndex = index(of: "finder-_-list_dir", in: names)
+        XCTAssertLessThan(agentIndex, finderIndex)
+        XCTAssertLessThan(sessionIndex, finderIndex)
+    }
+
+    func testColdStartWithoutSignalsRemainsAlphabetical() {
+        let service = makeService(routerEnabled: false)
+        service.enableTools(names: ["open_url"])
+
+        let schemas = service.availableToolSchemas(
+            for: ["safe", "sensitive"],
+            preferredToolGroups: [],
+            intentHint: nil
+        )
+        let names = orderedSchemaNames(from: schemas)
+        XCTAssertEqual(names, names.sorted())
     }
 
     func testExecuteMCPToolReturnsFallbackMessageWhenServerUnavailable() async {
@@ -198,7 +284,8 @@ final class BuiltInToolServiceCapabilityRouterTests: XCTestCase {
 
     private func makeService(
         routerEnabled: Bool,
-        mcpService: MCPServiceProtocol = MockMCPServiceForCapabilityTests()
+        mcpService: MCPServiceProtocol = MockMCPServiceForCapabilityTests(),
+        toolContextStore: (any ToolContextStoreProtocol)? = nil
     ) -> BuiltInToolService {
         let settings = AppSettings()
         settings.capabilityRouterV2Enabled = routerEnabled
@@ -211,7 +298,8 @@ final class BuiltInToolServiceCapabilityRouterTests: XCTestCase {
             settings: settings,
             supabaseService: MockSupabaseService(),
             telegramService: MockTelegramService(),
-            mcpService: mcpService
+            mcpService: mcpService,
+            toolContextStore: toolContextStore
         )
     }
 
@@ -232,5 +320,9 @@ final class BuiltInToolServiceCapabilityRouterTests: XCTestCase {
             guard let function = schema["function"] as? [String: Any] else { return nil }
             return function["name"] as? String
         }
+    }
+
+    private func index(of name: String, in names: [String]) -> Int {
+        names.firstIndex(of: name) ?? Int.max
     }
 }

--- a/DochiTests/ToolContextStoreTests.swift
+++ b/DochiTests/ToolContextStoreTests.swift
@@ -121,6 +121,35 @@ final class ToolContextStoreTests: XCTestCase {
         XCTAssertEqual(savedPreference.suppressedCategories, ["calendar"])
     }
 
+    func testRankingContextAggregatesProfileAndPreferenceSignals() async throws {
+        let tempDir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let store = ToolContextStore(baseURL: tempDir)
+        await store.record(ToolUsageEvent(
+            toolName: "agent.list",
+            category: "agent",
+            decision: .allowed,
+            latencyMs: 10,
+            agentName: "코디",
+            workspaceId: "ws-1",
+            timestamp: Date()
+        ))
+        await store.updateUserPreference(
+            UserToolPreference(
+                preferredCategories: ["Agent", " coding "],
+                suppressedCategories: ["finder", "coding"]
+            ),
+            workspaceId: "ws-1"
+        )
+
+        let context = store.rankingContext(workspaceId: "ws-1", agentName: "코디")
+        XCTAssertEqual(context.preferredCategories, ["agent", "coding"])
+        XCTAssertEqual(context.suppressedCategories, ["finder"])
+        XCTAssertEqual(context.toolScores["agent.list"] ?? 0, 1.0, accuracy: 0.001)
+        XCTAssertEqual(context.categoryScores["agent"] ?? 0, 1.0, accuracy: 0.001)
+    }
+
     func testMalformedJSONFallsBackToEmptyStore() async throws {
         let tempDir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: tempDir) }


### PR DESCRIPTION
## Summary
- extend tool schema selection with context-aware ranking signals
  - per-agent preferred tool groups (existing)
  - user preferred/suppressed categories (from `ToolContextStore`)
  - usage-derived category/tool scores (from `ToolContextStore`)
- add coding-agent intent boost so `agent.list` / `coding.sessions` are prioritized for relevant requests
- wire current user intent hint from latest user message in `DochiViewModel`
- record tool execution outcomes in `BuiltInToolService.execute(...)` into `ToolContextStore`
- wire `ToolContextStore` into app lifecycle and flush on termination
- add ranking regression tests and ranking-context store tests

Closes #389

## Spec Impact
- Uses existing spec: `spec/tool-context-preference-routing.md`

## Test Evidence
- `xcodegen generate`
- `xcodebuild -project Dochi.xcodeproj -scheme Dochi -configuration Debug build` ✅
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/BuiltInToolServiceCapabilityRouterTests -only-testing:DochiTests/ToolContextStoreTests` ✅
