### PR TITLE
feat: [K-5] provider source taxonomy normalization + client-kind unknown KPI

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -1611,6 +1611,7 @@ struct DochiApp: App {
                 "activity_classification_accuracy": report.activityClassificationAccuracy ?? NSNull(),
                 "session_selection_failure_rate": report.sessionSelectionFailureRate,
                 "history_search_hit_rate": report.historySearchHitRate,
+                "client_kind_unknown_rate": report.clientKindUnknownRate ?? NSNull(),
             ] as [String: Any],
             "counters": [
                 "repository_assigned_count": report.counters.repositoryAssignedCount,
@@ -1624,6 +1625,9 @@ struct DochiApp: App {
                 "activity_feedback_sample_count": report.counters.activityFeedbackSampleCount,
                 "activity_feedback_matched_count": report.counters.activityFeedbackMatchedCount,
                 "activity_state_distribution": report.counters.activityStateDistribution,
+                "client_kind_sample_count": report.counters.clientKindSampleCount,
+                "client_kind_unknown_count": report.counters.clientKindUnknownCount,
+                "client_kind_distribution": report.counters.clientKindDistribution,
             ] as [String: Any],
             "summary": formatSessionManagementKPISummary(report),
         ])
@@ -2159,6 +2163,12 @@ struct DochiApp: App {
         } else {
             activityAccuracy = "n/a"
         }
+        let clientKindUnknownRate: String
+        if let unknownRate = report.clientKindUnknownRate {
+            clientKindUnknownRate = percentageString(unknownRate)
+        } else {
+            clientKindUnknownRate = "n/a"
+        }
         let lines = [
             "session_management_kpi",
             "generated_at=\(isoTimestamp(report.generatedAt))",
@@ -2168,6 +2178,8 @@ struct DochiApp: App {
             "selection_failure_rate=\(percentageString(report.sessionSelectionFailureRate)) (\(report.counters.selectionFailureCount)/\(report.counters.selectionAttemptCount))",
             "history_search_hit_rate=\(percentageString(report.historySearchHitRate)) (\(report.counters.historySearchHitCount)/\(report.counters.historySearchQueryCount))",
             "activity_state_distribution=\(report.counters.activityStateDistribution)",
+            "client_kind_unknown_rate=\(clientKindUnknownRate) (\(report.counters.clientKindUnknownCount)/\(report.counters.clientKindSampleCount))",
+            "client_kind_distribution=\(report.counters.clientKindDistribution)",
         ]
         return lines.joined(separator: "\n")
     }

--- a/Dochi/Models/ExternalToolModels.swift
+++ b/Dochi/Models/ExternalToolModels.swift
@@ -404,6 +404,9 @@ struct SessionManagementKPICounters: Sendable, Equatable {
     var activityFeedbackSampleCount: Int = 0
     var activityFeedbackMatchedCount: Int = 0
     var activityStateDistribution: [String: Int] = [:]
+    var clientKindSampleCount: Int = 0
+    var clientKindUnknownCount: Int = 0
+    var clientKindDistribution: [String: Int] = [:]
 }
 
 struct SessionManagementKPIReport: Sendable, Equatable {
@@ -413,7 +416,28 @@ struct SessionManagementKPIReport: Sendable, Equatable {
     let activityClassificationAccuracy: Double?
     let sessionSelectionFailureRate: Double
     let historySearchHitRate: Double
+    let clientKindUnknownRate: Double?
     let counters: SessionManagementKPICounters
+
+    init(
+        generatedAt: Date,
+        repositoryAssignmentSuccessRate: Double,
+        dedupCorrectionRate: Double,
+        activityClassificationAccuracy: Double?,
+        sessionSelectionFailureRate: Double,
+        historySearchHitRate: Double,
+        clientKindUnknownRate: Double? = nil,
+        counters: SessionManagementKPICounters
+    ) {
+        self.generatedAt = generatedAt
+        self.repositoryAssignmentSuccessRate = repositoryAssignmentSuccessRate
+        self.dedupCorrectionRate = dedupCorrectionRate
+        self.activityClassificationAccuracy = activityClassificationAccuracy
+        self.sessionSelectionFailureRate = sessionSelectionFailureRate
+        self.historySearchHitRate = historySearchHitRate
+        self.clientKindUnknownRate = clientKindUnknownRate
+        self.counters = counters
+    }
 }
 
 enum OrchestrationRunState: String, Codable, Sendable {

--- a/Dochi/Services/ExternalToolSessionManager.swift
+++ b/Dochi/Services/ExternalToolSessionManager.swift
@@ -1194,6 +1194,23 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             distribution[session.activityState.rawValue, default: 0] += 1
         }
         sessionKPICounters.activityStateDistribution = distribution
+
+        let clientKindSampleCount = sessions.filter {
+            Self.hasClientMetadata(originator: $0.originator, sessionSource: $0.sessionSource)
+        }.count
+        let clientKindUnknownCount = sessions.filter {
+            Self.hasClientMetadata(originator: $0.originator, sessionSource: $0.sessionSource) &&
+                $0.clientKind == "unknown"
+        }.count
+        sessionKPICounters.clientKindSampleCount = min(Self.kpiCounterCap, clientKindSampleCount)
+        sessionKPICounters.clientKindUnknownCount = min(Self.kpiCounterCap, clientKindUnknownCount)
+
+        var clientKindDistribution: [String: Int] = [:]
+        for session in sessions {
+            let kind = session.clientKind ?? "unset"
+            clientKindDistribution[kind, default: 0] += 1
+        }
+        sessionKPICounters.clientKindDistribution = clientKindDistribution
     }
 
     private func incrementKPICounter(
@@ -1239,6 +1256,12 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         } else {
             activityAccuracy = nil
         }
+        let clientKindUnknownRate: Double?
+        if counters.clientKindSampleCount > 0 {
+            clientKindUnknownRate = ratio(counters.clientKindUnknownCount, counters.clientKindSampleCount)
+        } else {
+            clientKindUnknownRate = nil
+        }
 
         return SessionManagementKPIReport(
             generatedAt: now,
@@ -1247,6 +1270,7 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             activityClassificationAccuracy: activityAccuracy,
             sessionSelectionFailureRate: selectionFailureRate,
             historySearchHitRate: searchHitRate,
+            clientKindUnknownRate: clientKindUnknownRate,
             counters: counters
         )
     }
@@ -1254,6 +1278,21 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
     nonisolated private static func ratio(_ numerator: Int, _ denominator: Int) -> Double {
         guard denominator > 0 else { return 0 }
         return Double(numerator) / Double(denominator)
+    }
+
+    nonisolated private static func hasClientMetadata(
+        originator: String?,
+        sessionSource: String?
+    ) -> Bool {
+        if let originator {
+            let trimmedOriginator = originator.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedOriginator.isEmpty { return true }
+        }
+        if let sessionSource {
+            let trimmedSource = sessionSource.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedSource.isEmpty { return true }
+        }
+        return false
     }
 
     nonisolated static func evaluateOrchestrationExecutionGuard(
@@ -3353,6 +3392,68 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         return String(data: data, encoding: .utf8)
     }
 
+    private struct SessionClientTaxonomy {
+        let desktopSourceAliases: Set<String>
+        let cliSourceAliases: Set<String>
+        let desktopOriginatorKeywords: Set<String>
+        let cliOriginatorKeywords: Set<String>
+    }
+
+    // Keep provider-specific source normalization in one place so new source values
+    // can be added without changing parser/merge flow logic.
+    nonisolated private static let providerClientTaxonomy: [String: SessionClientTaxonomy] = [
+        "codex": SessionClientTaxonomy(
+            desktopSourceAliases: [
+                "desktop",
+                "vscode",
+                "vscodeinsiders",
+                "cursor",
+                "cursorapp",
+                "windsurf",
+                "zed",
+                "jetbrains",
+                "intellij",
+                "pycharm",
+                "xcode",
+            ],
+            cliSourceAliases: [
+                "cli",
+                "terminal",
+                "shell",
+                "tty",
+                "iterm",
+                "iterm2",
+                "tmux",
+                "zsh",
+                "bash",
+                "fish",
+                "pwsh",
+                "powershell",
+                "cmd",
+            ],
+            desktopOriginatorKeywords: [
+                "desktop",
+                "vscode",
+                "cursor",
+                "windsurf",
+                "zed",
+                "jetbrains",
+            ],
+            cliOriginatorKeywords: [
+                "cli",
+                "terminal",
+                "shell",
+                "tty",
+                "iterm",
+                "tmux",
+                "zsh",
+                "bash",
+                "fish",
+                "pwsh",
+            ]
+        ),
+    ]
+
     nonisolated private static func parseCodexSessionMeta(
         fromFirstLine line: String?
     ) -> (
@@ -3379,7 +3480,11 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         let cwd = payload["cwd"] as? String
         let originator = normalizedSessionText(payload["originator"], maxLength: 80)
         let sessionSource = normalizedSessionText(payload["source"], maxLength: 40)
-        let clientKind = codexClientKind(originator: originator, sessionSource: sessionSource)
+        let clientKind = classifySessionClientKind(
+            provider: "codex",
+            originator: originator,
+            sessionSource: sessionSource
+        )
         return (
             id: id,
             cwd: cwd,
@@ -3393,27 +3498,66 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
         )
     }
 
-    nonisolated private static func codexClientKind(
+    nonisolated private static func classifySessionClientKind(
+        provider: String,
         originator: String?,
         sessionSource: String?
     ) -> String? {
-        let normalizedOriginator = originator?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let normalizedSource = sessionSource?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let providerKey = provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let taxonomy = providerClientTaxonomy[providerKey]
+        let normalizedOriginator = normalizedSessionTaxonomyKey(originator)
+        let normalizedSource = normalizedSessionTaxonomyKey(sessionSource)
 
-        if normalizedOriginator?.contains("desktop") == true ||
-            normalizedSource == "vscode" ||
-            normalizedSource == "desktop" {
-            return "desktop"
+        if let taxonomy {
+            if let normalizedSource {
+                if taxonomy.desktopSourceAliases.contains(normalizedSource) {
+                    return "desktop"
+                }
+                if taxonomy.cliSourceAliases.contains(normalizedSource) {
+                    return "cli"
+                }
+            }
+
+            if let normalizedOriginator {
+                if containsTaxonomyKeyword(
+                    in: normalizedOriginator,
+                    keywords: taxonomy.desktopOriginatorKeywords
+                ) {
+                    return "desktop"
+                }
+                if containsTaxonomyKeyword(
+                    in: normalizedOriginator,
+                    keywords: taxonomy.cliOriginatorKeywords
+                ) {
+                    return "cli"
+                }
+            }
         }
-        if normalizedOriginator?.contains("cli") == true ||
-            normalizedSource == "cli" ||
-            normalizedSource == "terminal" {
-            return "cli"
-        }
+
         if normalizedOriginator != nil || normalizedSource != nil {
             return "unknown"
         }
         return nil
+    }
+
+    nonisolated private static func normalizedSessionTaxonomyKey(_ rawValue: String?) -> String? {
+        guard let rawValue else { return nil }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let lowercased = trimmed.lowercased()
+        let filteredScalars = lowercased.unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) }
+        guard !filteredScalars.isEmpty else { return nil }
+        return String(String.UnicodeScalarView(filteredScalars))
+    }
+
+    nonisolated private static func containsTaxonomyKeyword(
+        in normalizedValue: String,
+        keywords: Set<String>
+    ) -> Bool {
+        for keyword in keywords where normalizedValue.contains(keyword) {
+            return true
+        }
+        return false
     }
 
     nonisolated private static func parseClaudeSessionMeta(
@@ -3520,7 +3664,11 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             let mergedSessionSource = runtime.sessionSource ?? matched.session.sessionSource
             let mergedClientKind = runtime.clientKind
                 ?? matched.session.clientKind
-                ?? codexClientKind(originator: mergedOriginator, sessionSource: mergedSessionSource)
+                ?? classifySessionClientKind(
+                    provider: runtime.provider,
+                    originator: mergedOriginator,
+                    sessionSource: mergedSessionSource
+                )
 
             return RuntimeSessionSnapshot(
                 provider: runtime.provider,

--- a/DochiTests/GitRepositoryInsightScorerTests.swift
+++ b/DochiTests/GitRepositoryInsightScorerTests.swift
@@ -750,6 +750,92 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
         XCTAssertEqual(cli.clientKind, "cli")
     }
 
+    func testDiscoverLocalCodingSessionsNormalizesCodexSourceTaxonomy() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dochi-codex-taxonomy-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let codexRoot = tempRoot.appendingPathComponent("codex", isDirectory: true)
+        let claudeRoot = tempRoot.appendingPathComponent("claude", isDirectory: true)
+        let dayDirectory = codexRoot.appendingPathComponent("2026/02/21", isDirectory: true)
+        try FileManager.default.createDirectory(at: dayDirectory, withIntermediateDirectories: true)
+
+        func writeSessionMeta(
+            fileName: String,
+            sessionId: String,
+            originator: String?,
+            source: String?
+        ) throws {
+            var payload: [String: Any] = [
+                "id": sessionId,
+                "cwd": "/Users/hckim/repo/dochi",
+            ]
+            if let originator {
+                payload["originator"] = originator
+            }
+            if let source {
+                payload["source"] = source
+            }
+            let event: [String: Any] = [
+                "timestamp": "2026-02-21T12:00:00Z",
+                "type": "session_meta",
+                "payload": payload,
+            ]
+            let eventData = try JSONSerialization.data(withJSONObject: event, options: [])
+            let eventLine = String(data: eventData, encoding: .utf8) ?? "{}"
+            let content = """
+            \(eventLine)
+            {"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"ping"}]}}
+            """
+            let fileURL = dayDirectory.appendingPathComponent(fileName)
+            try content.data(using: .utf8)?.write(to: fileURL, options: .atomic)
+        }
+
+        try writeSessionMeta(
+            fileName: "desktop-vscode.jsonl",
+            sessionId: "desktop-vscode",
+            originator: "Codex Desktop",
+            source: "VS Code"
+        )
+        try writeSessionMeta(
+            fileName: "desktop-cursor.jsonl",
+            sessionId: "desktop-cursor",
+            originator: "Codex Desktop",
+            source: "cursor-app"
+        )
+        try writeSessionMeta(
+            fileName: "cli-iterm.jsonl",
+            sessionId: "cli-iterm",
+            originator: "Codex CLI",
+            source: "iTerm2"
+        )
+        try writeSessionMeta(
+            fileName: "cli-originator.jsonl",
+            sessionId: "cli-originator",
+            originator: "Codex CLI Terminal",
+            source: nil
+        )
+        try writeSessionMeta(
+            fileName: "unknown-source.jsonl",
+            sessionId: "unknown-source",
+            originator: "Codex Agent",
+            source: "mystery-ui"
+        )
+
+        let discovered = ExternalToolSessionManager.discoverLocalCodingSessions(
+            codexSessionsRoot: codexRoot,
+            claudeProjectsRoot: claudeRoot,
+            limit: 50,
+            now: Date(timeIntervalSince1970: 1_771_636_000)
+        )
+
+        XCTAssertEqual(discovered.first(where: { $0.sessionId == "desktop-vscode" })?.clientKind, "desktop")
+        XCTAssertEqual(discovered.first(where: { $0.sessionId == "desktop-cursor" })?.clientKind, "desktop")
+        XCTAssertEqual(discovered.first(where: { $0.sessionId == "cli-iterm" })?.clientKind, "cli")
+        XCTAssertEqual(discovered.first(where: { $0.sessionId == "cli-originator" })?.clientKind, "cli")
+        XCTAssertEqual(discovered.first(where: { $0.sessionId == "unknown-source" })?.clientKind, "unknown")
+    }
+
     func testEnrichRuntimeSessionMetadataMatchesByWorkingDirectory() {
         let now = Date(timeIntervalSince1970: 1_771_636_000)
         let runtime = ExternalToolSessionManager.RuntimeSessionSnapshot(

--- a/DochiTests/OrchestratorSessionSelectorTests.swift
+++ b/DochiTests/OrchestratorSessionSelectorTests.swift
@@ -332,6 +332,7 @@ final class DochiAppOrchestratorBridgeFlowTests: XCTestCase {
             activityClassificationAccuracy: 0.5,
             sessionSelectionFailureRate: 0.25,
             historySearchHitRate: 0.6,
+            clientKindUnknownRate: 0.25,
             counters: SessionManagementKPICounters(
                 repositoryAssignedCount: 3,
                 repositoryTotalCount: 4,
@@ -343,7 +344,10 @@ final class DochiAppOrchestratorBridgeFlowTests: XCTestCase {
                 historySearchHitCount: 3,
                 activityFeedbackSampleCount: 4,
                 activityFeedbackMatchedCount: 2,
-                activityStateDistribution: ["active": 2]
+                activityStateDistribution: ["active": 2],
+                clientKindSampleCount: 4,
+                clientKindUnknownCount: 1,
+                clientKindDistribution: ["desktop": 1, "cli": 2, "unknown": 1]
             )
         )
 
@@ -354,6 +358,7 @@ final class DochiAppOrchestratorBridgeFlowTests: XCTestCase {
         XCTAssertEqual(metrics["repository_assignment_success_rate"] as? Double, 0.75)
         XCTAssertEqual(metrics["session_selection_failure_rate"] as? Double, 0.25)
         XCTAssertEqual(metrics["history_search_hit_rate"] as? Double, 0.6)
+        XCTAssertEqual(metrics["client_kind_unknown_rate"] as? Double, 0.25)
 
         let summary = result.result["summary"] as? String
         XCTAssertTrue(summary?.contains("selection_failure_rate") == true)

--- a/DochiTests/SessionManagementKPITests.swift
+++ b/DochiTests/SessionManagementKPITests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class SessionManagementKPITests: XCTestCase {
 
-    func testBuildSessionManagementKPIReportCalculatesAllFiveMetrics() {
+    func testBuildSessionManagementKPIReportCalculatesAllMetricsIncludingClientKindUnknownRate() {
         let counters = SessionManagementKPICounters(
             repositoryAssignedCount: 9,
             repositoryTotalCount: 12,
@@ -15,7 +15,10 @@ final class SessionManagementKPITests: XCTestCase {
             historySearchHitCount: 7,
             activityFeedbackSampleCount: 6,
             activityFeedbackMatchedCount: 5,
-            activityStateDistribution: ["active": 4, "idle": 3, "stale": 2, "dead": 1]
+            activityStateDistribution: ["active": 4, "idle": 3, "stale": 2, "dead": 1],
+            clientKindSampleCount: 5,
+            clientKindUnknownCount: 2,
+            clientKindDistribution: ["desktop": 2, "cli": 1, "unknown": 2]
         )
 
         let now = Date(timeIntervalSince1970: 1_700_000_000)
@@ -28,7 +31,9 @@ final class SessionManagementKPITests: XCTestCase {
         XCTAssertEqual(report.activityClassificationAccuracy ?? 0, 5.0 / 6.0, accuracy: 0.0001)
         XCTAssertEqual(report.sessionSelectionFailureRate, 0.25, accuracy: 0.0001)
         XCTAssertEqual(report.historySearchHitRate, 0.7, accuracy: 0.0001)
+        XCTAssertEqual(report.clientKindUnknownRate ?? 0, 0.4, accuracy: 0.0001)
         XCTAssertEqual(report.counters.activityStateDistribution["active"], 4)
+        XCTAssertEqual(report.counters.clientKindDistribution["unknown"], 2)
     }
 
     func testBuildSessionManagementKPIReportAllowsNilActivityAccuracyWithoutFeedback() {
@@ -43,12 +48,16 @@ final class SessionManagementKPITests: XCTestCase {
             historySearchHitCount: 0,
             activityFeedbackSampleCount: 0,
             activityFeedbackMatchedCount: 0,
-            activityStateDistribution: [:]
+            activityStateDistribution: [:],
+            clientKindSampleCount: 0,
+            clientKindUnknownCount: 0,
+            clientKindDistribution: [:]
         )
 
         let report = ExternalToolSessionManager.buildSessionManagementKPIReport(from: counters)
 
         XCTAssertNil(report.activityClassificationAccuracy)
+        XCTAssertNil(report.clientKindUnknownRate)
         XCTAssertEqual(report.repositoryAssignmentSuccessRate, 0)
         XCTAssertEqual(report.dedupCorrectionRate, 0)
         XCTAssertEqual(report.sessionSelectionFailureRate, 0)


### PR DESCRIPTION
## Summary
- replace hard-coded Codex client classification with provider taxonomy table (`source/originator -> clientKind`) to make source expansion data-driven
- keep parser/runtime-merge flow unchanged while routing classification through the shared taxonomy helper
- add KPI counters and metric for `client_kind_unknown_rate` to track taxonomy coverage drift
- expose new KPI fields in bridge metrics payload and summary
- add regression tests for source normalization variants (`VS Code`, `cursor-app`, `iTerm2`, originator-only, unknown source)

## Linked Issue
- Closes #426

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/GitRepositoryInsightScorerTests -only-testing:DochiTests/OrchestratorSessionSelectorTests -only-testing:DochiTests/SessionManagementKPITests`

## Spec Impact
- None
