### PR TITLE
feat: [K-3] session history explorer controls and index freshness

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -1517,20 +1517,25 @@ struct DochiApp: App {
         ])
     }
 
-    nonisolated private static func handleBridgeSessionHistoryReindex(
+    nonisolated static func handleBridgeSessionHistoryReindex(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
         let limit = max(10, min(2_000, params["limit"] as? Int ?? 500))
         let chunkCount = await externalToolManager.rebuildSessionHistoryIndex(limit: limit)
+        let status = await MainActor.run {
+            externalToolManager.sessionHistoryIndexStatus()
+        }
         return .ok([
             "status": "reindexed",
             "limit": limit,
             "chunk_count": chunkCount,
+            "indexed_at": status.lastIndexedAt.map { isoTimestamp($0) } ?? NSNull(),
+            "latest_chunk_end_at": status.latestChunkEndAt.map { isoTimestamp($0) } ?? NSNull(),
         ])
     }
 
-    nonisolated private static func handleBridgeSessionHistorySearch(
+    nonisolated static func handleBridgeSessionHistorySearch(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
@@ -1570,10 +1575,17 @@ struct DochiApp: App {
                 "tags": item.tags,
             ]
         }
+        let status = await MainActor.run {
+            externalToolManager.sessionHistoryIndexStatus()
+        }
 
         return .ok([
             "count": payload.count,
+            "limit": limit,
             "results": payload,
+            "chunk_count": status.chunkCount,
+            "indexed_at": status.lastIndexedAt.map { isoTimestamp($0) } ?? NSNull(),
+            "latest_chunk_end_at": status.latestChunkEndAt.map { isoTimestamp($0) } ?? NSNull(),
         ])
     }
 

--- a/Dochi/Models/ExternalToolModels.swift
+++ b/Dochi/Models/ExternalToolModels.swift
@@ -269,6 +269,12 @@ struct SessionHistorySearchResult: Identifiable, Sendable, Equatable {
     let tags: [String]
 }
 
+struct SessionHistoryIndexStatus: Sendable, Equatable {
+    let chunkCount: Int
+    let lastIndexedAt: Date?
+    let latestChunkEndAt: Date?
+}
+
 enum OrchestrationSessionSelectionAction: String, Codable, Sendable {
     case reuseT0Active = "reuse_t0_active"
     case attachT1 = "attach_t1"

--- a/Dochi/Services/ExternalToolSessionManager.swift
+++ b/Dochi/Services/ExternalToolSessionManager.swift
@@ -76,6 +76,7 @@ protocol ExternalToolSessionManagerProtocol: AnyObject, Sendable {
         observed: CodingSessionActivityState
     )
     func sessionManagementKPIReport() -> SessionManagementKPIReport
+    func sessionHistoryIndexStatus() -> SessionHistoryIndexStatus
     func rebuildSessionHistoryIndex(limit: Int) async -> Int
     func searchSessionHistory(query: SessionHistorySearchQuery) async -> [SessionHistorySearchResult]
 }
@@ -173,6 +174,14 @@ extension ExternalToolSessionManagerProtocol {
         )
     }
 
+    func sessionHistoryIndexStatus() -> SessionHistoryIndexStatus {
+        SessionHistoryIndexStatus(
+            chunkCount: 0,
+            lastIndexedAt: nil,
+            latestChunkEndAt: nil
+        )
+    }
+
     func rebuildSessionHistoryIndex(limit _: Int) async -> Int {
         0
     }
@@ -242,6 +251,7 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
     private var localDiscoveryCacheDate: Date?
     private var manualRepositoryBindings: [String: String] = [:]
     private var sessionHistoryChunks: [SessionHistoryChunk] = []
+    private var sessionHistoryIndexedAt: Date?
     private var sessionKPICounters = SessionManagementKPICounters()
 
     init(
@@ -403,6 +413,7 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
     private func loadSessionHistoryIndex() {
         guard let data = try? Data(contentsOf: sessionHistoryFile) else {
             sessionHistoryChunks = []
+            sessionHistoryIndexedAt = nil
             return
         }
 
@@ -410,9 +421,16 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         decoder.dateDecodingStrategy = .iso8601
         guard let decoded = try? decoder.decode([SessionHistoryChunk].self, from: data) else {
             sessionHistoryChunks = []
+            sessionHistoryIndexedAt = nil
             return
         }
         sessionHistoryChunks = decoded.sorted(by: { $0.endAt > $1.endAt })
+        if let attributes = try? FileManager.default.attributesOfItem(atPath: sessionHistoryFile.path),
+           let modifiedAt = attributes[.modificationDate] as? Date {
+            sessionHistoryIndexedAt = modifiedAt
+        } else {
+            sessionHistoryIndexedAt = nil
+        }
     }
 
     private func persistSessionHistoryIndex() {
@@ -422,6 +440,7 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         do {
             let data = try encoder.encode(sessionHistoryChunks)
             try data.write(to: sessionHistoryFile, options: .atomic)
+            sessionHistoryIndexedAt = Date()
         } catch {
             Log.app.error("Failed to persist session history index: \(error.localizedDescription)")
         }
@@ -1000,6 +1019,14 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
 
     func sessionManagementKPIReport() -> SessionManagementKPIReport {
         Self.buildSessionManagementKPIReport(from: sessionKPICounters, now: Date())
+    }
+
+    func sessionHistoryIndexStatus() -> SessionHistoryIndexStatus {
+        SessionHistoryIndexStatus(
+            chunkCount: sessionHistoryChunks.count,
+            lastIndexedAt: sessionHistoryIndexedAt,
+            latestChunkEndAt: sessionHistoryChunks.map(\.endAt).max()
+        )
     }
 
     func rebuildSessionHistoryIndex(limit: Int) async -> Int {

--- a/Dochi/Views/Sidebar/ExternalToolListView.swift
+++ b/Dochi/Views/Sidebar/ExternalToolListView.swift
@@ -1,5 +1,40 @@
 import SwiftUI
 
+private enum SessionHistoryTimeFilter: String, CaseIterable, Identifiable {
+    case day1 = "1d"
+    case day7 = "7d"
+    case day30 = "30d"
+    case all = "all"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .day1:
+            return "최근 1일"
+        case .day7:
+            return "최근 7일"
+        case .day30:
+            return "최근 30일"
+        case .all:
+            return "전체"
+        }
+    }
+
+    func sinceDate(now: Date = Date()) -> Date? {
+        switch self {
+        case .day1:
+            return now.addingTimeInterval(-24 * 60 * 60)
+        case .day7:
+            return now.addingTimeInterval(-7 * 24 * 60 * 60)
+        case .day30:
+            return now.addingTimeInterval(-30 * 24 * 60 * 60)
+        case .all:
+            return nil
+        }
+    }
+}
+
 struct ExternalToolListView: View {
     let manager: ExternalToolSessionManagerProtocol
     @Binding var selectedSessionId: UUID?
@@ -16,6 +51,19 @@ struct ExternalToolListView: View {
     @State private var mappingNotice: String?
     @State private var expandedRepositoryGroups: Set<String> = []
     @State private var didInitializeRepositoryExpansion = false
+    @State private var historyQueryText = ""
+    @State private var historyRepositoryFilter: String?
+    @State private var historyBranchFilter = ""
+    @State private var historyTimeFilter: SessionHistoryTimeFilter = .day30
+    @State private var historyLimit = 20
+    @State private var historyResults: [SessionHistorySearchResult] = []
+    @State private var historyIndexStatus = SessionHistoryIndexStatus(
+        chunkCount: 0,
+        lastIndexedAt: nil,
+        latestChunkEndAt: nil
+    )
+    @State private var isHistoryIndexing = false
+    @State private var isHistorySearching = false
     private static let relativeDateFormatter: RelativeDateTimeFormatter = {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
@@ -165,6 +213,7 @@ struct ExternalToolListView: View {
         )
         .task {
             await refreshUnifiedSessions()
+            refreshHistoryIndexStatus()
         }
     }
 
@@ -201,6 +250,7 @@ struct ExternalToolListView: View {
                 repoDashboardSection
                 sessionExplorerSection
                 unassignedQueueSection
+                sessionHistorySection
 
                 Divider()
                     .padding(.top, 10)
@@ -417,6 +467,117 @@ struct ExternalToolListView: View {
                 .padding(.vertical, 6)
             }
         }
+    }
+
+    @ViewBuilder
+    private var sessionHistorySection: some View {
+        sectionHeader("Session History")
+
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                TextField("히스토리 검색어", text: $historyQueryText)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 11))
+                Button("검색") {
+                    Task { await searchSessionHistoryFromUI() }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.mini)
+                .disabled(isHistorySearching)
+            }
+
+            HStack(spacing: 6) {
+                Menu("repo") {
+                    Button("전체") { historyRepositoryFilter = nil }
+                    ForEach(repositoryFilterOptions, id: \.self) { root in
+                        Button(root) { historyRepositoryFilter = root }
+                    }
+                }
+                TextField("branch(선택)", text: $historyBranchFilter)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 10))
+                Menu("기간") {
+                    ForEach(SessionHistoryTimeFilter.allCases) { filter in
+                        Button(filter.label) { historyTimeFilter = filter }
+                    }
+                }
+                Menu("limit") {
+                    Button("20") { historyLimit = 20 }
+                    Button("50") { historyLimit = 50 }
+                    Button("100") { historyLimit = 100 }
+                }
+            }
+            .font(.system(size: 10))
+
+            HStack(spacing: 8) {
+                Text("chunks \(historyIndexStatus.chunkCount)")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                Text("indexed \(relativeTimestamp(historyIndexStatus.lastIndexedAt))")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                if let latestChunkEndAt = historyIndexStatus.latestChunkEndAt {
+                    Text("latest \(relativeTimestamp(latestChunkEndAt))")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if isHistoryIndexing {
+                    ProgressView()
+                        .controlSize(.mini)
+                }
+                Button("재인덱싱") {
+                    Task { await rebuildSessionHistoryFromUI() }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+                .disabled(isHistoryIndexing)
+            }
+
+            if historyResults.isEmpty {
+                Text("검색 결과가 없습니다. 검색어를 입력해 히스토리를 조회하세요.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(historyResults.prefix(30)) { item in
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text("[\(item.provider)] \(item.sessionId)")
+                                .font(.system(size: 10, weight: .semibold))
+                                .lineLimit(1)
+                            if let branch = item.branch {
+                                Text(branch)
+                                    .font(.system(size: 9))
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                            Spacer()
+                            Text(String(format: "%.2f", item.score))
+                                .font(.system(size: 9))
+                                .foregroundStyle(.secondary)
+                        }
+                        Text(item.maskedSnippet)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                        HStack(spacing: 6) {
+                            Text(relativeTimestamp(item.endAt))
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                            Spacer()
+                            Button("세션 보기") {
+                                jumpToHistoryResult(item)
+                            }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 9, weight: .semibold))
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.bottom, 8)
     }
 
     @ViewBuilder
@@ -781,6 +942,56 @@ struct ExternalToolListView: View {
         case .none:
             mappingNotice = selection.reason
         }
+    }
+
+    @MainActor
+    private func rebuildSessionHistoryFromUI() async {
+        guard !isHistoryIndexing else { return }
+        isHistoryIndexing = true
+        let chunkCount = await manager.rebuildSessionHistoryIndex(limit: max(100, historyLimit * 20))
+        refreshHistoryIndexStatus()
+        isHistoryIndexing = false
+        mappingNotice = "세션 히스토리 인덱스를 재구축했습니다. (chunks: \(chunkCount))"
+    }
+
+    @MainActor
+    private func searchSessionHistoryFromUI() async {
+        guard !isHistorySearching else { return }
+        let queryText = historyQueryText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !queryText.isEmpty else {
+            mappingNotice = "히스토리 검색어를 입력해주세요."
+            return
+        }
+        isHistorySearching = true
+        let results = await manager.searchSessionHistory(
+            query: SessionHistorySearchQuery(
+                query: queryText,
+                repositoryRoot: historyRepositoryFilter,
+                branch: historyBranchFilter.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    ? nil
+                    : historyBranchFilter.trimmingCharacters(in: .whitespacesAndNewlines),
+                since: historyTimeFilter.sinceDate(),
+                until: nil,
+                limit: historyLimit
+            )
+        )
+        historyResults = results
+        refreshHistoryIndexStatus()
+        isHistorySearching = false
+    }
+
+    @MainActor
+    private func jumpToHistoryResult(_ result: SessionHistorySearchResult) {
+        historyQueryText = result.sessionId
+        searchText = result.sessionId
+        explorerFilter.repositoryRoot = result.repositoryRoot
+        explorerFilter.unassignedOnly = false
+        explorerFilter.activeOnly = false
+    }
+
+    @MainActor
+    private func refreshHistoryIndexStatus() {
+        historyIndexStatus = manager.sessionHistoryIndexStatus()
     }
 
     private func startableProfiles(for repositoryRoot: String) -> [ExternalToolProfile] {

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -973,6 +973,7 @@ final class MockExternalToolSessionManager: ExternalToolSessionManagerProtocol {
     var sessionHistoryMaskingRulesCallCount = 0
     var recordActivityClassificationFeedbackCallCount = 0
     var sessionManagementKPIReportCallCount = 0
+    var sessionHistoryIndexStatusCallCount = 0
     var rebuildSessionHistoryIndexCallCount = 0
     var searchSessionHistoryCallCount = 0
 
@@ -1005,6 +1006,11 @@ final class MockExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         counters: SessionManagementKPICounters()
     )
     var mockSessionHistoryResults: [SessionHistorySearchResult] = []
+    var mockSessionHistoryIndexStatus = SessionHistoryIndexStatus(
+        chunkCount: 0,
+        lastIndexedAt: nil,
+        latestChunkEndAt: nil
+    )
 
     func loadProfiles() {
         loadProfilesCallCount += 1
@@ -1212,6 +1218,11 @@ final class MockExternalToolSessionManager: ExternalToolSessionManagerProtocol {
     func sessionManagementKPIReport() -> SessionManagementKPIReport {
         sessionManagementKPIReportCallCount += 1
         return mockSessionManagementKPIReport
+    }
+
+    func sessionHistoryIndexStatus() -> SessionHistoryIndexStatus {
+        sessionHistoryIndexStatusCallCount += 1
+        return mockSessionHistoryIndexStatus
     }
 
     func rebuildSessionHistoryIndex(limit: Int) async -> Int {


### PR DESCRIPTION
## Summary\n- add Session History controls in External Tool sidebar (query/repo/branch/time/limit + reindex)\n- expose and surface index freshness metadata (chunk count, indexed_at, latest_chunk_end_at)\n- return session history index status in bridge reindex/search responses\n\n## Test\n- xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/SessionHistoryRAGTests -only-testing:DochiTests/DochiDevBridgeToolTests -only-testing:DochiTests/SessionExplorerViewModelTests\n\nCloses #416