### PR TITLE
fix: refresh native follow-up tools after tools.enable

### DIFF
--- a/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
+++ b/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
@@ -18,6 +18,13 @@ struct NativeAgentLoopHookContext: Sendable {
     let agentId: String?
 }
 
+struct NativeAgentLoopToolRefreshContext: Sendable {
+    let permissions: [String]
+    let preferredToolGroups: [String]
+    let intentHint: String?
+    let supportsToolCalling: Bool
+}
+
 @MainActor
 final class NativeAgentLoopService {
     private struct PendingToolUse: Sendable {
@@ -72,7 +79,8 @@ final class NativeAgentLoopService {
 
     func run(
         request: NativeLLMRequest,
-        hookContext: NativeAgentLoopHookContext? = nil
+        hookContext: NativeAgentLoopHookContext? = nil,
+        toolRefreshContext: NativeAgentLoopToolRefreshContext? = nil
     ) -> AsyncThrowingStream<NativeLLMStreamEvent, Error> {
         guard let adapter = adapters[request.provider] else {
             return AsyncThrowingStream { continuation in
@@ -355,11 +363,17 @@ final class NativeAgentLoopService {
                             }
                         }
 
+                        let refreshedTools = Self.resolveFollowUpTools(
+                            currentRequest: currentRequest,
+                            toolRefreshContext: toolRefreshContext,
+                            toolService: toolService
+                        )
                         currentRequest = Self.makeFollowUpRequest(
                             from: currentRequest,
                             assistantText: accumulatedAssistantText,
                             toolUses: pendingToolUses,
-                            toolResults: executedToolResults
+                            toolResults: executedToolResults,
+                            tools: refreshedTools
                         )
                     }
 
@@ -601,7 +615,8 @@ private extension NativeAgentLoopService {
         from request: NativeLLMRequest,
         assistantText: String,
         toolUses: [PendingToolUse],
-        toolResults: [ExecutedToolResult]
+        toolResults: [ExecutedToolResult],
+        tools: [NativeLLMToolDefinition]
     ) -> NativeLLMRequest {
         var messages = request.messages
 
@@ -633,12 +648,57 @@ private extension NativeAgentLoopService {
             apiKey: request.apiKey,
             systemPrompt: request.systemPrompt,
             messages: messages,
-            tools: request.tools,
+            tools: tools,
             maxTokens: request.maxTokens,
             temperature: request.temperature,
             endpointURL: request.endpointURL,
             timeoutSeconds: request.timeoutSeconds,
             anthropicVersion: request.anthropicVersion
         )
+    }
+
+    private static func resolveFollowUpTools(
+        currentRequest: NativeLLMRequest,
+        toolRefreshContext: NativeAgentLoopToolRefreshContext?,
+        toolService: (any BuiltInToolServiceProtocol)?
+    ) -> [NativeLLMToolDefinition] {
+        guard let toolRefreshContext else {
+            return currentRequest.tools
+        }
+
+        guard toolRefreshContext.supportsToolCalling else {
+            return []
+        }
+
+        guard let toolService else {
+            return currentRequest.tools
+        }
+
+        let schemas = toolService.availableToolSchemas(
+            for: toolRefreshContext.permissions,
+            preferredToolGroups: toolRefreshContext.preferredToolGroups,
+            intentHint: toolRefreshContext.intentHint
+        )
+        return makeNativeToolDefinitions(from: schemas)
+    }
+
+    private static func makeNativeToolDefinitions(
+        from schemas: [[String: Any]]
+    ) -> [NativeLLMToolDefinition] {
+        schemas.compactMap { schema in
+            guard let function = schema["function"] as? [String: Any],
+                  let name = function["name"] as? String,
+                  let description = function["description"] as? String,
+                  let rawInputSchema = function["parameters"] as? [String: Any] else {
+                return nil
+            }
+
+            let inputSchema = rawInputSchema.compactMapValues { makeCodableValue($0) }
+            return NativeLLMToolDefinition(
+                name: name,
+                description: description,
+                inputSchema: inputSchema
+            )
+        }
     }
 }

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -1419,6 +1419,11 @@ final class DochiViewModel {
                 provider: provider,
                 model: model
             )
+            let toolRefreshContext = makeNativeToolRefreshContext(
+                provider: request.provider,
+                model: request.model,
+                conversation: currentConversation
+            )
             estimatedInputTokensForLatestRequest = contextCompactionService.estimateRequestInputTokens(
                 systemPrompt: request.systemPrompt,
                 messages: request.messages,
@@ -1437,7 +1442,8 @@ final class DochiViewModel {
 
             eventLoop: for try await event in nativeAgentLoopService.run(
                 request: request,
-                hookContext: nativeHookContext
+                hookContext: nativeHookContext,
+                toolRefreshContext: toolRefreshContext
             ) {
                 guard !Task.isCancelled else { break }
 
@@ -2499,6 +2505,11 @@ final class DochiViewModel {
                 conversation: conversation,
                 channelMetadata: "telegram:\(update.chatId)"
             )
+            let toolRefreshContext = makeNativeToolRefreshContext(
+                provider: request.provider,
+                model: request.model,
+                conversation: conversation
+            )
             let hookContext = NativeAgentLoopHookContext(
                 sessionId: conversation.id.uuidString,
                 workspaceId: sessionContext.workspaceId.uuidString,
@@ -2512,7 +2523,11 @@ final class DochiViewModel {
             var lastEditLength = 0
             let useStreaming = settings.telegramStreamReplies
 
-            for try await event in nativeAgentLoopService.run(request: request, hookContext: hookContext) {
+            for try await event in nativeAgentLoopService.run(
+                request: request,
+                hookContext: hookContext,
+                toolRefreshContext: toolRefreshContext
+            ) {
                 switch event.kind {
                 case .partial:
                     if let delta = event.text {
@@ -3053,6 +3068,23 @@ final class DochiViewModel {
             }
         }
         return nil
+    }
+
+    private func makeNativeToolRefreshContext(
+        provider: LLMProvider,
+        model: String,
+        conversation: Conversation?
+    ) -> NativeAgentLoopToolRefreshContext {
+        let capabilities = ProviderCapabilityMatrix.capabilities(
+            for: provider,
+            model: model
+        )
+        return NativeAgentLoopToolRefreshContext(
+            permissions: currentAgentPermissions(),
+            preferredToolGroups: currentAgentPreferredToolGroups(),
+            intentHint: conversation.flatMap { latestUserIntentHint(in: $0) },
+            supportsToolCalling: capabilities.supportsToolCalling
+        )
     }
 
     private func nativeEndpointURL(for provider: LLMProvider) -> URL? {

--- a/DochiTests/NativeAgentLoopServiceTests.swift
+++ b/DochiTests/NativeAgentLoopServiceTests.swift
@@ -203,6 +203,67 @@ final class NativeAgentLoopServiceTests: XCTestCase {
         XCTAssertTrue(adapter.capturedRequests[1].messages.containsToolResult(toolCallId: "tool_1"))
     }
 
+    func testNativeAgentLoopServiceRefreshesToolsForFollowUpRequest() async throws {
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(toolCallId: "", content: "enabled")
+        toolService.stubbedSchemas = [
+            makeToolSchema(name: "tools_enable"),
+            makeToolSchema(name: "coding_sessions"),
+        ]
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { request in
+            if request.messages.containsToolResult(toolCallId: "tool_1") {
+                return [.done(text: "done")]
+            }
+            return [
+                .toolUse(
+                    toolCallId: "tool_1",
+                    toolName: "tools.enable",
+                    toolInputJSON: "{\"groups\":[\"coding\"]}"
+                ),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService
+        )
+        let initialRequest = NativeLLMRequest(
+            provider: .anthropic,
+            model: "test-model",
+            apiKey: "test-key",
+            messages: [.init(role: .user, text: "coding 세션 확인해줘")],
+            tools: [
+                NativeLLMToolDefinition(
+                    name: "tools_enable",
+                    description: "enable tools",
+                    inputSchema: [:]
+                ),
+            ]
+        )
+
+        _ = try await collectEvents(
+            from: service.run(
+                request: initialRequest,
+                toolRefreshContext: NativeAgentLoopToolRefreshContext(
+                    permissions: ["safe", "restricted"],
+                    preferredToolGroups: ["coding"],
+                    intentHint: "coding 세션 확인해줘",
+                    supportsToolCalling: true
+                )
+            )
+        )
+
+        XCTAssertEqual(adapter.capturedRequests.count, 2)
+        XCTAssertEqual(adapter.capturedRequests[0].tools.map(\.name), ["tools_enable"])
+        XCTAssertEqual(
+            Set(adapter.capturedRequests[1].tools.map(\.name)),
+            Set(["tools_enable", "coding_sessions"])
+        )
+        XCTAssertEqual(toolService.lastPreferredToolGroups, ["coding"])
+    }
+
     func testNativeAgentLoopServiceExecutesMultiToolCallsBeforeRerun() async throws {
         let toolService = MockBuiltInToolService()
         toolService.stubbedResult = ToolResult(toolCallId: "", content: "ok")
@@ -574,6 +635,20 @@ private extension NativeAgentLoopServiceTests {
         } catch {
             return (events, error)
         }
+    }
+
+    func makeToolSchema(name: String) -> [String: Any] {
+        [
+            "type": "function",
+            "function": [
+                "name": name,
+                "description": "\(name) description",
+                "parameters": [
+                    "type": "object",
+                    "properties": [String: Any]()
+                ] as [String: Any]
+            ] as [String: Any]
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix native agent loop follow-up behavior so tool definitions are refreshed after tool execution instead of reusing the initial static list.
- Pass runtime tool-refresh context (permissions, preferred groups, intent hint, capability support) from `DochiViewModel` into `NativeAgentLoopService`.
- Add regression test covering `tools.enable` -> follow-up request tool list refresh.

Closes #397

## Root Cause
`NativeAgentLoopService.makeFollowUpRequest` always reused `request.tools`. After `tools.enable`, registry state changed but follow-up requests still used stale tool definitions from the first request.

## Changes
- `Dochi/Services/NativeLLM/NativeAgentLoopService.swift`
  - Added `NativeAgentLoopToolRefreshContext`.
  - Added `toolRefreshContext` to `run(...)`.
  - Added `resolveFollowUpTools(...)` and schema->native conversion path for follow-up requests.
  - Updated follow-up request creation to use refreshed tools.
- `Dochi/ViewModels/DochiViewModel.swift`
  - Added `makeNativeToolRefreshContext(...)`.
  - Wired refresh context into both chat and Telegram native loop calls.
- `DochiTests/NativeAgentLoopServiceTests.swift`
  - Added `testNativeAgentLoopServiceRefreshesToolsForFollowUpRequest` regression test.

## Verification
### Unit tests
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/NativeAgentLoopServiceTests`
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/SessionStreamingTests -only-testing:DochiTests/NativeSessionRoutingTests`

### Build
- `xcodebuild -project Dochi.xcodeproj -scheme Dochi -configuration Debug build`
- `xcodebuild -project Dochi.xcodeproj -scheme DochiCLI -configuration Debug build`

### CLI runtime checks
- `dochi doctor` (looped until `control_plane_ping` recovered 7/7)
- `dochi dev tool tools.enable '{"groups":["coding"]}'`
- `dochi dev tool coding.sessions '{}'`
- `dochi dev chat stream "...tools.enable...coding.sessions..."`
  - Observed `tool_call` event for `coding-_-sessions` and successful `tool_result`.

## Spec Impact
- None (runtime bug fix; no product spec behavior change beyond intended tool-loop consistency).
