### PR TITLE
feat: [K-431] persist heartbeat change journal

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -114,6 +114,7 @@ struct DochiApp: App {
     private let interestDiscoveryService: InterestDiscoveryService
     private let externalToolManager: ExternalToolSessionManager
     private let telegramProactiveRelay: TelegramProactiveRelay
+    private let heartbeatChangeJournalService: HeartbeatChangeJournalService
     private let deviceHeartbeatService: DeviceHeartbeatService
     private let controlPlaneService: LocalControlPlaneService
     private let controlPlaneTokenManager: ControlPlaneTokenManager
@@ -175,6 +176,8 @@ struct DochiApp: App {
         self.usageStore = usageStore
         let toolContextStore = ToolContextStore(baseURL: appSupportURL)
         self.toolContextStore = toolContextStore
+        let heartbeatChangeJournalService = HeartbeatChangeJournalService(baseURL: appSupportURL)
+        self.heartbeatChangeJournalService = heartbeatChangeJournalService
 
         // Plugin Manager (J-4)
         let pluginManager = PluginManager()
@@ -299,6 +302,7 @@ struct DochiApp: App {
 
         heartbeatService.configure(contextService: contextService, sessionContext: sessionContext)
         heartbeatService.setNotificationManager(notificationManager)
+        heartbeatService.setChangeJournalService(heartbeatChangeJournalService)
         heartbeatService.setProactiveHandler { [weak viewModel] message in
             guard let viewModel else { return }
             Log.app.info("Heartbeat proactive message: \(message)")

--- a/Dochi/Models/HeartbeatChangeModels.swift
+++ b/Dochi/Models/HeartbeatChangeModels.swift
@@ -62,3 +62,22 @@ struct HeartbeatChangeEvent: Identifiable, Codable, Equatable, Sendable {
         "\(source.rawValue)|\(eventType.rawValue)|\(targetId)"
     }
 }
+
+struct ChangeJournalEntry: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    let event: HeartbeatChangeEvent
+    let recordedAt: Date
+    let dedupeKey: String
+
+    init(
+        id: UUID = UUID(),
+        event: HeartbeatChangeEvent,
+        recordedAt: Date = Date(),
+        dedupeKey: String? = nil
+    ) {
+        self.id = id
+        self.event = event
+        self.recordedAt = recordedAt
+        self.dedupeKey = dedupeKey ?? event.dedupeKey
+    }
+}

--- a/Dochi/Services/HeartbeatChangeJournalService.swift
+++ b/Dochi/Services/HeartbeatChangeJournalService.swift
@@ -1,0 +1,85 @@
+import Foundation
+import os
+
+@MainActor
+@Observable
+final class HeartbeatChangeJournalService: HeartbeatChangeJournalProtocol {
+    private struct ChangeJournalFile: Codable {
+        let entries: [ChangeJournalEntry]
+    }
+
+    private let baseURL: URL
+    private let maxEntries: Int
+
+    private(set) var entries: [ChangeJournalEntry] = []
+
+    init(baseURL: URL? = nil, maxEntries: Int = 300) {
+        let appSupport = baseURL ?? FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first!.appendingPathComponent("Dochi")
+        self.baseURL = appSupport
+        self.maxEntries = max(1, maxEntries)
+        loadFromDisk()
+    }
+
+    func append(events: [HeartbeatChangeEvent]) {
+        guard !events.isEmpty else { return }
+
+        let additions = events.map { ChangeJournalEntry(event: $0) }
+        entries.append(contentsOf: additions)
+        if entries.count > maxEntries {
+            entries = Array(entries.suffix(maxEntries))
+        }
+        saveToDisk()
+    }
+
+    func recentEntries(limit: Int, source: HeartbeatChangeSource? = nil) -> [ChangeJournalEntry] {
+        guard limit > 0 else { return [] }
+        let filtered: [ChangeJournalEntry]
+        if let source {
+            filtered = entries.filter { $0.event.source == source }
+        } else {
+            filtered = entries
+        }
+        return Array(filtered.suffix(limit).reversed())
+    }
+
+    // MARK: - Persistence
+
+    private var filePath: URL {
+        baseURL.appendingPathComponent("heartbeat_change_journal.json")
+    }
+
+    private func loadFromDisk() {
+        do {
+            let data = try Data(contentsOf: filePath)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let file = try decoder.decode(ChangeJournalFile.self, from: data)
+            entries = Array(file.entries.suffix(maxEntries))
+            Log.storage.debug("Loaded \(self.entries.count) heartbeat change journal entries")
+        } catch {
+            let nsError = error as NSError
+            if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileReadNoSuchFileError {
+                Log.storage.debug("No heartbeat change journal file found, starting fresh")
+            } else {
+                Log.storage.warning("Failed to load heartbeat change journal: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func saveToDisk() {
+        do {
+            try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+            let payload = ChangeJournalFile(entries: entries)
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(payload)
+            try data.write(to: filePath, options: .atomic)
+        } catch {
+            Log.storage.error("Failed to save heartbeat change journal: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Dochi/Services/HeartbeatService.swift
+++ b/Dochi/Services/HeartbeatService.swift
@@ -55,6 +55,7 @@ final class HeartbeatService: Observable {
     private var externalToolManager: ExternalToolSessionManagerProtocol?
     private var resourceOptimizer: ResourceOptimizerProtocol?
     private var telegramRelay: TelegramProactiveRelayProtocol?
+    private var changeJournalService: HeartbeatChangeJournalProtocol?
 
     // Observable state
     private(set) var lastTickDate: Date?
@@ -101,6 +102,11 @@ final class HeartbeatService: Observable {
     /// Inject TelegramProactiveRelay for Telegram notification delivery (K-6).
     func setTelegramRelay(_ relay: TelegramProactiveRelayProtocol) {
         self.telegramRelay = relay
+    }
+
+    /// Inject change journal persistence service for heartbeat change events.
+    func setChangeJournalService(_ service: HeartbeatChangeJournalProtocol) {
+        self.changeJournalService = service
     }
 
     /// Set a callback for when the heartbeat decides to proactively message the user.
@@ -268,6 +274,7 @@ final class HeartbeatService: Observable {
                 timestamp: Date()
             )
             if !detectedChanges.isEmpty {
+                changeJournalService?.append(events: detectedChanges)
                 Log.app.info("HeartbeatService detected \(detectedChanges.count) change event(s)")
             }
 

--- a/Dochi/Services/Protocols/HeartbeatChangeJournalProtocol.swift
+++ b/Dochi/Services/Protocols/HeartbeatChangeJournalProtocol.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+@MainActor
+protocol HeartbeatChangeJournalProtocol: AnyObject, Sendable {
+    var entries: [ChangeJournalEntry] { get }
+    func append(events: [HeartbeatChangeEvent])
+    func recentEntries(limit: Int, source: HeartbeatChangeSource?) -> [ChangeJournalEntry]
+}
+
+extension HeartbeatChangeJournalProtocol {
+    func recentEntries(limit: Int) -> [ChangeJournalEntry] {
+        recentEntries(limit: limit, source: nil)
+    }
+}

--- a/DochiTests/HeartbeatChangeJournalServiceTests.swift
+++ b/DochiTests/HeartbeatChangeJournalServiceTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import Dochi
+
+@MainActor
+final class HeartbeatChangeJournalServiceTests: XCTestCase {
+    private func makeEvent(
+        source: HeartbeatChangeSource = .git,
+        eventType: HeartbeatChangeEventType = .gitBranchChanged,
+        targetId: String
+    ) -> HeartbeatChangeEvent {
+        HeartbeatChangeEvent(
+            source: source,
+            eventType: eventType,
+            severity: .info,
+            targetId: targetId,
+            title: "test",
+            detail: "test detail",
+            metadata: [:],
+            timestamp: Date()
+        )
+    }
+
+    func testAppendPersistsAndLoadsEntries() {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dochi-change-journal-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let writer = HeartbeatChangeJournalService(baseURL: tempRoot, maxEntries: 10)
+        writer.append(events: [makeEvent(targetId: "repo-a")])
+        XCTAssertEqual(writer.entries.count, 1)
+
+        let reader = HeartbeatChangeJournalService(baseURL: tempRoot, maxEntries: 10)
+        XCTAssertEqual(reader.entries.count, 1)
+        XCTAssertEqual(reader.entries.first?.event.targetId, "repo-a")
+    }
+
+    func testHistoryCapKeepsMostRecentEntries() {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dochi-change-journal-cap-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let service = HeartbeatChangeJournalService(baseURL: tempRoot, maxEntries: 3)
+        service.append(events: [
+            makeEvent(targetId: "1"),
+            makeEvent(targetId: "2"),
+            makeEvent(targetId: "3"),
+            makeEvent(targetId: "4"),
+            makeEvent(targetId: "5"),
+        ])
+
+        XCTAssertEqual(service.entries.count, 3)
+        XCTAssertEqual(service.entries.map(\.event.targetId), ["3", "4", "5"])
+    }
+
+    func testRecentEntriesSupportsSourceFilter() {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dochi-change-journal-filter-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let service = HeartbeatChangeJournalService(baseURL: tempRoot, maxEntries: 10)
+        service.append(events: [
+            makeEvent(source: .git, eventType: .gitBranchChanged, targetId: "repo-a"),
+            makeEvent(source: .codingSession, eventType: .codingSessionStarted, targetId: "session-a"),
+            makeEvent(source: .codingSession, eventType: .codingSessionEnded, targetId: "session-b"),
+        ])
+
+        let codingRecent = service.recentEntries(limit: 5, source: .codingSession)
+        XCTAssertEqual(codingRecent.count, 2)
+        XCTAssertTrue(codingRecent.allSatisfy { $0.event.source == .codingSession })
+        XCTAssertEqual(codingRecent.first?.event.targetId, "session-b")
+    }
+}

--- a/DochiTests/HeartbeatServiceTests.swift
+++ b/DochiTests/HeartbeatServiceTests.swift
@@ -3,6 +3,22 @@ import XCTest
 
 @MainActor
 final class HeartbeatServiceTests: XCTestCase {
+    private final class MockHeartbeatChangeJournal: HeartbeatChangeJournalProtocol {
+        private(set) var entries: [ChangeJournalEntry] = []
+        private(set) var appendCallCount = 0
+
+        func append(events: [HeartbeatChangeEvent]) {
+            appendCallCount += 1
+            entries.append(contentsOf: events.map { ChangeJournalEntry(event: $0) })
+        }
+
+        func recentEntries(limit: Int, source: HeartbeatChangeSource?) -> [ChangeJournalEntry] {
+            let filtered = source.map { source in
+                entries.filter { $0.event.source == source }
+            } ?? entries
+            return Array(filtered.suffix(max(0, limit)).reversed())
+        }
+    }
 
     private func makeViewModelForOpportunityTests() -> DochiViewModel {
         let contextService = MockContextService()
@@ -394,6 +410,40 @@ final class HeartbeatServiceTests: XCTestCase {
 
         XCTAssertTrue(hasSessionEvent)
         XCTAssertGreaterThan(externalToolManager.listUnifiedCodingSessionsCallCount, 0)
+    }
+
+    func testTickPersistsDetectedChangesIntoJournalService() async {
+        let settings = AppSettings()
+        settings.heartbeatEnabled = true
+        settings.heartbeatCheckCalendar = false
+        settings.heartbeatCheckKanban = false
+        settings.heartbeatCheckReminders = false
+        settings.heartbeatQuietHoursStart = 0
+        settings.heartbeatQuietHoursEnd = 0
+
+        let service = HeartbeatService(settings: settings)
+        let externalToolManager = MockExternalToolSessionManager()
+        let journal = MockHeartbeatChangeJournal()
+        service.setChangeJournalService(journal)
+
+        externalToolManager.mockGitRepositoryInsights = [makeGitInsight(path: "/tmp/repo-a")]
+        externalToolManager.mockUnifiedCodingSessions = [
+            makeUnifiedSession(
+                nativeSessionId: "session-1",
+                path: "tmux://session-1",
+                repositoryRoot: "/tmp/repo-a",
+                activityState: .active
+            ),
+        ]
+        service.setExternalToolManager(externalToolManager)
+
+        await service.runTickForTesting() // baseline
+
+        externalToolManager.mockUnifiedCodingSessions = []
+        await service.runTickForTesting() // session end event
+
+        XCTAssertGreaterThan(journal.appendCallCount, 0)
+        XCTAssertTrue(journal.entries.contains { $0.event.eventType == .codingSessionEnded })
     }
 
     func testTickRefreshesSessionHistoryIndexWhenStale() async throws {


### PR DESCRIPTION
## Summary
- add `HeartbeatChangeJournalProtocol` + `HeartbeatChangeJournalService` for heartbeat change-event persistence
- introduce `ChangeJournalEntry` model with event, recordedAt, and dedupe key
- wire journal service into `HeartbeatService` so detected change events are appended automatically
- initialize and inject the journal service in app boot (`DochiApp`)
- add tests for journal persistence/FIFO/source filtering and heartbeat->journal integration

## Test Evidence
- `xcodegen generate`
- `xcodebuild -quiet test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/HeartbeatChangeJournalServiceTests -only-testing:DochiTests/HeartbeatServiceTests`

## Spec Impact
- no spec doc updated (implementation foundation for #433 UI exposure)

Closes #431
