### PR TITLE
feat: [K-5] classify Codex Desktop/CLI session metadata

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -1378,6 +1378,9 @@ struct DochiApp: App {
                 "summary": session.summary ?? NSNull(),
                 "title_source": session.titleSource ?? NSNull(),
                 "title_confidence": session.titleConfidence ?? NSNull(),
+                "originator": session.originator ?? NSNull(),
+                "session_source": session.sessionSource ?? NSNull(),
+                "client_kind": session.clientKind ?? NSNull(),
             ]
         }
         let unifiedSessions = await externalToolManager.listUnifiedCodingSessions(limit: 120)
@@ -1408,6 +1411,9 @@ struct DochiApp: App {
                 "summary": session.summary ?? NSNull(),
                 "title_source": session.titleSource ?? NSNull(),
                 "title_confidence": session.titleConfidence ?? NSNull(),
+                "originator": session.originator ?? NSNull(),
+                "session_source": session.sessionSource ?? NSNull(),
+                "client_kind": session.clientKind ?? NSNull(),
             ]
         }
         let unassignedCount = unifiedSessions.filter(\.isUnassigned).count
@@ -2134,6 +2140,9 @@ struct DochiApp: App {
                 "summary": selected.summary ?? NSNull(),
                 "title_source": selected.titleSource ?? NSNull(),
                 "title_confidence": selected.titleConfidence ?? NSNull(),
+                "originator": selected.originator ?? NSNull(),
+                "session_source": selected.sessionSource ?? NSNull(),
+                "client_kind": selected.clientKind ?? NSNull(),
             ] as [String: Any]
         } else {
             payload["selected_session"] = NSNull()

--- a/Dochi/Models/ExternalToolModels.swift
+++ b/Dochi/Models/ExternalToolModels.swift
@@ -29,6 +29,41 @@ struct DiscoveredCodingSession: Sendable, Equatable {
     let summary: String?
     let titleSource: String?
     let titleConfidence: Double?
+    let originator: String?
+    let sessionSource: String?
+    let clientKind: String?
+
+    init(
+        source: DiscoveredCodingSessionSource,
+        provider: String,
+        sessionId: String,
+        workingDirectory: String?,
+        path: String,
+        updatedAt: Date,
+        isActive: Bool,
+        title: String? = nil,
+        summary: String? = nil,
+        titleSource: String? = nil,
+        titleConfidence: Double? = nil,
+        originator: String? = nil,
+        sessionSource: String? = nil,
+        clientKind: String? = nil
+    ) {
+        self.source = source
+        self.provider = provider
+        self.sessionId = sessionId
+        self.workingDirectory = workingDirectory
+        self.path = path
+        self.updatedAt = updatedAt
+        self.isActive = isActive
+        self.title = title
+        self.summary = summary
+        self.titleSource = titleSource
+        self.titleConfidence = titleConfidence
+        self.originator = originator
+        self.sessionSource = sessionSource
+        self.clientKind = clientKind
+    }
 }
 
 enum ManagedGitRepositorySource: String, Codable, Sendable {
@@ -149,6 +184,9 @@ struct UnifiedCodingSession: Sendable, Equatable {
     let summary: String?
     let titleSource: String?
     let titleConfidence: Double?
+    let originator: String?
+    let sessionSource: String?
+    let clientKind: String?
     let activityScore: Int
     let activityState: CodingSessionActivityState
     let activitySignals: CodingSessionActivitySignals
@@ -171,6 +209,9 @@ struct UnifiedCodingSession: Sendable, Equatable {
         summary: String? = nil,
         titleSource: String? = nil,
         titleConfidence: Double? = nil,
+        originator: String? = nil,
+        sessionSource: String? = nil,
+        clientKind: String? = nil,
         activityScore: Int = 0,
         activityState: CodingSessionActivityState = .stale,
         activitySignals: CodingSessionActivitySignals = CodingSessionActivitySignals(
@@ -196,6 +237,9 @@ struct UnifiedCodingSession: Sendable, Equatable {
         self.summary = summary
         self.titleSource = titleSource
         self.titleConfidence = titleConfidence
+        self.originator = originator
+        self.sessionSource = sessionSource
+        self.clientKind = clientKind
         self.activityScore = activityScore
         self.activityState = activityState
         self.activitySignals = activitySignals

--- a/Dochi/Services/ExternalToolSessionManager.swift
+++ b/Dochi/Services/ExternalToolSessionManager.swift
@@ -947,7 +947,10 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                 title: session.lastTerminalTitle,
                 summary: nil,
                 titleSource: session.lastTerminalTitle == nil ? nil : "terminal_osc",
-                titleConfidence: session.lastTerminalTitle == nil ? nil : 0.95
+                titleConfidence: session.lastTerminalTitle == nil ? nil : 0.95,
+                originator: nil,
+                sessionSource: nil,
+                clientKind: nil
             )
         }
 
@@ -2089,6 +2092,9 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                 summary: runtime.summary,
                 titleSource: runtime.titleSource,
                 titleConfidence: runtime.titleConfidence,
+                originator: runtime.originator,
+                sessionSource: runtime.sessionSource,
+                clientKind: runtime.clientKind,
                 activityScore: activity.score,
                 activityState: activity.state,
                 activitySignals: activity.signals
@@ -2126,6 +2132,9 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                 summary: discovered.summary,
                 titleSource: discovered.titleSource,
                 titleConfidence: discovered.titleConfidence,
+                originator: discovered.originator,
+                sessionSource: discovered.sessionSource,
+                clientKind: discovered.clientKind,
                 activityScore: activity.score,
                 activityState: activity.state,
                 activitySignals: activity.signals
@@ -2298,6 +2307,9 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                 summary: session.summary,
                 titleSource: session.titleSource,
                 titleConfidence: session.titleConfidence,
+                originator: session.originator,
+                sessionSource: session.sessionSource,
+                clientKind: session.clientKind,
                 activityScore: session.activityScore,
                 activityState: session.activityState,
                 activitySignals: session.activitySignals
@@ -2672,6 +2684,9 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         let summary: String?
         let titleSource: String?
         let titleConfidence: Double?
+        let originator: String?
+        let sessionSource: String?
+        let clientKind: String?
 
         init(
             provider: String,
@@ -2691,7 +2706,10 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             title: String? = nil,
             summary: String? = nil,
             titleSource: String? = nil,
-            titleConfidence: Double? = nil
+            titleConfidence: Double? = nil,
+            originator: String? = nil,
+            sessionSource: String? = nil,
+            clientKind: String? = nil
         ) {
             self.provider = provider
             self.nativeSessionId = nativeSessionId
@@ -2711,6 +2729,9 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             self.summary = summary
             self.titleSource = titleSource
             self.titleConfidence = titleConfidence
+            self.originator = originator
+            self.sessionSource = sessionSource
+            self.clientKind = clientKind
         }
     }
 
@@ -3179,10 +3200,13 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                 path: candidate.url.path,
                 updatedAt: candidate.modifiedAt,
                 isActive: isActive,
-                title: nil,
-                summary: nil,
-                titleSource: nil,
-                titleConfidence: nil
+                title: meta?.title,
+                summary: meta?.summary,
+                titleSource: meta?.titleSource,
+                titleConfidence: meta?.titleConfidence,
+                originator: meta?.originator,
+                sessionSource: meta?.sessionSource,
+                clientKind: meta?.clientKind
             )
         }
     }
@@ -3234,7 +3258,10 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                             title: metadata.title,
                             summary: metadata.summary,
                             titleSource: metadata.titleSource,
-                            titleConfidence: metadata.titleConfidence
+                            titleConfidence: metadata.titleConfidence,
+                            originator: nil,
+                            sessionSource: nil,
+                            clientKind: nil
                         )
                     )
                 }
@@ -3284,7 +3311,10 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                     title: meta?.title,
                     summary: meta?.summary,
                     titleSource: meta?.titleSource,
-                    titleConfidence: meta?.titleConfidence
+                    titleConfidence: meta?.titleConfidence,
+                    originator: nil,
+                    sessionSource: nil,
+                    clientKind: nil
                 )
             )
         }
@@ -3323,7 +3353,19 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         return String(data: data, encoding: .utf8)
     }
 
-    nonisolated private static func parseCodexSessionMeta(fromFirstLine line: String?) -> (id: String, cwd: String?)? {
+    nonisolated private static func parseCodexSessionMeta(
+        fromFirstLine line: String?
+    ) -> (
+        id: String,
+        cwd: String?,
+        title: String?,
+        summary: String?,
+        titleSource: String?,
+        titleConfidence: Double?,
+        originator: String?,
+        sessionSource: String?,
+        clientKind: String?
+    )? {
         guard let line,
               let data = line.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -3335,7 +3377,43 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         }
 
         let cwd = payload["cwd"] as? String
-        return (id: id, cwd: cwd)
+        let originator = normalizedSessionText(payload["originator"], maxLength: 80)
+        let sessionSource = normalizedSessionText(payload["source"], maxLength: 40)
+        let clientKind = codexClientKind(originator: originator, sessionSource: sessionSource)
+        return (
+            id: id,
+            cwd: cwd,
+            title: nil,
+            summary: nil,
+            titleSource: nil,
+            titleConfidence: nil,
+            originator: originator,
+            sessionSource: sessionSource,
+            clientKind: clientKind
+        )
+    }
+
+    nonisolated private static func codexClientKind(
+        originator: String?,
+        sessionSource: String?
+    ) -> String? {
+        let normalizedOriginator = originator?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedSource = sessionSource?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if normalizedOriginator?.contains("desktop") == true ||
+            normalizedSource == "vscode" ||
+            normalizedSource == "desktop" {
+            return "desktop"
+        }
+        if normalizedOriginator?.contains("cli") == true ||
+            normalizedSource == "cli" ||
+            normalizedSource == "terminal" {
+            return "cli"
+        }
+        if normalizedOriginator != nil || normalizedSource != nil {
+            return "unknown"
+        }
+        return nil
     }
 
     nonisolated private static func parseClaudeSessionMeta(
@@ -3438,6 +3516,11 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             let mergedSource = runtime.titleSource ?? "\(sourceBase)_\(matched.reason)"
             let baseConfidence = matched.session.titleConfidence ?? 0.6
             let mergedConfidence = runtime.titleConfidence ?? min(0.98, baseConfidence * matched.confidenceScale)
+            let mergedOriginator = runtime.originator ?? matched.session.originator
+            let mergedSessionSource = runtime.sessionSource ?? matched.session.sessionSource
+            let mergedClientKind = runtime.clientKind
+                ?? matched.session.clientKind
+                ?? codexClientKind(originator: mergedOriginator, sessionSource: mergedSessionSource)
 
             return RuntimeSessionSnapshot(
                 provider: runtime.provider,
@@ -3457,7 +3540,10 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
                 title: mergedTitle,
                 summary: mergedSummary,
                 titleSource: mergedSource,
-                titleConfidence: mergedConfidence
+                titleConfidence: mergedConfidence,
+                originator: mergedOriginator,
+                sessionSource: mergedSessionSource,
+                clientKind: mergedClientKind
             )
         }
     }

--- a/Dochi/Views/Sidebar/ExternalToolListView.swift
+++ b/Dochi/Views/Sidebar/ExternalToolListView.swift
@@ -138,6 +138,9 @@ struct ExternalToolListView: View {
                 session.workingDirectory ?? "",
                 session.title ?? "",
                 session.summary ?? "",
+                session.originator ?? "",
+                session.sessionSource ?? "",
+                session.clientKind ?? "",
             ].joined(separator: " ").lowercased()
             return haystack.contains(query)
         }
@@ -861,6 +864,13 @@ struct ExternalToolListView: View {
                         .lineLimit(1)
                 }
 
+                if let clientDescriptor = sessionClientDescriptor(session) {
+                    Text(clientDescriptor)
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
                 Text("state=\(session.activityState.rawValue), score=\(session.activityScore), repo=\(session.repositoryRoot ?? "(unassigned)")")
                     .font(.system(size: 9))
                     .foregroundStyle(.secondary)
@@ -1357,6 +1367,33 @@ struct ExternalToolListView: View {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty else { return nil }
         return String(normalized.prefix(100))
+    }
+
+    private func sessionClientDescriptor(_ session: UnifiedCodingSession) -> String? {
+        var parts: [String] = []
+        if session.provider.lowercased() == "codex" {
+            switch session.clientKind {
+            case "desktop":
+                parts.append("Codex Desktop")
+            case "cli":
+                parts.append("Codex CLI")
+            case "unknown":
+                parts.append("Codex")
+            default:
+                if let originator = session.originator {
+                    parts.append(originator)
+                }
+            }
+        } else if let originator = session.originator {
+            parts.append(originator)
+        }
+
+        if let sessionSource = session.sessionSource, !sessionSource.isEmpty {
+            parts.append("src=\(sessionSource)")
+        }
+
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: " · ")
     }
 
     private func relativeTimestamp(_ date: Date?) -> String {

--- a/DochiTests/GitRepositoryInsightScorerTests.swift
+++ b/DochiTests/GitRepositoryInsightScorerTests.swift
@@ -700,6 +700,56 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
         }
     }
 
+    func testDiscoverLocalCodingSessionsParsesCodexClientMetadata() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dochi-codex-meta-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let codexRoot = tempRoot.appendingPathComponent("codex", isDirectory: true)
+        let claudeRoot = tempRoot.appendingPathComponent("claude", isDirectory: true)
+        let desktopFile = codexRoot
+            .appendingPathComponent("2026/02/21", isDirectory: true)
+            .appendingPathComponent("rollout-desktop.jsonl")
+        let cliFile = codexRoot
+            .appendingPathComponent("2026/02/21", isDirectory: true)
+            .appendingPathComponent("rollout-cli.jsonl")
+        try FileManager.default.createDirectory(
+            at: desktopFile.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let desktopMeta = """
+        {"timestamp":"2026-02-21T12:00:00Z","type":"session_meta","payload":{"id":"codex-desktop-1","cwd":"/Users/hckim/repo/dochi","originator":"Codex Desktop","source":"vscode"}}
+        {"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}
+        """
+        try desktopMeta.data(using: .utf8)?.write(to: desktopFile, options: .atomic)
+
+        let cliMeta = """
+        {"timestamp":"2026-02-21T12:10:00Z","type":"session_meta","payload":{"id":"codex-cli-1","cwd":"/Users/hckim/repo/dochi","originator":"Codex CLI","source":"cli"}}
+        {"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}
+        """
+        try cliMeta.data(using: .utf8)?.write(to: cliFile, options: .atomic)
+
+        let discovered = ExternalToolSessionManager.discoverLocalCodingSessions(
+            codexSessionsRoot: codexRoot,
+            claudeProjectsRoot: claudeRoot,
+            limit: 20,
+            now: Date(timeIntervalSince1970: 1_771_636_000)
+        )
+
+        let desktop = try XCTUnwrap(discovered.first(where: { $0.sessionId == "codex-desktop-1" }))
+        XCTAssertEqual(desktop.provider, "codex")
+        XCTAssertEqual(desktop.originator, "Codex Desktop")
+        XCTAssertEqual(desktop.sessionSource, "vscode")
+        XCTAssertEqual(desktop.clientKind, "desktop")
+
+        let cli = try XCTUnwrap(discovered.first(where: { $0.sessionId == "codex-cli-1" }))
+        XCTAssertEqual(cli.provider, "codex")
+        XCTAssertEqual(cli.originator, "Codex CLI")
+        XCTAssertEqual(cli.sessionSource, "cli")
+        XCTAssertEqual(cli.clientKind, "cli")
+    }
+
     func testEnrichRuntimeSessionMetadataMatchesByWorkingDirectory() {
         let now = Date(timeIntervalSince1970: 1_771_636_000)
         let runtime = ExternalToolSessionManager.RuntimeSessionSnapshot(
@@ -729,7 +779,10 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
             title: "Dochi 브리지 세션 상태 정비",
             summary: "bridge.status payload 개선",
             titleSource: "claude_sessions_index",
-            titleConfidence: 0.9
+            titleConfidence: 0.9,
+            originator: "Codex Desktop",
+            sessionSource: "vscode",
+            clientKind: "desktop"
         )
 
         let enriched = ExternalToolSessionManager.enrichRuntimeSessionMetadata(
@@ -747,6 +800,9 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
         if let confidence = item.titleConfidence {
             XCTAssertEqual(confidence, 0.81, accuracy: 0.0001)
         }
+        XCTAssertEqual(item.originator, "Codex Desktop")
+        XCTAssertEqual(item.sessionSource, "vscode")
+        XCTAssertEqual(item.clientKind, "desktop")
     }
 
     func testExtractLatestTerminalTitleParsesOscSequences() {


### PR DESCRIPTION
## Summary
- parse `originator` / `source` from Codex `session_meta` payload and normalize `clientKind` (`desktop` / `cli` / `unknown`)
- propagate client metadata through discovered -> runtime enrich -> unified session merge
- expose metadata in bridge payload and surface it in session explorer search/row descriptors
- add tests for Codex metadata parsing and runtime metadata merge propagation

## Linked Issue
- Closes #424

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/GitRepositoryInsightScorerTests -only-testing:DochiTests/OrchestratorSessionSelectorTests -only-testing:DochiTests/SessionExplorerViewModelTests`

## Spec Impact
- None
