### PR TITLE
feat: secret mode mock execution and pollution guard (#401)

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -1000,6 +1000,15 @@ struct DochiApp: App {
         let secretAllowedTools = (params["secret_allowed_tools"] as? [String] ?? [])
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
+        if secretMode && secretAllowedTools.isEmpty {
+            return .failure(
+                code: "missing_secret_allowed_tools",
+                message: "secret_mode에서는 secret_allowed_tools가 1개 이상 필요합니다."
+            )
+        }
+        let executionMode: DochiViewModel.ControlPlaneExecutionMode = secretMode
+            ? .secret(DochiViewModel.ControlPlaneSecretOptions(allowedToolNames: secretAllowedTools))
+            : .standard
 
         let timeoutSeconds = max(5, min(300, params["timeout_seconds"] as? Int ?? 120))
         let correlationId = nonEmptyString(params["correlation_id"]) ?? UUID().uuidString
@@ -1011,7 +1020,8 @@ struct DochiApp: App {
                 _ = try await uncheckedViewModel.value.runControlPlaneChatStream(
                     prompt: prompt,
                     correlationId: correlationId,
-                    timeoutSeconds: timeoutSeconds
+                    timeoutSeconds: timeoutSeconds,
+                    executionMode: executionMode
                 ) { event in
                     await streamRegistry.appendChatEvent(
                         streamId: streamId,

--- a/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
+++ b/Dochi/Services/NativeLLM/NativeAgentLoopService.swift
@@ -12,10 +12,31 @@ struct NativeAgentLoopGuardPolicy: Sendable {
     static let `default` = NativeAgentLoopGuardPolicy()
 }
 
+enum NativeAgentLoopToolExecutionMode: Sendable {
+    case live
+    case mock(allowedToolNames: [String])
+}
+
 struct NativeAgentLoopHookContext: Sendable {
     let sessionId: String
     let workspaceId: String
     let agentId: String?
+    let allowMemoryMutation: Bool
+    let toolExecutionMode: NativeAgentLoopToolExecutionMode
+
+    init(
+        sessionId: String,
+        workspaceId: String,
+        agentId: String?,
+        allowMemoryMutation: Bool = true,
+        toolExecutionMode: NativeAgentLoopToolExecutionMode = .live
+    ) {
+        self.sessionId = sessionId
+        self.workspaceId = workspaceId
+        self.agentId = agentId
+        self.allowMemoryMutation = allowMemoryMutation
+        self.toolExecutionMode = toolExecutionMode
+    }
 }
 
 struct NativeAgentLoopToolRefreshContext: Sendable {
@@ -96,7 +117,9 @@ final class NativeAgentLoopService {
         return AsyncThrowingStream { continuation in
             let task = Task { @MainActor [self, guardPolicy, toolService] in
                 let resolvedHookContext = Self.normalizedHookContext(hookContext)
-                if let memoryPipeline, !resolvedHookContext.workspaceId.isEmpty {
+                if resolvedHookContext.allowMemoryMutation,
+                   let memoryPipeline,
+                   !resolvedHookContext.workspaceId.isEmpty {
                     hookPipeline.attachMemoryPipeline(memoryPipeline, workspaceId: resolvedHookContext.workspaceId)
                 }
 
@@ -310,7 +333,17 @@ final class NativeAgentLoopService {
                                 effectiveArguments = arguments
                             }
 
-                            let result = await toolService.execute(name: pending.name, arguments: effectiveArguments)
+                            let result: ToolResult
+                            switch resolvedHookContext.toolExecutionMode {
+                            case .live:
+                                result = await toolService.execute(name: pending.name, arguments: effectiveArguments)
+                            case .mock(let allowedToolNames):
+                                result = Self.executeMockTool(
+                                    name: pending.name,
+                                    arguments: effectiveArguments,
+                                    allowedToolNames: allowedToolNames
+                                )
+                            }
                             continuation.yield(.toolResult(
                                 toolCallId: pending.toolCallId,
                                 content: result.content,
@@ -428,7 +461,9 @@ private extension NativeAgentLoopService {
         return NativeAgentLoopHookContext(
             sessionId: sessionId.isEmpty ? UUID().uuidString : sessionId,
             workspaceId: workspaceId,
-            agentId: context.agentId
+            agentId: context.agentId,
+            allowMemoryMutation: context.allowMemoryMutation,
+            toolExecutionMode: context.toolExecutionMode
         )
     }
 
@@ -527,6 +562,42 @@ private extension NativeAgentLoopService {
         default:
             return .string(String(describing: value))
         }
+    }
+
+    private static func executeMockTool(
+        name: String,
+        arguments: [String: Any],
+        allowedToolNames: [String]
+    ) -> ToolResult {
+        let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let allowed = Set(
+            allowedToolNames
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        )
+
+        guard allowed.contains(normalizedName) else {
+            return ToolResult(
+                toolCallId: "",
+                content: "secret mock 모드 차단: 허용되지 않은 도구 '\(normalizedName)'",
+                isError: true
+            )
+        }
+
+        let argumentsDescription: String
+        if JSONSerialization.isValidJSONObject(arguments),
+           let data = try? JSONSerialization.data(withJSONObject: arguments, options: [.sortedKeys]),
+           let text = String(data: data, encoding: .utf8) {
+            argumentsDescription = text
+        } else {
+            argumentsDescription = String(describing: arguments)
+        }
+
+        return ToolResult(
+            toolCallId: "",
+            content: "secret-mock tool '\(normalizedName)' executed with arguments: \(argumentsDescription)",
+            isError: false
+        )
     }
 
     private static func makeSafeIntegerCodable<T: BinaryInteger>(_ value: T) -> AnyCodableValue {

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -90,6 +90,26 @@ final class DochiViewModel {
         let timestamp: String
     }
 
+    struct ControlPlaneSecretOptions: Sendable {
+        let allowedToolNames: [String]
+
+        init(allowedToolNames: [String]) {
+            self.allowedToolNames = allowedToolNames
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .reduce(into: [String]()) { result, value in
+                    if !result.contains(value) {
+                        result.append(value)
+                    }
+                }
+        }
+    }
+
+    enum ControlPlaneExecutionMode: Sendable {
+        case standard
+        case secret(ControlPlaneSecretOptions)
+    }
+
     // MARK: - State
 
     private(set) var interactionState: InteractionState = .idle
@@ -232,6 +252,7 @@ final class DochiViewModel {
     private var sessionTimeoutTask: Task<Void, Never>?
     private var confirmationTimeoutTask: Task<Void, Never>?
     private var localServerMonitorTask: Task<Void, Never>?
+    private var activeControlPlaneExecutionMode: ControlPlaneExecutionMode = .standard
     private var sentenceChunker = SentenceChunker()
     private static let sessionEndingTimeout: TimeInterval = 10
     private static let toolConfirmationTimeout: TimeInterval = 30
@@ -259,6 +280,17 @@ final class DochiViewModel {
     /// Context window size (tokens) for the currently selected model.
     var contextWindowTokens: Int {
         settings.currentProvider.contextWindowTokens(for: settings.llmModel)
+    }
+
+    private var activeControlPlaneSecretOptions: ControlPlaneSecretOptions? {
+        if case .secret(let options) = activeControlPlaneExecutionMode {
+            return options
+        }
+        return nil
+    }
+
+    private var isControlPlaneSecretExecutionActive: Bool {
+        activeControlPlaneSecretOptions != nil
     }
 
     // MARK: - Init
@@ -1035,7 +1067,8 @@ final class DochiViewModel {
         ensureConversation()
 
         // K-3: Analyze message for interest discovery
-        if let conversationId = currentConversation?.id,
+        if !isControlPlaneSecretExecutionActive,
+           let conversationId = currentConversation?.id,
            let interestService = interestDiscoveryService {
             let countBefore = interestService.profile.interests.count
             interestService.analyzeMessage(finalText, conversationId: conversationId)
@@ -1096,11 +1129,16 @@ final class DochiViewModel {
 
     /// Control Plane `chat.send`용 단발 요청.
     /// 기존 `sendMessage()` 플로우를 재사용하고, 완료까지 대기한 뒤 최신 assistant 응답을 반환한다.
-    func sendMessageFromControlPlane(prompt: String, timeoutSeconds: Int = 120) async throws -> ControlPlaneChatSendResponse {
+    func sendMessageFromControlPlane(
+        prompt: String,
+        timeoutSeconds: Int = 120,
+        executionMode: ControlPlaneExecutionMode = .standard
+    ) async throws -> ControlPlaneChatSendResponse {
         try await runControlPlaneChatStream(
             prompt: prompt,
             correlationId: UUID().uuidString,
-            timeoutSeconds: timeoutSeconds
+            timeoutSeconds: timeoutSeconds,
+            executionMode: executionMode
         ) { _ in }
     }
 
@@ -1110,6 +1148,79 @@ final class DochiViewModel {
         prompt: String,
         correlationId: String,
         timeoutSeconds: Int = 120,
+        executionMode: ControlPlaneExecutionMode = .standard,
+        onEvent: @Sendable @escaping (ControlPlaneStreamEvent) async -> Void
+    ) async throws -> ControlPlaneChatSendResponse {
+        switch executionMode {
+        case .standard:
+            return try await runControlPlaneChatStreamCore(
+                prompt: prompt,
+                correlationId: correlationId,
+                timeoutSeconds: timeoutSeconds,
+                onEvent: onEvent
+            )
+        case .secret(let secretOptions):
+            return try await runControlPlaneChatStreamSecret(
+                prompt: prompt,
+                correlationId: correlationId,
+                timeoutSeconds: timeoutSeconds,
+                secretOptions: secretOptions,
+                onEvent: onEvent
+            )
+        }
+    }
+
+    private func runControlPlaneChatStreamSecret(
+        prompt: String,
+        correlationId: String,
+        timeoutSeconds: Int,
+        secretOptions: ControlPlaneSecretOptions,
+        onEvent: @Sendable @escaping (ControlPlaneStreamEvent) async -> Void
+    ) async throws -> ControlPlaneChatSendResponse {
+        guard !secretOptions.allowedToolNames.isEmpty else {
+            throw ControlPlaneChatSendError.requestFailed("secret 모드는 secret_allowed_tools가 1개 이상 필요합니다.")
+        }
+
+        let previousConversation = currentConversation
+        let previousStreamingText = streamingText
+        let previousErrorMessage = errorMessage
+        let previousToolName = currentToolName
+        let previousInputText = inputText
+        let previousPendingImages = pendingImages
+        let previousVisionWarningDismissed = visionWarningDismissed
+
+        activeControlPlaneExecutionMode = .secret(secretOptions)
+        currentConversation = Conversation(title: "Secret Smoke Session", userId: sessionContext.currentUserId)
+        streamingText = ""
+        errorMessage = nil
+        currentToolName = nil
+        inputText = ""
+        pendingImages = []
+        visionWarningDismissed = false
+
+        defer {
+            activeControlPlaneExecutionMode = .standard
+            currentConversation = previousConversation
+            streamingText = previousStreamingText
+            errorMessage = previousErrorMessage
+            currentToolName = previousToolName
+            inputText = previousInputText
+            pendingImages = previousPendingImages
+            visionWarningDismissed = previousVisionWarningDismissed
+        }
+
+        return try await runControlPlaneChatStreamCore(
+            prompt: prompt,
+            correlationId: correlationId,
+            timeoutSeconds: timeoutSeconds,
+            onEvent: onEvent
+        )
+    }
+
+    private func runControlPlaneChatStreamCore(
+        prompt: String,
+        correlationId: String,
+        timeoutSeconds: Int,
         onEvent: @Sendable @escaping (ControlPlaneStreamEvent) async -> Void
     ) async throws -> ControlPlaneChatSendResponse {
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1434,7 +1545,14 @@ final class DochiViewModel {
             let nativeHookContext = NativeAgentLoopHookContext(
                 sessionId: currentConversation?.id.uuidString ?? UUID().uuidString,
                 workspaceId: sessionContext.workspaceId.uuidString,
-                agentId: settings.activeAgentName
+                agentId: settings.activeAgentName,
+                allowMemoryMutation: !isControlPlaneSecretExecutionActive,
+                toolExecutionMode: {
+                    if let secret = activeControlPlaneSecretOptions {
+                        return .mock(allowedToolNames: secret.allowedToolNames)
+                    }
+                    return .live
+                }()
             )
 
             streamingText = ""
@@ -3331,7 +3449,9 @@ final class DochiViewModel {
         if currentConversation == nil {
             currentConversation = Conversation(userId: sessionContext.currentUserId)
         }
-        markCurrentNativeSessionActive()
+        if !isControlPlaneSecretExecutionActive {
+            markCurrentNativeSessionActive()
+        }
     }
 
     private func appendUserMessage(_ text: String, imageData: [ImageContent]? = nil) {
@@ -3432,6 +3552,10 @@ final class DochiViewModel {
 
     private func saveConversation() {
         guard let conversation = currentConversation else { return }
+        guard !isControlPlaneSecretExecutionActive else {
+            Log.app.debug("Secret control-plane execution: skip conversation persistence")
+            return
+        }
         markCurrentNativeSessionActive()
 
         if conversation.title == "새 대화",
@@ -3447,6 +3571,7 @@ final class DochiViewModel {
     }
 
     private func markCurrentNativeSessionActive() {
+        guard !isControlPlaneSecretExecutionActive else { return }
         guard let conversation = currentConversation else { return }
         let workspaceId = sessionContext.workspaceId
         let agentId = settings.activeAgentName
@@ -3470,6 +3595,7 @@ final class DochiViewModel {
     }
 
     private func markCurrentNativeSessionInterrupted() {
+        guard !isControlPlaneSecretExecutionActive else { return }
         guard let conversation = currentConversation else { return }
         let ownerUserId = normalizedUserId(conversation.userId) ?? normalizedUserId(sessionContext.currentUserId)
         _ = nativeSessionStore.interrupt(

--- a/DochiTests/NativeAgentLoopServiceTests.swift
+++ b/DochiTests/NativeAgentLoopServiceTests.swift
@@ -203,6 +203,83 @@ final class NativeAgentLoopServiceTests: XCTestCase {
         XCTAssertTrue(adapter.capturedRequests[1].messages.containsToolResult(toolCallId: "tool_1"))
     }
 
+    func testNativeAgentLoopServiceSecretMockExecutesWithoutRealToolInvocation() async throws {
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(toolCallId: "", content: "real-executed")
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { request in
+            if request.messages.containsToolResult(toolCallId: "tool_1") {
+                return [.done(text: "done")]
+            }
+            return [
+                .toolUse(toolCallId: "tool_1", toolName: "calendar.create", toolInputJSON: "{\"title\":\"회의\"}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService
+        )
+
+        let events = try await collectEvents(
+            from: service.run(
+                request: makeRequest(provider: .anthropic),
+                hookContext: NativeAgentLoopHookContext(
+                    sessionId: "native-secret-1",
+                    workspaceId: "workspace-secret-1",
+                    agentId: "도치",
+                    toolExecutionMode: .mock(allowedToolNames: ["calendar.create"])
+                )
+            )
+        )
+
+        XCTAssertEqual(events.map(\.kind), [.toolUse, .toolResult, .done])
+        XCTAssertEqual(toolService.executeCallCount, 0)
+        let toolResultText = events.first(where: { $0.kind == .toolResult })?.toolResultText ?? ""
+        XCTAssertTrue(toolResultText.contains("secret-mock tool"))
+    }
+
+    func testNativeAgentLoopServiceSecretMockFailsClosedForUnlistedTool() async {
+        let toolService = MockBuiltInToolService()
+
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { request in
+            if request.messages.containsToolResult(toolCallId: "tool_1") {
+                return [.done(text: "done")]
+            }
+            return [
+                .toolUse(toolCallId: "tool_1", toolName: "calendar.create", toolInputJSON: "{\"title\":\"회의\"}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService
+        )
+
+        let result = await collectEventsAndError(
+            from: service.run(
+                request: makeRequest(provider: .anthropic),
+                hookContext: NativeAgentLoopHookContext(
+                    sessionId: "native-secret-2",
+                    workspaceId: "workspace-secret-2",
+                    agentId: "도치",
+                    toolExecutionMode: .mock(allowedToolNames: ["datetime"])
+                )
+            )
+        )
+
+        XCTAssertEqual(result.events.map(\.kind), [.toolUse, .toolResult])
+        XCTAssertEqual(toolService.executeCallCount, 0)
+        guard let error = result.error as? NativeLLMError else {
+            return XCTFail("Expected NativeLLMError")
+        }
+        XCTAssertEqual(error.code, .toolExecutionFailed)
+        let toolResultText = result.events.first(where: { $0.kind == .toolResult })?.toolResultText ?? ""
+        XCTAssertTrue(toolResultText.contains("secret mock 모드 차단"))
+    }
+
     func testNativeAgentLoopServiceRefreshesToolsForFollowUpRequest() async throws {
         let toolService = MockBuiltInToolService()
         toolService.stubbedResult = ToolResult(toolCallId: "", content: "enabled")
@@ -516,6 +593,56 @@ final class NativeAgentLoopServiceTests: XCTestCase {
         XCTAssertEqual(candidate.workspaceId, "workspace-3")
         XCTAssertEqual(candidate.agentId, "도치")
         XCTAssertEqual(candidate.source, .toolResult)
+    }
+
+    func testNativeAgentLoopServiceSkipsMemoryMutationWhenDisabled() async throws {
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(
+            toolCallId: "",
+            content: "오늘 일정: 14시 제품 리뷰 미팅, 16시 디자인 동기화"
+        )
+        toolService.allToolInfos = [
+            ToolInfo(
+                name: "calendar.today",
+                description: "today",
+                category: .safe,
+                isBaseline: true,
+                isEnabled: true,
+                parameters: []
+            ),
+        ]
+
+        let memoryPipeline = MockMemoryPipelineService()
+        let adapter = CapturingNativeLLMProviderAdapter(provider: .anthropic) { request in
+            if request.messages.containsToolResult(toolCallId: "tool_1") {
+                return [.done(text: "done")]
+            }
+            return [
+                .toolUse(toolCallId: "tool_1", toolName: "calendar.today", toolInputJSON: "{}"),
+                .done(text: nil),
+            ]
+        }
+
+        let service = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService,
+            memoryPipeline: memoryPipeline
+        )
+
+        _ = try await collectEvents(
+            from: service.run(
+                request: makeRequest(provider: .anthropic),
+                hookContext: NativeAgentLoopHookContext(
+                    sessionId: "native-session-4",
+                    workspaceId: "workspace-4",
+                    agentId: "도치",
+                    allowMemoryMutation: false
+                )
+            )
+        )
+        try await Task.sleep(for: .milliseconds(30))
+
+        XCTAssertEqual(memoryPipeline.submitCallCount, 0)
     }
 
     func testNativeAgentLoopServiceHandlesOutOfRangeUnsignedArguments() async throws {

--- a/DochiTests/SessionStreamingTests.swift
+++ b/DochiTests/SessionStreamingTests.swift
@@ -117,6 +117,81 @@ final class SessionStreamingTests: XCTestCase {
         XCTAssertEqual(assistant, "도구 결과 확인")
     }
 
+    @MainActor
+    func testControlPlaneSecretModeUsesMockToolAndRestoresConversation() async throws {
+        let toolService = MockBuiltInToolService()
+        toolService.stubbedResult = ToolResult(toolCallId: "", content: "real tool executed")
+
+        let adapter = CapturingStreamAdapter(provider: .anthropic) { request in
+            if request.messages.containsToolResult(callId: "tool_1") {
+                return [.done(text: "secret 완료")]
+            }
+            return [
+                .toolUse(
+                    toolCallId: "tool_1",
+                    toolName: "calendar.create",
+                    toolInputJSON: "{\"title\":\"미팅\"}"
+                ),
+                .done(text: nil),
+            ]
+        }
+
+        let nativeService = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: toolService
+        )
+        let conversationService = MockConversationService()
+        let existingConversation = Conversation(
+            id: UUID(),
+            title: "기존 대화",
+            messages: [Message(role: .assistant, content: "기존 메시지")]
+        )
+        conversationService.save(conversation: existingConversation)
+
+        let viewModel = makeViewModel(
+            provider: .anthropic,
+            nativeLoopService: nativeService,
+            toolService: toolService,
+            conversationService: conversationService
+        )
+        viewModel.selectConversation(id: existingConversation.id)
+
+        actor EventCollector {
+            private var events: [DochiViewModel.ControlPlaneStreamEvent] = []
+
+            func append(_ event: DochiViewModel.ControlPlaneStreamEvent) {
+                events.append(event)
+            }
+
+            func all() -> [DochiViewModel.ControlPlaneStreamEvent] {
+                events
+            }
+        }
+        let eventCollector = EventCollector()
+        let response = try await viewModel.runControlPlaneChatStream(
+            prompt: "일정 만들어",
+            correlationId: "secret-cid",
+            timeoutSeconds: 5,
+            executionMode: .secret(.init(allowedToolNames: ["calendar.create"]))
+        ) { event in
+            await eventCollector.append(event)
+        }
+        let events = await eventCollector.all()
+
+        XCTAssertEqual(response.assistantMessage, "secret 완료")
+        XCTAssertEqual(toolService.executeCallCount, 0)
+        XCTAssertEqual(viewModel.currentConversation?.id, existingConversation.id)
+        XCTAssertEqual(
+            viewModel.currentConversation?.messages.last?.content,
+            existingConversation.messages.last?.content
+        )
+        XCTAssertEqual(conversationService.list().count, 1)
+        XCTAssertGreaterThanOrEqual(adapter.capturedRequests.count, 2)
+        XCTAssertFalse(adapter.capturedRequests[0].messages.containsToolResult(callId: "tool_1"))
+        XCTAssertTrue(adapter.capturedRequests[1].messages.containsToolResult(callId: "tool_1"))
+        XCTAssertTrue(events.contains(where: { $0.kind == .done }))
+    }
+
     // MARK: - testFailedEventSetsErrorMessage
 
     /// Verifies that a network error from the native loop sets `errorMessage` on the ViewModel.
@@ -247,7 +322,8 @@ private extension SessionStreamingTests {
         provider: LLMProvider,
         nativeLoopService: NativeAgentLoopService,
         toolService: MockBuiltInToolService? = nil,
-        keychainService: MockKeychainService? = nil
+        keychainService: MockKeychainService? = nil,
+        conversationService: MockConversationService = MockConversationService()
     ) -> DochiViewModel {
         let resolvedToolService = toolService ?? MockBuiltInToolService()
         let resolvedKeychainService = keychainService ?? MockKeychainService()
@@ -266,7 +342,7 @@ private extension SessionStreamingTests {
         return DochiViewModel(
             toolService: resolvedToolService,
             contextService: MockContextService(),
-            conversationService: MockConversationService(),
+            conversationService: conversationService,
             keychainService: resolvedKeychainService,
             speechService: MockSpeechService(),
             ttsService: MockTTSService(),


### PR DESCRIPTION
## Summary
- add control-plane execution mode with a `secret` option that requires an allow-list of tools
- run secret requests in an ephemeral conversation and restore prior UI/session state afterward
- disable conversation/session/memory mutation side effects during secret runs
- add native loop mock tool execution mode (`live` vs `mock`) with fail-closed allow-list behavior
- wire `chat.stream.open` (`secret_mode`, `secret_allowed_tools`) to the new execution mode and validate request params
- add tests for mock execution, fail-closed behavior, memory mutation guard, and control-plane restoration

## UX step
- skipped (no screen/UI surface changes in this issue)

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/NativeAgentLoopServiceTests -only-testing:DochiTests/SessionStreamingTests`

## Spec Impact
- none

Closes #401
