### PR TITLE
fix: hide tools negotiation chatter behind expandable summaries

### DIFF
--- a/Dochi/Models/ToolExecution.swift
+++ b/Dochi/Models/ToolExecution.swift
@@ -142,4 +142,94 @@ enum ToolExecutionSummary {
         }
         return prefix + String(clean.prefix(97)) + "..."
     }
+
+    /// Returns true when content represents an error-like tool result.
+    static func isErrorResult(_ content: String) -> Bool {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return trimmed.hasPrefix("오류:")
+            || trimmed.localizedCaseInsensitiveContains("error")
+            || trimmed.localizedCaseInsensitiveContains("실패")
+    }
+
+    /// Returns true when content looks like a tools.* negotiation/control result.
+    static func isControlToolNegotiationResult(_ content: String) -> Bool {
+        let lines = normalizedNonEmptyLines(from: content)
+        guard !lines.isEmpty else { return false }
+
+        return lines.contains(where: { $0.hasPrefix("도구 목록 (") })
+            || lines.contains(where: { $0.hasPrefix("도구 활성화 완료:") })
+            || lines.contains(where: { $0.hasPrefix("이미 활성화된 도구:") })
+            || lines.contains(where: { $0.hasPrefix("찾을 수 없는 도구:") })
+            || lines.contains(where: { $0.hasPrefix("활성화 가능한 도구가 없습니다.") })
+            || lines.contains(where: { $0.hasPrefix("도구 TTL을 ") })
+            || lines.contains(where: { $0.hasPrefix("도구 레지스트리를 기본 상태로 복원") })
+            || lines.contains(where: { $0.localizedCaseInsensitiveContains("tools.enable") })
+    }
+
+    /// Compact one-line summary for chat bubbles (collapsed tool result view).
+    static func generateCompactResultSummary(from content: String) -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "도구 실행 결과" }
+        let lines = normalizedNonEmptyLines(from: trimmed)
+        guard let first = lines.first else { return "도구 실행 결과" }
+
+        if first.hasPrefix("도구 목록 (") {
+            if let totalCount = extractLeadingCount(in: first, prefix: "도구 목록 (", suffix: "개)") {
+                return "도구 목록 조회 (\(totalCount)개)"
+            }
+            return "도구 목록 조회 결과"
+        }
+
+        let newlyEnabledCount = countCommaSeparatedItems(in: lines, prefix: "도구 활성화 완료:")
+        let alreadyEnabledCount = countCommaSeparatedItems(in: lines, prefix: "이미 활성화된 도구:")
+        let invalidCount = countCommaSeparatedItems(in: lines, prefix: "찾을 수 없는 도구:")
+        if newlyEnabledCount > 0 || alreadyEnabledCount > 0 || invalidCount > 0 {
+            var parts: [String] = []
+            if newlyEnabledCount > 0 { parts.append("신규 \(newlyEnabledCount)") }
+            if alreadyEnabledCount > 0 { parts.append("이미 \(alreadyEnabledCount)") }
+            if invalidCount > 0 { parts.append("미존재 \(invalidCount)") }
+            return "도구 활성화 결과 · " + parts.joined(separator: ", ")
+        }
+
+        if lines.contains(where: { $0.hasPrefix("활성화 가능한 도구가 없습니다.") }) {
+            return "도구 활성화 결과 · 활성화 대상 없음"
+        }
+
+        if first.hasPrefix("도구 TTL을 ") {
+            return first
+        }
+
+        if first.hasPrefix("도구 레지스트리를 기본 상태로 복원") {
+            return "도구 레지스트리 초기화 완료"
+        }
+
+        return generateResultSummary(from: trimmed, isError: isErrorResult(trimmed))
+    }
+
+    private static func normalizedNonEmptyLines(from content: String) -> [String] {
+        content
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func countCommaSeparatedItems(in lines: [String], prefix: String) -> Int {
+        guard let line = lines.first(where: { $0.hasPrefix(prefix) }) else { return 0 }
+        let payload = line.dropFirst(prefix.count).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !payload.isEmpty else { return 0 }
+        return payload
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .count
+    }
+
+    private static func extractLeadingCount(in line: String, prefix: String, suffix: String) -> Int? {
+        guard let prefixRange = line.range(of: prefix) else { return nil }
+        let remainder = line[prefixRange.upperBound...]
+        guard let suffixRange = remainder.range(of: suffix) else { return nil }
+        let numberSlice = remainder[..<suffixRange.lowerBound]
+        return Int(numberSlice)
+    }
 }

--- a/Dochi/Views/ConversationView.swift
+++ b/Dochi/Views/ConversationView.swift
@@ -144,21 +144,25 @@ struct ConversationView: View {
             }
 
             // Keep tool messages only when they are useful in chat:
-            // errors and visual outputs (e.g., generated images).
+            // errors, tools.* negotiation/control outputs, and visual outputs.
             if message.role == .tool {
-                if let imageURLs = message.imageURLs, !imageURLs.isEmpty {
-                    return true
-                }
-
-                let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return false }
-                return trimmed.hasPrefix("오류:")
-                    || trimmed.localizedCaseInsensitiveContains("error")
-                    || trimmed.localizedCaseInsensitiveContains("실패")
+                return Self.shouldDisplayToolMessage(content: message.content, imageURLs: message.imageURLs)
             }
 
             return true
         }
+    }
+
+    nonisolated static func shouldDisplayToolMessage(content: String, imageURLs: [URL]?) -> Bool {
+        if let imageURLs, !imageURLs.isEmpty {
+            return true
+        }
+
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+
+        return ToolExecutionSummary.isErrorResult(trimmed)
+            || ToolExecutionSummary.isControlToolNegotiationResult(trimmed)
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy) {

--- a/Dochi/Views/MessageBubbleView.swift
+++ b/Dochi/Views/MessageBubbleView.swift
@@ -13,6 +13,7 @@ struct MessageBubbleView: View {
     @State private var isHovering = false
     @State private var showCopied = false
     @State private var showFeedbackSheet = false
+    @State private var isToolResultExpanded = false
 
     init(
         message: Message,
@@ -234,6 +235,8 @@ struct MessageBubbleView: View {
         if shouldSuppressToolTextForVisualOutput {
             EmptyView()
                 .frame(width: 0, height: 0)
+        } else if shouldRenderCompactToolResultView {
+            compactToolResultView
         } else
         if message.content.isEmpty && message.toolCalls != nil {
             // Assistant message with only tool calls, no text content
@@ -258,6 +261,65 @@ struct MessageBubbleView: View {
         guard message.role == .tool else { return false }
         guard let imageURLs = message.imageURLs, !imageURLs.isEmpty else { return false }
         return true
+    }
+
+    private var shouldRenderCompactToolResultView: Bool {
+        guard message.role == .tool else { return false }
+        let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty
+    }
+
+    private var compactToolResultView: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isToolResultExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: isToolResultError ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(isToolResultError ? .orange : .green)
+
+                    Text(compactToolResultSummary)
+                        .font(.system(size: fontSize))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    Spacer(minLength: 6)
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .rotationEffect(.degrees(isToolResultExpanded ? 90 : 0))
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isToolResultExpanded {
+                Divider()
+                    .padding(.top, 1)
+
+                Text(renderedContent)
+                    .font(.system(size: max(12, fontSize - 1), design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        }
+        .onAppear {
+            if isToolResultError {
+                isToolResultExpanded = true
+            }
+        }
+    }
+
+    private var isToolResultError: Bool {
+        ToolExecutionSummary.isErrorResult(message.content)
+    }
+
+    private var compactToolResultSummary: String {
+        ToolExecutionSummary.generateCompactResultSummary(from: message.content)
     }
 
     // MARK: - Inline Image Data Display (I-3)
@@ -309,6 +371,7 @@ struct MessageBubbleView: View {
 
 private struct ToolExecutionSummaryRow: View {
     let records: [ToolExecutionRecord]
+    @State private var isExpanded = false
 
     private var successCount: Int {
         records.filter { !$0.isError }.count
@@ -331,32 +394,55 @@ private struct ToolExecutionSummaryRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: statusIcon)
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(statusColor)
+        VStack(alignment: .leading, spacing: 6) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: statusIcon)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(statusColor)
 
-            Text("도구 \(records.count)개")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(.secondary)
+                    Text("도구 \(records.count)개")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
 
-            Text("성공 \(successCount)")
-                .font(.system(size: 10))
-                .foregroundStyle(.secondary)
+                    Text("성공 \(successCount)")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
 
-            if errorCount > 0 {
-                Text("실패 \(errorCount)")
-                    .font(.system(size: 10))
-                    .foregroundStyle(.orange)
+                    if errorCount > 0 {
+                        Text("실패 \(errorCount)")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.orange)
+                    }
+
+                    if totalDuration > 0 {
+                        Text(String(format: "%.1f초", totalDuration))
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(.tertiary)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                }
             }
+            .buttonStyle(.plain)
 
-            if totalDuration > 0 {
-                Text(String(format: "%.1f초", totalDuration))
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(.tertiary)
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(records.enumerated()), id: \.offset) { _, record in
+                        ToolExecutionRecordCardView(record: record)
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
-
-            Spacer()
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)

--- a/DochiTests/ToolExecutionTests.swift
+++ b/DochiTests/ToolExecutionTests.swift
@@ -90,6 +90,47 @@ final class ToolExecutionTests: XCTestCase {
         XCTAssertTrue(result.hasSuffix("..."))
     }
 
+    func testIsErrorResultRecognizesKoreanErrorPrefix() {
+        XCTAssertTrue(ToolExecutionSummary.isErrorResult("오류: 권한이 없습니다."))
+    }
+
+    func testIsControlToolNegotiationResultRecognizesToolsEnableOutput() {
+        let content = """
+        도구 활성화 완료: web_search, open_url
+        이미 활성화된 도구: datetime
+        같은 tools.enable 호출을 반복하지 말고, 이제 실제 작업 도구를 호출하세요.
+        """
+        XCTAssertTrue(ToolExecutionSummary.isControlToolNegotiationResult(content))
+    }
+
+    func testGenerateCompactResultSummaryForToolsEnable() {
+        let content = """
+        도구 활성화 완료: web_search, open_url
+        이미 활성화된 도구: datetime
+        찾을 수 없는 도구: ghost_tool
+        """
+        let summary = ToolExecutionSummary.generateCompactResultSummary(from: content)
+        XCTAssertEqual(summary, "도구 활성화 결과 · 신규 2, 이미 1, 미존재 1")
+    }
+
+    func testGenerateCompactResultSummaryForToolsList() {
+        let content = "도구 목록 (35개):\n- a\n- b"
+        let summary = ToolExecutionSummary.generateCompactResultSummary(from: content)
+        XCTAssertEqual(summary, "도구 목록 조회 (35개)")
+    }
+
+    func testConversationViewShouldDisplayToolMessageForToolsEnableResult() {
+        let content = """
+        도구 활성화 완료: web_search, open_url
+        이미 활성화된 도구: datetime
+        """
+        XCTAssertTrue(ConversationView.shouldDisplayToolMessage(content: content, imageURLs: nil))
+    }
+
+    func testConversationViewShouldDisplayToolMessageForErrorResult() {
+        XCTAssertTrue(ConversationView.shouldDisplayToolMessage(content: "오류: 파일 열기 실패", imageURLs: nil))
+    }
+
     // MARK: - ToolExecutionRecord Codable
 
     func testToolExecutionRecordEncodeDecode() throws {


### PR DESCRIPTION
## Summary
- keep control-tool outputs (`tools.enable`, `tools.list`, TTL/reset) visible in chat as compact summaries instead of dumping full tool text
- add click-to-expand detail for tool result bubbles so full raw output is still accessible on demand
- make archived tool execution summary row expandable to per-tool detail cards
- keep existing visibility for tool errors and image-generating tool outputs

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ToolExecutionTests`
- result: **TEST SUCCEEDED** (30 tests)

## Spec Impact
- behavior aligns with noise-reduction direction in `spec/tool-context-slimming-plan.md`
- no schema/interface changes

## UI Notes
- chat now shows a one-line tool-result summary with a chevron
- clicking expands full detail inline (error tool results auto-expand)
