### PR TITLE
fix: improve bridge session detection fallback and status count

### DIFF
--- a/Dochi/Services/ExternalToolSessionManager.swift
+++ b/Dochi/Services/ExternalToolSessionManager.swift
@@ -901,14 +901,21 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             )
         }
 
-        async let discoveredSessions = discoverLocalCodingSessions(limit: max(effectiveLimit * 2, 80))
+        // Keep process probing bounded for control-plane latency.
+        let processLimit = max(min(effectiveLimit, 120), 60)
         let processSnapshots = await Task.detached(priority: .utility) {
             Self.discoverProcessRuntimeSessions(
-                limit: max(effectiveLimit * 2, 120),
+                limit: processLimit,
                 now: now
             )
         }.value
-        let discovered = await discoveredSessions
+        let hasRuntimeCandidates = !(sessionSnapshots.isEmpty && processSnapshots.isEmpty)
+        let discovered: [DiscoveredCodingSession]
+        if hasRuntimeCandidates {
+            discovered = []
+        } else {
+            discovered = await discoverLocalCodingSessions(limit: max(effectiveLimit, 80))
+        }
         let managedRoots = managedRepositories
             .filter { !$0.isArchived }
             .map { URL(fileURLWithPath: $0.rootPath).standardizedFileURL.path }
@@ -2382,15 +2389,16 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             psOutput: psResult.output,
             now: now,
             workingDirectories: [:],
-            limit: max(effectiveLimit * 2, 80)
+            limit: max(effectiveLimit, 80)
         )
         guard !rough.isEmpty else {
             return []
         }
 
-        let pids = rough
-            .compactMap(\.runtimeSessionId)
-            .compactMap(Int.init)
+        let pids = processWorkingDirectoryCandidatePIDs(
+            from: rough,
+            cap: min(max(effectiveLimit, 24), 64)
+        )
         let workingDirectories = resolveProcessWorkingDirectories(pids: pids)
         return parseProcessRuntimeSnapshots(
             psOutput: psResult.output,
@@ -2445,28 +2453,60 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             .map { $0 }
     }
 
+    nonisolated static func processWorkingDirectoryCandidatePIDs(
+        from snapshots: [RuntimeSessionSnapshot],
+        cap: Int
+    ) -> [Int] {
+        let effectiveCap = max(1, min(400, cap))
+        var selected: [Int] = []
+        selected.reserveCapacity(effectiveCap)
+        var seen: Set<Int> = []
+        seen.reserveCapacity(effectiveCap)
+
+        for snapshot in snapshots {
+            guard selected.count < effectiveCap,
+                  let raw = snapshot.runtimeSessionId,
+                  let pid = Int(raw),
+                  pid > 0,
+                  !seen.contains(pid) else {
+                continue
+            }
+            seen.insert(pid)
+            selected.append(pid)
+        }
+        return selected
+    }
+
     nonisolated static func processProvider(fromCommandLine commandLine: String) -> String? {
         let trimmed = commandLine.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
-        let executable = trimmed
-            .split(maxSplits: 1, omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
-            .first
-            .map(String.init) ?? trimmed
-        let basename = URL(fileURLWithPath: executable).lastPathComponent.lowercased()
-        if basename == "codex" || basename == "claude" || basename == "aider" {
-            return basename
+        let lower = trimmed.lowercased()
+        if lower.contains("/applications/codex.app/contents/") ||
+            lower.contains("/applications/claude.app/contents/") {
+            return nil
         }
 
-        let lower = " \(trimmed.lowercased()) "
-        if lower.contains(" -m aider ") || lower.contains(" /aider ") || lower.contains(" aider ") {
+        let tokens = trimmed.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !tokens.isEmpty else { return nil }
+        let normalizedTokens = tokens.map { token in
+            URL(fileURLWithPath: token).lastPathComponent.lowercased()
+        }
+
+        if normalizedTokens.contains("aider") {
             return "aider"
         }
-        if lower.contains(" /codex ") || lower.contains(" codex ") || lower.contains(" codex-cli ") {
+        if normalizedTokens.contains("codex") || normalizedTokens.contains("codex-cli") {
             return "codex"
         }
-        if lower.contains(" /claude ") || lower.contains(" claude ") || lower.contains(" claude-code ") {
+        if normalizedTokens.contains("claude") || normalizedTokens.contains("claude-code") {
             return "claude"
+        }
+
+        if let moduleIndex = normalizedTokens.firstIndex(of: "-m"),
+           normalizedTokens.indices.contains(moduleIndex + 1),
+           normalizedTokens[moduleIndex + 1] == "aider" {
+            return "aider"
         }
         return nil
     }

--- a/DochiCLI/main.swift
+++ b/DochiCLI/main.swift
@@ -953,7 +953,7 @@ enum DochiCLI {
                 } else {
                     params = [:]
                 }
-                let result = try client.call(method: "bridge.status", params: params)
+                var result = try client.call(method: "bridge.status", params: params)
                 if let sessions = result["sessions"] as? [[String: Any]] {
                     var lines = sessions.map { session -> String in
                         let id = session["session_id"] as? String ?? "-"
@@ -963,6 +963,9 @@ enum DochiCLI {
                     }
 
                     if let unified = result["unified_sessions"] as? [[String: Any]], !unified.isEmpty {
+                        if (result["count"] as? Int ?? 0) == 0 {
+                            result["count"] = unified.count
+                        }
                         if !lines.isEmpty {
                             lines.append("")
                         }
@@ -996,6 +999,34 @@ enum DochiCLI {
                         if discovered.count > 20 {
                             lines.append("... \(discovered.count - 20)개 추가")
                         }
+                        if (result["count"] as? Int ?? 0) == 0 {
+                            result["count"] = discovered.count
+                        }
+                    }
+
+                    if lines.isEmpty, sessionId == nil {
+                        let processFallback = discoverProcessCodingSessions(limit: 30)
+                        if !processFallback.isEmpty {
+                            lines.append("Control Plane 응답에 세션이 없어 로컬 프로세스 감지 결과를 표시합니다.")
+                            lines.append("프로세스 감지 세션 \(processFallback.count)개")
+                            result["process_fallback_count"] = processFallback.count
+                            result["process_fallback_sessions"] = processFallback.map { snapshot in
+                                [
+                                    "provider": snapshot.provider,
+                                    "native_session_id": "pid-\(snapshot.pid)",
+                                    "runtime_session_id": "\(snapshot.pid)",
+                                    "tty": snapshot.tty,
+                                    "is_active": snapshot.isActive,
+                                    "updated_at": ISO8601DateFormatter().string(from: snapshot.updatedAt),
+                                    "command": snapshot.commandLine,
+                                ]
+                            }
+                            result["count"] = processFallback.count
+                            for item in processFallback {
+                                let state = item.isActive ? "active" : "stale"
+                                lines.append("- [\(item.provider)] pid-\(item.pid) state=\(state) tty=\(item.tty)")
+                            }
+                        }
                     }
 
                     let message = lines.isEmpty ? "브리지/파일 기반 세션이 없습니다." : lines.joined(separator: "\n")
@@ -1012,6 +1043,40 @@ enum DochiCLI {
                     data: result
                 )
             } catch let error as CLIControlPlaneError {
+                if sessionId == nil {
+                    let processFallback = discoverProcessCodingSessions(limit: 30)
+                    if !processFallback.isEmpty {
+                        let lines: [String] = [
+                            "Control Plane bridge.status 호출에 실패하여 로컬 프로세스 감지 결과를 표시합니다.",
+                            "프로세스 감지 세션 \(processFallback.count)개",
+                        ] + processFallback.map { snapshot in
+                            let state = snapshot.isActive ? "active" : "stale"
+                            return "- [\(snapshot.provider)] pid-\(snapshot.pid) state=\(state) tty=\(snapshot.tty)"
+                        }
+                        let payload: [[String: Any]] = processFallback.map { snapshot in
+                            [
+                                "provider": snapshot.provider,
+                                "native_session_id": "pid-\(snapshot.pid)",
+                                "runtime_session_id": "\(snapshot.pid)",
+                                "tty": snapshot.tty,
+                                "is_active": snapshot.isActive,
+                                "updated_at": ISO8601DateFormatter().string(from: snapshot.updatedAt),
+                                "command": snapshot.commandLine,
+                            ]
+                        }
+                        return CLIResult(
+                            exitCode: .success,
+                            command: "dev.bridge.status",
+                            message: lines.joined(separator: "\n"),
+                            data: [
+                                "fallback_reason": error.localizedDescription,
+                                "count": processFallback.count,
+                                "process_fallback_count": processFallback.count,
+                                "process_fallback_sessions": payload,
+                            ]
+                        )
+                    }
+                }
                 return mapControlPlaneError(error, command: "dev.bridge.status")
             } catch {
                 return CLIResult(exitCode: .runtimeError, command: "dev.bridge.status", message: "요청 실패: \(error.localizedDescription)")
@@ -1566,6 +1631,184 @@ enum DochiCLI {
             }
             return CLIResult(exitCode: .runtimeError, command: command, message: "앱 요청 실패 (\(code)): \(message)")
         }
+    }
+
+    private struct CLIProcessSessionSnapshot {
+        let provider: String
+        let pid: Int
+        let tty: String
+        let commandLine: String
+        let updatedAt: Date
+        let isActive: Bool
+    }
+
+    private static func discoverProcessCodingSessions(limit: Int, now: Date = Date()) -> [CLIProcessSessionSnapshot] {
+        let effectiveLimit = max(1, min(80, limit))
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["ps", "-axo", "pid=,tty=,etime=,command="]
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        do {
+            try process.run()
+            let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else {
+                return []
+            }
+
+            let output = String(data: data, encoding: .utf8) ?? ""
+            let snapshots = output
+                .components(separatedBy: .newlines)
+                .compactMap { parseProcessSessionSnapshotLine($0, now: now) }
+                .sorted { lhs, rhs in
+                    if lhs.isActive != rhs.isActive {
+                        return lhs.isActive && !rhs.isActive
+                    }
+                    if lhs.updatedAt != rhs.updatedAt {
+                        return lhs.updatedAt > rhs.updatedAt
+                    }
+                    if lhs.provider != rhs.provider {
+                        return lhs.provider < rhs.provider
+                    }
+                    return lhs.pid < rhs.pid
+                }
+
+            var dedup: [String: CLIProcessSessionSnapshot] = [:]
+            for snapshot in snapshots {
+                let key = "\(snapshot.provider)|\(snapshot.pid)"
+                if dedup[key] == nil {
+                    dedup[key] = snapshot
+                }
+            }
+            return Array(dedup.values)
+                .sorted { lhs, rhs in
+                    if lhs.isActive != rhs.isActive {
+                        return lhs.isActive && !rhs.isActive
+                    }
+                    if lhs.updatedAt != rhs.updatedAt {
+                        return lhs.updatedAt > rhs.updatedAt
+                    }
+                    if lhs.provider != rhs.provider {
+                        return lhs.provider < rhs.provider
+                    }
+                    return lhs.pid < rhs.pid
+                }
+                .prefix(effectiveLimit)
+                .map { $0 }
+        } catch {
+            return []
+        }
+    }
+
+    private static func parseProcessSessionSnapshotLine(
+        _ rawLine: String,
+        now: Date
+    ) -> CLIProcessSessionSnapshot? {
+        let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let parts = trimmed.split(maxSplits: 3, omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
+        guard parts.count >= 4,
+              let pid = Int(parts[0]) else {
+            return nil
+        }
+
+        let tty = String(parts[1])
+        let elapsed = parsePSElapsed(String(parts[2]))
+        let commandLine = String(parts[3]).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let provider = processProviderFromCommandLine(commandLine) else {
+            return nil
+        }
+
+        let updatedAt = elapsed.map { now.addingTimeInterval(-$0) } ?? now
+        let isActive = elapsed.map { $0 <= 45 * 60 } ?? true
+        return CLIProcessSessionSnapshot(
+            provider: provider,
+            pid: pid,
+            tty: tty,
+            commandLine: commandLine,
+            updatedAt: updatedAt,
+            isActive: isActive
+        )
+    }
+
+    private static func processProviderFromCommandLine(_ commandLine: String) -> String? {
+        let trimmed = commandLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let lower = trimmed.lowercased()
+        if lower.contains("/applications/codex.app/contents/") ||
+            lower.contains("/applications/claude.app/contents/") {
+            return nil
+        }
+
+        let tokens = trimmed.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard !tokens.isEmpty else { return nil }
+        let normalizedTokens = tokens.map { token in
+            URL(fileURLWithPath: token).lastPathComponent.lowercased()
+        }
+
+        if normalizedTokens.contains("codex") { return "codex" }
+        if normalizedTokens.contains("claude") || normalizedTokens.contains("claude-code") { return "claude" }
+        if normalizedTokens.contains("aider") { return "aider" }
+
+        if let moduleIndex = normalizedTokens.firstIndex(of: "-m"),
+           normalizedTokens.indices.contains(moduleIndex + 1),
+           normalizedTokens[moduleIndex + 1] == "aider" {
+            return "aider"
+        }
+        return nil
+    }
+
+    private static func parsePSElapsed(_ raw: String) -> TimeInterval? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let daySplit = trimmed.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: true)
+        let days: Int
+        let timePart: Substring
+        if daySplit.count == 2 {
+            guard let parsedDays = Int(daySplit[0]) else { return nil }
+            days = parsedDays
+            timePart = daySplit[1]
+        } else {
+            days = 0
+            timePart = daySplit[0]
+        }
+
+        let timeComponents = timePart.split(separator: ":")
+        let hours: Int
+        let minutes: Int
+        let seconds: Int
+        switch timeComponents.count {
+        case 2:
+            hours = 0
+            guard let parsedMinutes = Int(timeComponents[0]),
+                  let parsedSeconds = Int(timeComponents[1]) else {
+                return nil
+            }
+            minutes = parsedMinutes
+            seconds = parsedSeconds
+        case 3:
+            guard let parsedHours = Int(timeComponents[0]),
+                  let parsedMinutes = Int(timeComponents[1]),
+                  let parsedSeconds = Int(timeComponents[2]) else {
+                return nil
+            }
+            hours = parsedHours
+            minutes = parsedMinutes
+            seconds = parsedSeconds
+        default:
+            return nil
+        }
+
+        guard days >= 0, hours >= 0, minutes >= 0, seconds >= 0 else { return nil }
+        let totalSeconds = (((days * 24) + hours) * 60 + minutes) * 60 + seconds
+        return TimeInterval(totalSeconds)
     }
 
     private static func parseJSONArguments(_ argumentsJSON: String?) throws -> [String: Any] {

--- a/DochiTests/GitRepositoryInsightScorerTests.swift
+++ b/DochiTests/GitRepositoryInsightScorerTests.swift
@@ -490,6 +490,14 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
             "claude"
         )
         XCTAssertNil(
+            ExternalToolSessionManager.processProvider(fromCommandLine: "/Applications/Codex.app/Contents/MacOS/Codex")
+        )
+        XCTAssertNil(
+            ExternalToolSessionManager.processProvider(
+                fromCommandLine: "/Applications/Codex.app/Contents/Frameworks/Codex Helper.app/Contents/MacOS/Codex Helper --type=gpu-process"
+            )
+        )
+        XCTAssertNil(
             ExternalToolSessionManager.processProvider(fromCommandLine: "/usr/bin/vim main.swift")
         )
     }
@@ -499,5 +507,82 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
         XCTAssertEqual(ExternalToolSessionManager.processControllabilityTier(tty: "??"), .t3Unknown)
         XCTAssertEqual(ExternalToolSessionManager.processControllabilityTier(tty: "-"), .t3Unknown)
         XCTAssertEqual(ExternalToolSessionManager.processControllabilityTier(tty: "   "), .t3Unknown)
+    }
+
+    func testProcessWorkingDirectoryCandidatePIDSCapsAndSkipsInvalidIDs() {
+        let now = Date()
+        let snapshots: [ExternalToolSessionManager.RuntimeSessionSnapshot] = [
+            .init(
+                provider: "codex",
+                nativeSessionId: "pid-101",
+                runtimeSessionId: "101",
+                workingDirectory: nil,
+                path: "process://101",
+                updatedAt: now,
+                isActive: true,
+                status: .unknown,
+                lastOutputAt: nil,
+                lastCommandAt: nil,
+                hasErrorPattern: false,
+                runtimeType: .process,
+                controllabilityTier: .t1Attach,
+                source: "process_runtime"
+            ),
+            .init(
+                provider: "codex",
+                nativeSessionId: "pid-101-dup",
+                runtimeSessionId: "101",
+                workingDirectory: nil,
+                path: "process://101",
+                updatedAt: now.addingTimeInterval(-1),
+                isActive: true,
+                status: .unknown,
+                lastOutputAt: nil,
+                lastCommandAt: nil,
+                hasErrorPattern: false,
+                runtimeType: .process,
+                controllabilityTier: .t1Attach,
+                source: "process_runtime"
+            ),
+            .init(
+                provider: "claude",
+                nativeSessionId: "pid-202",
+                runtimeSessionId: "202",
+                workingDirectory: nil,
+                path: "process://202",
+                updatedAt: now.addingTimeInterval(-2),
+                isActive: true,
+                status: .unknown,
+                lastOutputAt: nil,
+                lastCommandAt: nil,
+                hasErrorPattern: false,
+                runtimeType: .process,
+                controllabilityTier: .t1Attach,
+                source: "process_runtime"
+            ),
+            .init(
+                provider: "aider",
+                nativeSessionId: "pid-invalid",
+                runtimeSessionId: "abc",
+                workingDirectory: nil,
+                path: "process://abc",
+                updatedAt: now.addingTimeInterval(-3),
+                isActive: true,
+                status: .unknown,
+                lastOutputAt: nil,
+                lastCommandAt: nil,
+                hasErrorPattern: false,
+                runtimeType: .process,
+                controllabilityTier: .t1Attach,
+                source: "process_runtime"
+            ),
+        ]
+
+        let selected = ExternalToolSessionManager.processWorkingDirectoryCandidatePIDs(
+            from: snapshots,
+            cap: 2
+        )
+
+        XCTAssertEqual(selected, [101, 202])
     }
 }


### PR DESCRIPTION
## Summary
- optimize process/runtime session probing in `ExternalToolSessionManager` to reduce bridge status latency
- add CLI-side process fallback for `dev bridge status` when Control Plane 응답이 비어 있거나 연결 실패할 때
- normalize `dev bridge status --json`의 `data.count` to reflect unified/discovered/fallback session counts
- tighten provider heuristics to avoid false positives from desktop app helper processes
- add unit tests for provider heuristics and PID candidate capping/dedup logic

## Why
- some environments return empty `sessions` from the app even when sessions are actually discoverable
- `--json` output could show `count=0` despite unified sessions being present, causing false negative interpretation
- process probing path could become expensive and increase control-plane latency

## Test Evidence
- `xcodebuild -project Dochi.xcodeproj -scheme DochiCLI -configuration Debug build`
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/GitRepositoryInsightScorerTests`
- `dochi --mode app dev bridge status --json | jq '{count: .data.count, unified_count: .data.unified_count}'`

## Spec Impact
- None (robustness/telemetry behavior only; no product spec doc changes)

## Related
- refs #399
- refs #410
