### PR TITLE
feat: add secret mode flags to dev chat stream

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -996,6 +996,11 @@ struct DochiApp: App {
             return .failure(code: "empty_prompt", message: "prompt가 필요합니다.")
         }
 
+        let secretMode = params["secret_mode"] as? Bool ?? false
+        let secretAllowedTools = (params["secret_allowed_tools"] as? [String] ?? [])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
         let timeoutSeconds = max(5, min(300, params["timeout_seconds"] as? Int ?? 120))
         let correlationId = nonEmptyString(params["correlation_id"]) ?? UUID().uuidString
         let streamId = await streamRegistry.createChatSession(correlationId: correlationId)
@@ -1029,11 +1034,16 @@ struct DochiApp: App {
         }
 
         await streamRegistry.attachChatTask(streamId: streamId, task: task)
-        return .ok([
+        var payload: [String: Any] = [
             "stream_id": streamId,
             "correlation_id": correlationId,
             "status": "started",
-        ])
+            "secret_mode": secretMode,
+        ]
+        if !secretAllowedTools.isEmpty {
+            payload["secret_allowed_tools"] = secretAllowedTools
+        }
+        return .ok(payload)
     }
 
     nonisolated private static func handleChatStreamRead(

--- a/Dochi/CLIShared/CLICommandSurface.swift
+++ b/Dochi/CLIShared/CLICommandSurface.swift
@@ -45,7 +45,7 @@ enum CLIDevAction: Equatable, Sendable {
     case tool(name: String, argumentsJSON: String?)
     case logRecent(minutes: Int)
     case logTail(seconds: Int, category: String?, level: String?, contains: String?)
-    case chatStream(prompt: String)
+    case chatStream(prompt: String, secretMode: Bool, secretAllowedTools: [String])
     case bridgeOpen(agent: String, profileName: String?, workingDirectory: String?, forceWorkingDirectory: Bool)
     case bridgeRoots(limit: Int, searchPaths: [String])
     case bridgeStatus(sessionId: String?)
@@ -427,11 +427,62 @@ enum CLICommandParser {
             guard sub == "stream" else {
                 throw CLIParseError.invalidUsage("dev chat 하위 명령은 stream만 지원합니다.")
             }
-            let prompt = args.dropFirst(2).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let streamArgs = Array(args.dropFirst(2))
+            var secretMode = false
+            var secretAllowedTools: [String] = []
+            var promptParts: [String] = []
+            var index = 0
+
+            while index < streamArgs.count {
+                let token = streamArgs[index]
+                if promptParts.isEmpty {
+                    switch token {
+                    case "--secret":
+                        secretMode = true
+                        index += 1
+                        continue
+                    case "--secret-allow-tool", "--allow-tool":
+                        guard index + 1 < streamArgs.count else {
+                            throw CLIParseError.invalidUsage("dev chat stream --secret-allow-tool <tool_name> 형식이 필요합니다.")
+                        }
+                        secretAllowedTools.append(streamArgs[index + 1])
+                        index += 2
+                        continue
+                    case "--":
+                        promptParts.append(contentsOf: streamArgs.dropFirst(index + 1))
+                        index = streamArgs.count
+                        continue
+                    default:
+                        if token.hasPrefix("--") {
+                            throw CLIParseError.invalidUsage("dev chat stream의 알 수 없는 옵션입니다: \(token)")
+                        }
+                    }
+                }
+
+                promptParts.append(contentsOf: streamArgs.dropFirst(index))
+                break
+            }
+
+            let prompt = promptParts.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
             guard !prompt.isEmpty else {
                 throw CLIParseError.invalidUsage("dev chat stream <prompt> 형식이 필요합니다.")
             }
-            return .dev(.chatStream(prompt: prompt))
+
+            let normalizedAllowedTools = secretAllowedTools
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .reduce(into: [String]()) { result, value in
+                    if !result.contains(value) {
+                        result.append(value)
+                    }
+                }
+
+            return .dev(.chatStream(
+                prompt: prompt,
+                secretMode: secretMode,
+                secretAllowedTools: normalizedAllowedTools
+            ))
 
         case "bridge":
             let sub = args.dropFirst().first ?? "status"

--- a/DochiCLI/README.md
+++ b/DochiCLI/README.md
@@ -67,6 +67,7 @@ dochi dev tool conversation.search '{"query":"회의","limit":5}'
 dochi dev log recent --minutes 15
 dochi dev log tail --seconds 30 --category App --level info
 dochi dev chat stream "최근 대화 3개를 요약해줘"
+dochi dev chat stream --secret --secret-allow-tool datetime "현재 시각만 알려줘"
 dochi dev bridge open codex --cwd ~/repo/dochi
 dochi dev bridge open codex --profile "Dochi Bridge Codex" --cwd ~/work/app --force-working-directory
 dochi dev bridge roots --limit 10
@@ -76,6 +77,9 @@ dochi dev bridge send <session_id> "pwd"
 dochi dev bridge read <session_id> 120
 dochi doctor
 ```
+
+- `dev chat stream --secret`은 secret 모드 플래그를 앱 control-plane에 전달합니다.
+- `--secret-allow-tool <name>`를 반복해서 전달하면 허용 도구 후보를 함께 전달합니다.
 
 ## 4) JSON 출력
 

--- a/DochiCLI/main.swift
+++ b/DochiCLI/main.swift
@@ -794,8 +794,14 @@ enum DochiCLI {
                 contains: contains
             )
 
-        case .chatStream(let prompt):
-            return handleDevChatStream(client: client, outputMode: outputMode, prompt: prompt)
+        case .chatStream(let prompt, let secretMode, let secretAllowedTools):
+            return handleDevChatStream(
+                client: client,
+                outputMode: outputMode,
+                prompt: prompt,
+                secretMode: secretMode,
+                secretAllowedTools: secretAllowedTools
+            )
 
         case .tool(let name, let argumentsJSON):
             do {
@@ -1183,10 +1189,20 @@ enum DochiCLI {
     private static func handleDevChatStream(
         client: CLIControlPlaneClient,
         outputMode: CLIOutputMode,
-        prompt: String
+        prompt: String,
+        secretMode: Bool,
+        secretAllowedTools: [String]
     ) -> CLIResult {
         do {
-            let openResult = try client.call(method: "chat.stream.open", params: ["prompt": prompt])
+            var openParams: [String: Any] = ["prompt": prompt]
+            if secretMode {
+                openParams["secret_mode"] = true
+                if !secretAllowedTools.isEmpty {
+                    openParams["secret_allowed_tools"] = secretAllowedTools
+                }
+            }
+
+            let openResult = try client.call(method: "chat.stream.open", params: openParams)
             guard let streamId = openResult["stream_id"] as? String, !streamId.isEmpty else {
                 return CLIResult(exitCode: .runtimeError, command: "dev.chat.stream", message: "chat.stream.open 응답에 stream_id가 없습니다.")
             }
@@ -1558,7 +1574,7 @@ enum DochiCLI {
           dochi dev tool <name> [arguments_json]
           dochi dev log recent [--minutes N]
           dochi dev log tail [--seconds N] [--category C] [--level L] [--contains K]
-          dochi dev chat stream <prompt>
+          dochi dev chat stream [--secret] [--secret-allow-tool <name>]... <prompt>
           dochi dev bridge open [agent] [--profile NAME] [--cwd DIR] [--force-working-directory]
           dochi dev bridge roots [--limit N] [--path DIR]...
           dochi dev bridge status [session_id]

--- a/DochiTests/CLICommandSurfaceTests.swift
+++ b/DochiTests/CLICommandSurfaceTests.swift
@@ -283,7 +283,53 @@ final class CLICommandSurfaceTests: XCTestCase {
 
     func testParseDevChatStream() throws {
         let invocation = try CLICommandParser.parse(["dev", "chat", "stream", "실시간", "테스트"])
-        XCTAssertEqual(invocation.command, .dev(.chatStream(prompt: "실시간 테스트")))
+        XCTAssertEqual(
+            invocation.command,
+            .dev(.chatStream(prompt: "실시간 테스트", secretMode: false, secretAllowedTools: []))
+        )
+    }
+
+    func testParseDevChatStreamSecretOptions() throws {
+        let invocation = try CLICommandParser.parse([
+            "dev", "chat", "stream",
+            "--secret",
+            "--secret-allow-tool", "datetime",
+            "--secret-allow-tool", "calculator",
+            "툴 호출 테스트"
+        ])
+        XCTAssertEqual(
+            invocation.command,
+            .dev(.chatStream(
+                prompt: "툴 호출 테스트",
+                secretMode: true,
+                secretAllowedTools: ["datetime", "calculator"]
+            ))
+        )
+    }
+
+    func testParseDevChatStreamAllowToolAliasAndDeduplicate() throws {
+        let invocation = try CLICommandParser.parse([
+            "dev", "chat", "stream",
+            "--allow-tool", "datetime",
+            "--allow-tool", "datetime",
+            "테스트"
+        ])
+        XCTAssertEqual(
+            invocation.command,
+            .dev(.chatStream(
+                prompt: "테스트",
+                secretMode: false,
+                secretAllowedTools: ["datetime"]
+            ))
+        )
+    }
+
+    func testParseDevChatStreamUnknownOptionThrows() {
+        XCTAssertThrowsError(try CLICommandParser.parse([
+            "dev", "chat", "stream", "--dry-run", "테스트"
+        ])) { error in
+            XCTAssertTrue(error.localizedDescription.contains("알 수 없는 옵션"))
+        }
     }
 
     func testParseDevToolWithDottedBuiltInToolName() throws {


### PR DESCRIPTION
## Summary
- extend `dev chat stream` parser with `--secret` and repeated `--secret-allow-tool` options
- pass secret options from CLI to control-plane `chat.stream.open` params
- make control-plane `chat.stream.open` accept/echo secret params in response payload
- update CLI README and usage text
- add parser tests for new options and failure path

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/CLICommandSurfaceTests`

## Issue
- closes #400
