### PR TITLE
feat: [K-2] repo-first session explorer UI restructure (#415)

### DIFF
--- a/Dochi/ViewModels/SessionExplorerViewModel.swift
+++ b/Dochi/ViewModels/SessionExplorerViewModel.swift
@@ -42,6 +42,19 @@ enum SessionExplorerViewStateBuilder {
         return URL(fileURLWithPath: path).standardizedFileURL.path
     }
 
+    static func repositoryContainsWorkingDirectory(
+        repositoryRoot: String,
+        workingDirectory: String
+    ) -> Bool {
+        let normalizedRoot = normalizedRepositoryPath(repositoryRoot)
+        let normalizedWorkingDirectory = normalizedRepositoryPath(workingDirectory)
+        guard let normalizedRoot, let normalizedWorkingDirectory else { return false }
+        if normalizedWorkingDirectory == normalizedRoot {
+            return true
+        }
+        return normalizedWorkingDirectory.hasPrefix(normalizedRoot + "/")
+    }
+
     private static func sortSessions(
         _ sessions: [UnifiedCodingSession],
         sort: SessionExplorerSortOption

--- a/Dochi/Views/Sidebar/ExternalToolListView.swift
+++ b/Dochi/Views/Sidebar/ExternalToolListView.swift
@@ -786,7 +786,10 @@ struct ExternalToolListView: View {
     private func startableProfiles(for repositoryRoot: String) -> [ExternalToolProfile] {
         unlaunchedProfiles
             .filter { profile in
-                normalizedRepositoryPath(profile.workingDirectory) == repositoryRoot
+                SessionExplorerViewStateBuilder.repositoryContainsWorkingDirectory(
+                    repositoryRoot: repositoryRoot,
+                    workingDirectory: profile.workingDirectory
+                )
             }
             .sorted { lhs, rhs in
                 lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending

--- a/DochiTests/SessionExplorerViewModelTests.swift
+++ b/DochiTests/SessionExplorerViewModelTests.swift
@@ -191,6 +191,24 @@ final class SessionExplorerViewModelTests: XCTestCase {
         XCTAssertEqual(filtered.first?.nativeSessionId, "normalized")
     }
 
+    func testRepositoryContainsWorkingDirectoryMatchesNestedPath() {
+        let matches = SessionExplorerViewStateBuilder.repositoryContainsWorkingDirectory(
+            repositoryRoot: "/tmp/repo-a",
+            workingDirectory: "/tmp/repo-a/subdir"
+        )
+
+        XCTAssertTrue(matches)
+    }
+
+    func testRepositoryContainsWorkingDirectoryRejectsDifferentRepo() {
+        let matches = SessionExplorerViewStateBuilder.repositoryContainsWorkingDirectory(
+            repositoryRoot: "/tmp/repo-a",
+            workingDirectory: "/tmp/repo-b/subdir"
+        )
+
+        XCTAssertFalse(matches)
+    }
+
     func testApplyManualRepositoryBindingsOverridesUnassignedSession() {
         let session = makeSession(
             provider: "claude",


### PR DESCRIPTION
## Summary
- Session Explorer를 repo-first 구조로 재구성했습니다.
- `SessionExplorerViewStateBuilder`에 `RepositorySessionGroup`/`repositoryGroups`를 추가해 그룹핑/정렬 로직을 ViewModel 레벨로 이동했습니다.
- `ExternalToolListView`에서 flat unified list를 레포 그룹 UI로 전환하고, 각 레포 그룹에 quick actions를 추가했습니다.
  - 새 세션 시작(레포 경로와 일치하는 미시작 프로파일)
  - attach 가능한 세션 추천(orchestrator.select 기반)
  - unassigned 세션을 해당 레포로 매핑
- 세션 row에 title/summary, 업데이트 상대 시각, row quick actions를 추가했습니다.

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/SessionExplorerViewModelTests`
- 결과: 10 tests, 0 failures

## Linked Issues
- Closes #415
- Ref #413

## Spec Impact
- `spec/` 문서 변경 없음 (UI 탐색 흐름 개선, 기존 기능 회귀 없이 확장)
