### PR TITLE
fix: avoid stale bias for attachable process sessions

### DIFF
--- a/Dochi/Services/ExternalToolSessionManager.swift
+++ b/Dochi/Services/ExternalToolSessionManager.swift
@@ -1987,12 +1987,25 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                 for: runtime.workingDirectory,
                 managedRepositoryRoots: managedRepositoryRoots
             )
+            let runtimeAlive = runtime.status != .dead
+            // `ps etime` is process uptime, not recent activity. For attachable process sessions,
+            // avoid stale bias by inferring a fresh command signal from runtime liveness.
+            let inferredRecentCommandAge: TimeInterval?
+            if runtime.runtimeType == .process,
+               runtime.controllabilityTier == .t1Attach,
+               runtimeAlive {
+                inferredRecentCommandAge = 0
+            } else {
+                inferredRecentCommandAge = ageSince(runtime.lastCommandAt, now: now)
+            }
+            let inferredFileMtimeAge: TimeInterval? =
+                runtime.runtimeType == .process ? nil : ageSince(runtime.updatedAt, now: now)
             let activity = scoreUnifiedSessionActivity(
                 input: UnifiedSessionActivityInput(
-                    runtimeAlive: runtime.status != .dead,
+                    runtimeAlive: runtimeAlive,
                     recentOutputAge: ageSince(runtime.lastOutputAt, now: now),
-                    recentCommandAge: ageSince(runtime.lastCommandAt, now: now),
-                    fileMtimeAge: ageSince(runtime.updatedAt, now: now),
+                    recentCommandAge: inferredRecentCommandAge,
+                    fileMtimeAge: inferredFileMtimeAge,
                     hasErrorPattern: runtime.hasErrorPattern
                 ),
                 config: config

--- a/DochiTests/GitRepositoryInsightScorerTests.swift
+++ b/DochiTests/GitRepositoryInsightScorerTests.swift
@@ -399,6 +399,79 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
         XCTAssertLessThan(dead.score, stale.score)
     }
 
+    func testMergeUnifiedCodingSessionsScoresAttachableProcessAsIdle() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let runtime = ExternalToolSessionManager.RuntimeSessionSnapshot(
+            provider: "codex",
+            nativeSessionId: "pid-9001",
+            runtimeSessionId: "9001",
+            workingDirectory: "/tmp/repo-a",
+            path: "process://9001",
+            updatedAt: now.addingTimeInterval(-3 * 24 * 60 * 60),
+            isActive: true,
+            status: .unknown,
+            lastOutputAt: nil,
+            lastCommandAt: nil,
+            hasErrorPattern: false,
+            runtimeType: .process,
+            controllabilityTier: .t1Attach,
+            source: "process_runtime"
+        )
+
+        let merged = ExternalToolSessionManager.mergeUnifiedCodingSessions(
+            runtimeSessions: [runtime],
+            discoveredSessions: [],
+            managedRepositoryRoots: ["/tmp/repo-a"],
+            limit: 10,
+            now: now,
+            config: .standard
+        )
+
+        guard let session = merged.first else {
+            return XCTFail("Expected merged session")
+        }
+        XCTAssertEqual(session.activityState, .idle)
+        XCTAssertGreaterThanOrEqual(
+            session.activityScore,
+            CodingSessionActivityScoringConfig.standard.idleThreshold
+        )
+    }
+
+    func testMergeUnifiedCodingSessionsKeepsUnknownProcessAsStale() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let runtime = ExternalToolSessionManager.RuntimeSessionSnapshot(
+            provider: "codex",
+            nativeSessionId: "pid-9002",
+            runtimeSessionId: "9002",
+            workingDirectory: nil,
+            path: "process://9002",
+            updatedAt: now.addingTimeInterval(-3 * 24 * 60 * 60),
+            isActive: true,
+            status: .unknown,
+            lastOutputAt: nil,
+            lastCommandAt: nil,
+            hasErrorPattern: false,
+            runtimeType: .process,
+            controllabilityTier: .t3Unknown,
+            source: "process_runtime"
+        )
+
+        let merged = ExternalToolSessionManager.mergeUnifiedCodingSessions(
+            runtimeSessions: [runtime],
+            discoveredSessions: [],
+            managedRepositoryRoots: [],
+            limit: 10,
+            now: now,
+            config: .standard
+        )
+
+        guard let session = merged.first else {
+            return XCTFail("Expected merged session")
+        }
+        XCTAssertEqual(session.activityState, .stale)
+        XCTAssertEqual(session.activityScore, CodingSessionActivityScoringConfig.standard.runtimeAliveWeight)
+    }
+
     func testUnifiedSessionOrderingIsDeterministicWhenTimestampsTie() {
         let tiedTime = Date(timeIntervalSince1970: 1_700_000_000)
         let later = UnifiedCodingSession(


### PR DESCRIPTION
## Summary
- remove stale bias for process runtime sessions in unified activity scoring
- treat attachable process sessions (`runtimeType=process`, `tier=t1_attach`) as having inferred recent command activity
- stop using process uptime-derived freshness as file freshness input for process sessions
- add tests for attachable (`t1_attach`) vs unknown (`t3_unknown`) process scoring behavior

## Why
`ps etime` is process uptime, not last activity. The previous scoring path effectively penalized long-lived but still attachable sessions as stale.

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/GitRepositoryInsightScorerTests`

## Spec Impact
- None (scoring heuristics adjustment)

## Related
- closes #410
