### PR TITLE
fix: Claude Code CLI process detection for node-wrapper launches

### DIFF
--- a/Dochi/Services/ExternalToolSessionManager.swift
+++ b/Dochi/Services/ExternalToolSessionManager.swift
@@ -2626,7 +2626,9 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
             return nil
         }
 
-        let tokens = trimmed.split(whereSeparator: \.isWhitespace).map(String.init)
+        let tokens = trimmed.split(whereSeparator: \.isWhitespace).map { raw in
+            raw.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+        }
         guard !tokens.isEmpty else { return nil }
         let normalizedTokens = tokens.map { token in
             URL(fileURLWithPath: token).lastPathComponent.lowercased()
@@ -2646,6 +2648,13 @@ final class ExternalToolSessionManager: ExternalToolSessionManagerProtocol {
            normalizedTokens.indices.contains(moduleIndex + 1),
            normalizedTokens[moduleIndex + 1] == "aider" {
             return "aider"
+        }
+
+        // Claude Code is often launched via node wrappers where the executable is `node`
+        // and only module path reveals the provider.
+        if lower.contains("@anthropic-ai/claude-code") ||
+            lower.contains("/claude-code/") {
+            return "claude"
         }
         return nil
     }

--- a/DochiTests/GitRepositoryInsightScorerTests.swift
+++ b/DochiTests/GitRepositoryInsightScorerTests.swift
@@ -562,12 +562,29 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
             ExternalToolSessionManager.processProvider(fromCommandLine: "/usr/local/bin/claude --continue"),
             "claude"
         )
+        XCTAssertEqual(
+            ExternalToolSessionManager.processProvider(
+                fromCommandLine: "node /Users/me/.nvm/versions/node/v20.10.0/lib/node_modules/@anthropic-ai/claude-code/dist/cli.js --resume"
+            ),
+            "claude"
+        )
+        XCTAssertEqual(
+            ExternalToolSessionManager.processProvider(
+                fromCommandLine: "bun '/tmp/work/node_modules/@anthropic-ai/claude-code/dist/cli.mjs' --print"
+            ),
+            "claude"
+        )
         XCTAssertNil(
             ExternalToolSessionManager.processProvider(fromCommandLine: "/Applications/Codex.app/Contents/MacOS/Codex")
         )
         XCTAssertNil(
             ExternalToolSessionManager.processProvider(
                 fromCommandLine: "/Applications/Codex.app/Contents/Frameworks/Codex Helper.app/Contents/MacOS/Codex Helper --type=gpu-process"
+            )
+        )
+        XCTAssertNil(
+            ExternalToolSessionManager.processProvider(
+                fromCommandLine: "/bin/zsh -c source /Users/me/.claude/shell-snapshots/snapshot.sh && tail -f /private/tmp/claude-501/task.output"
             )
         )
         XCTAssertNil(


### PR DESCRIPTION
## Summary
- broaden `processProvider` heuristics for Claude Code to detect wrapper launch patterns (`node .../@anthropic-ai/claude-code/...`)
- normalize token parsing by trimming shell quote characters before basename matching
- keep explicit exclusions for Claude/Codex desktop app helper processes
- add regression tests for wrapper launch detection and `.claude` shell snapshot false-positive guard

## Verification
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/GitRepositoryInsightScorerTests`
- runtime probe: `dochi --mode app --json dev bridge status` shows Claude process sessions in unified list
