### PR TITLE
feat: [K] heartbeat change alerts with dedupe/cooldown (#432)

### DIFF
--- a/Dochi/App/NotificationManager.swift
+++ b/Dochi/App/NotificationManager.swift
@@ -14,6 +14,7 @@ final class NotificationManager: NSObject, Observable, UNUserNotificationCenterD
         case reminder = "dochi-reminder"
         case memory = "dochi-memory"
         case proactive = "dochi-proactive"
+        case change = "dochi-change"
     }
 
     enum ActionIdentifier: String {
@@ -114,8 +115,15 @@ final class NotificationManager: NSObject, Observable, UNUserNotificationCenterD
             options: []
         )
 
+        let changeCategory = UNNotificationCategory(
+            identifier: Category.change.rawValue,
+            actions: [openAppAction, dismissAction],
+            intentIdentifiers: [],
+            options: []
+        )
+
         UNUserNotificationCenter.current().setNotificationCategories([
-            calendarCategory, kanbanCategory, reminderCategory, memoryCategory, proactiveCategory
+            calendarCategory, kanbanCategory, reminderCategory, memoryCategory, proactiveCategory, changeCategory
         ])
         Log.app.info("NotificationManager: registered \(Category.allCases.count) notification categories (replyEnabled: \(replyEnabled))")
     }
@@ -192,6 +200,16 @@ final class NotificationManager: NSObject, Observable, UNUserNotificationCenterD
         )
     }
 
+    func sendHeartbeatChangeNotification(event: HeartbeatChangeEvent) {
+        guard settings.heartbeatChangeAlertEnabled else { return }
+
+        sendNotification(
+            title: "도치 - 변화 알림 (\(severityLabel(for: event.severity)))",
+            body: "\(event.title)\n\(event.detail)",
+            category: .change
+        )
+    }
+
     // MARK: - Private
 
     private func sendNotification(title: String, body: String, category: Category) {
@@ -217,6 +235,17 @@ final class NotificationManager: NSObject, Observable, UNUserNotificationCenterD
             } else {
                 Log.app.info("NotificationManager: sent \(category.rawValue) notification")
             }
+        }
+    }
+
+    private func severityLabel(for severity: HeartbeatChangeSeverity) -> String {
+        switch severity {
+        case .info:
+            return "정보"
+        case .warning:
+            return "주의"
+        case .critical:
+            return "중요"
         }
     }
 

--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -414,6 +414,16 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(heartbeatQuietHoursEnd, forKey: "heartbeatQuietHoursEnd") }
     }
 
+    /// Enables proactive alert delivery for detected Git/coding-session change events.
+    var heartbeatChangeAlertEnabled: Bool = UserDefaults.standard.object(forKey: "heartbeatChangeAlertEnabled") as? Bool ?? true {
+        didSet { UserDefaults.standard.set(heartbeatChangeAlertEnabled, forKey: "heartbeatChangeAlertEnabled") }
+    }
+
+    /// Minimum interval between repeated alerts for the same change dedupe key.
+    var heartbeatChangeAlertCooldownMinutes: Int = UserDefaults.standard.object(forKey: "heartbeatChangeAlertCooldownMinutes") as? Int ?? 30 {
+        didSet { UserDefaults.standard.set(heartbeatChangeAlertCooldownMinutes, forKey: "heartbeatChangeAlertCooldownMinutes") }
+    }
+
     // MARK: - Automation / Scheduler (J-3)
 
     var automationEnabled: Bool = UserDefaults.standard.object(forKey: "automationEnabled") as? Bool ?? false {

--- a/Dochi/Services/HeartbeatService.swift
+++ b/Dochi/Services/HeartbeatService.swift
@@ -65,9 +65,12 @@ final class HeartbeatService: Observable {
     private var previousGitInsightSnapshot: [String: GitRepositoryInsight] = [:]
     private var previousCodingSessionSnapshot: [String: UnifiedCodingSession] = [:]
     private var lastSessionHistoryIndexRefreshAt: Date?
+    private var changeAlertLastSentAt: [String: Date] = [:]
 
     static let maxHistoryCount = 20
     private static let sessionHistoryRefreshInterval: TimeInterval = 6 * 60 * 60
+    private static let maxChangeAlertsPerTick = 3
+    private static let maxChangeAlertDedupeEntries = 300
 
     init(settings: AppSettings) {
         self.settings = settings
@@ -276,6 +279,19 @@ final class HeartbeatService: Observable {
             if !detectedChanges.isEmpty {
                 changeJournalService?.append(events: detectedChanges)
                 Log.app.info("HeartbeatService detected \(detectedChanges.count) change event(s)")
+
+                let channel = NotificationChannel(rawValue: settings.heartbeatNotificationChannel) ?? .appOnly
+                if channel != .off {
+                    let alerts = Array(
+                        selectChangeAlertsToSend(
+                            from: detectedChanges,
+                            now: Date()
+                        ).prefix(Self.maxChangeAlertsPerTick)
+                    )
+                    if !alerts.isEmpty {
+                        await sendHeartbeatChangeAlerts(alerts, channel: channel)
+                    }
+                }
             }
 
             consecutiveErrors = 0
@@ -680,6 +696,100 @@ final class HeartbeatService: Observable {
     static func codingSessionIdentityKey(for session: UnifiedCodingSession) -> String {
         let runtimeId = session.runtimeSessionId ?? "-"
         return "\(session.provider.lowercased())|\(session.nativeSessionId)|\(runtimeId)|\(session.path)"
+    }
+
+    func selectChangeAlertsToSend(
+        from events: [HeartbeatChangeEvent],
+        now: Date = Date()
+    ) -> [HeartbeatChangeEvent] {
+        guard settings.heartbeatChangeAlertEnabled else { return [] }
+
+        let cooldownMinutes = max(1, settings.heartbeatChangeAlertCooldownMinutes)
+        let cooldownInterval = TimeInterval(cooldownMinutes * 60)
+        var selected: [HeartbeatChangeEvent] = []
+
+        for event in events where shouldSendChangeAlert(for: event) {
+            if let lastSent = changeAlertLastSentAt[event.dedupeKey],
+               now.timeIntervalSince(lastSent) < cooldownInterval {
+                continue
+            }
+            changeAlertLastSentAt[event.dedupeKey] = now
+            selected.append(event)
+        }
+
+        trimChangeAlertDedupeState()
+        return selected.sorted { lhs, rhs in
+            if lhs.severity != rhs.severity {
+                return severityScore(lhs.severity) > severityScore(rhs.severity)
+            }
+            return lhs.timestamp < rhs.timestamp
+        }
+    }
+
+    func shouldSendChangeAlert(for event: HeartbeatChangeEvent) -> Bool {
+        switch event.eventType {
+        case .codingSessionEnded, .gitDirtySpike:
+            return true
+        case .codingSessionActivityChanged:
+            let nextState = event.metadata["newActivityState"]?.lowercased() ?? ""
+            return nextState == CodingSessionActivityState.stale.rawValue
+                || nextState == CodingSessionActivityState.dead.rawValue
+        case .gitAheadBehindChanged:
+            let oldAhead = numericMetadataValue(event.metadata["oldAhead"])
+            let oldBehind = numericMetadataValue(event.metadata["oldBehind"])
+            let newAhead = numericMetadataValue(event.metadata["newAhead"])
+            let newBehind = numericMetadataValue(event.metadata["newBehind"])
+            let totalDelta = abs(newAhead - oldAhead) + abs(newBehind - oldBehind)
+            return totalDelta >= 4 || newAhead >= 5 || newBehind >= 5
+        default:
+            return false
+        }
+    }
+
+    private func sendHeartbeatChangeAlerts(
+        _ events: [HeartbeatChangeEvent],
+        channel: NotificationChannel
+    ) async {
+        guard !events.isEmpty else { return }
+
+        for event in events {
+            if channel.deliversToApp {
+                notificationManager?.sendHeartbeatChangeNotification(event: event)
+            }
+            if channel.deliversToTelegram {
+                await telegramRelay?.sendHeartbeatChangeAlert(event)
+            }
+        }
+        Log.app.info("HeartbeatService sent \(events.count) change alert(s)")
+    }
+
+    private func trimChangeAlertDedupeState() {
+        let overflow = changeAlertLastSentAt.count - Self.maxChangeAlertDedupeEntries
+        guard overflow > 0 else { return }
+
+        let keysToDrop = changeAlertLastSentAt
+            .sorted { $0.value < $1.value }
+            .prefix(overflow)
+            .map(\.key)
+        for key in keysToDrop {
+            changeAlertLastSentAt.removeValue(forKey: key)
+        }
+    }
+
+    private func severityScore(_ severity: HeartbeatChangeSeverity) -> Int {
+        switch severity {
+        case .critical:
+            return 3
+        case .warning:
+            return 2
+        case .info:
+            return 1
+        }
+    }
+
+    private func numericMetadataValue(_ raw: String?) -> Int {
+        guard let raw, let value = Int(raw) else { return 0 }
+        return value
     }
 
     // MARK: - Context Gathering

--- a/Dochi/Services/Protocols/TelegramProactiveRelayProtocol.swift
+++ b/Dochi/Services/Protocols/TelegramProactiveRelayProtocol.swift
@@ -20,6 +20,9 @@ protocol TelegramProactiveRelayProtocol: AnyObject {
     /// Send a proactive suggestion to Telegram.
     func sendSuggestion(_ suggestion: ProactiveSuggestion) async
 
+    /// Send a heartbeat change alert to Telegram.
+    func sendHeartbeatChangeAlert(_ event: HeartbeatChangeEvent) async
+
     /// Number of Telegram notifications sent today.
     var todayTelegramNotificationCount: Int { get }
 }

--- a/Dochi/Services/Telegram/TelegramProactiveRelay.swift
+++ b/Dochi/Services/Telegram/TelegramProactiveRelay.swift
@@ -106,6 +106,22 @@ final class TelegramProactiveRelay: TelegramProactiveRelayProtocol {
         await send(chatId: chatId, text: message)
     }
 
+    func sendHeartbeatChangeAlert(_ event: HeartbeatChangeEvent) async {
+        let channel = NotificationChannel(rawValue: settings.heartbeatNotificationChannel) ?? .appOnly
+        guard shouldSendToTelegram(channel: channel) else { return }
+        guard let chatId = resolveChatId() else {
+            Log.telegram.debug("변화 알람 텔레그램 전송 건너뜀: chatId 미매핑")
+            return
+        }
+        guard hasTelegramToken() else {
+            Log.telegram.debug("변화 알람 텔레그램 전송 건너뜀: 토큰 미설정")
+            return
+        }
+
+        let message = formatChangeAlert(event)
+        await send(chatId: chatId, text: message)
+    }
+
     // MARK: - Channel Logic
 
     func shouldSendToTelegram(channel: NotificationChannel) -> Bool {
@@ -147,6 +163,21 @@ final class TelegramProactiveRelay: TelegramProactiveRelayProtocol {
         }
 
         return "\(emoji) *\(escapeMarkdown(suggestion.title))*\n\(escapeMarkdown(suggestion.body))\n\n\u{1F4A1} \(replyHint)"
+    }
+
+    private func formatChangeAlert(_ event: HeartbeatChangeEvent) -> String {
+        let sourceLabel = event.source == .git ? "Git" : "Coding Session"
+        let severityEmoji: String
+        switch event.severity {
+        case .info:
+            severityEmoji = "\u{2139}\u{FE0F}"
+        case .warning:
+            severityEmoji = "\u{26A0}\u{FE0F}"
+        case .critical:
+            severityEmoji = "\u{1F6A8}"
+        }
+
+        return "\(severityEmoji) *변화 알림 (\(sourceLabel))*\n\(escapeMarkdown(event.title))\n\(escapeMarkdown(event.detail))"
     }
 
     /// Escape Telegram Markdown special characters in user data.

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -2743,6 +2743,9 @@ final class DochiViewModel {
         case NotificationManager.Category.proactive.rawValue:
             notificationRequestedSection = "chat"
             Log.app.info("Notification: navigating to conversation for proactive suggestion")
+        case NotificationManager.Category.change.rawValue:
+            notificationRequestedSection = "chat"
+            Log.app.info("Notification: navigating to conversation for heartbeat change alert")
         default:
             break
         }

--- a/DochiTests/HeartbeatServiceTests.swift
+++ b/DochiTests/HeartbeatServiceTests.swift
@@ -208,6 +208,61 @@ final class HeartbeatServiceTests: XCTestCase {
         XCTAssertTrue(eventTypes.contains(.codingSessionRepositoryChanged))
     }
 
+    func testSelectChangeAlertsToSendAppliesRuleAndCooldown() {
+        let settings = AppSettings()
+        settings.heartbeatChangeAlertEnabled = true
+        settings.heartbeatChangeAlertCooldownMinutes = 10
+        let service = HeartbeatService(settings: settings)
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let dirtySpike = HeartbeatChangeEvent(
+            source: .git,
+            eventType: .gitDirtySpike,
+            severity: .warning,
+            targetId: "/tmp/repo-a",
+            title: "dirty",
+            detail: "dirty spike",
+            timestamp: now
+        )
+        let branchChanged = HeartbeatChangeEvent(
+            source: .git,
+            eventType: .gitBranchChanged,
+            severity: .info,
+            targetId: "/tmp/repo-a",
+            title: "branch",
+            detail: "branch changed",
+            timestamp: now
+        )
+        let staleTransition = HeartbeatChangeEvent(
+            source: .codingSession,
+            eventType: .codingSessionActivityChanged,
+            severity: .warning,
+            targetId: "codex|sess-1|-|/tmp/repo-a",
+            title: "state",
+            detail: "active -> stale",
+            metadata: ["newActivityState": "stale"],
+            timestamp: now
+        )
+
+        let first = service.selectChangeAlertsToSend(
+            from: [dirtySpike, branchChanged, staleTransition],
+            now: now
+        )
+        XCTAssertEqual(Set(first.map(\.eventType)), Set([.gitDirtySpike, .codingSessionActivityChanged]))
+
+        let withinCooldown = service.selectChangeAlertsToSend(
+            from: [dirtySpike, staleTransition],
+            now: now.addingTimeInterval(60)
+        )
+        XCTAssertTrue(withinCooldown.isEmpty)
+
+        let afterCooldown = service.selectChangeAlertsToSend(
+            from: [dirtySpike, staleTransition],
+            now: now.addingTimeInterval(601)
+        )
+        XCTAssertEqual(Set(afterCooldown.map(\.eventType)), Set([.gitDirtySpike, .codingSessionActivityChanged]))
+    }
+
     func testMapTaskOpportunitiesBuildsStructuredActions() {
         let settings = AppSettings()
         let service = HeartbeatService(settings: settings)
@@ -444,6 +499,79 @@ final class HeartbeatServiceTests: XCTestCase {
 
         XCTAssertGreaterThan(journal.appendCallCount, 0)
         XCTAssertTrue(journal.entries.contains { $0.event.eventType == .codingSessionEnded })
+    }
+
+    func testTickSendsChangeAlertToTelegramWhenEnabled() async {
+        let settings = AppSettings()
+        settings.heartbeatEnabled = true
+        settings.heartbeatCheckCalendar = false
+        settings.heartbeatCheckKanban = false
+        settings.heartbeatCheckReminders = false
+        settings.heartbeatQuietHoursStart = 0
+        settings.heartbeatQuietHoursEnd = 0
+        settings.heartbeatNotificationChannel = NotificationChannel.telegramOnly.rawValue
+        settings.heartbeatChangeAlertEnabled = true
+
+        let service = HeartbeatService(settings: settings)
+        let externalToolManager = MockExternalToolSessionManager()
+        let relay = MockTelegramProactiveRelay()
+        service.setExternalToolManager(externalToolManager)
+        service.setTelegramRelay(relay)
+
+        externalToolManager.mockGitRepositoryInsights = [makeGitInsight(path: "/tmp/repo-a")]
+        externalToolManager.mockUnifiedCodingSessions = [
+            makeUnifiedSession(
+                nativeSessionId: "session-1",
+                path: "tmux://session-1",
+                repositoryRoot: "/tmp/repo-a",
+                activityState: .active
+            ),
+        ]
+        await service.runTickForTesting() // baseline
+
+        externalToolManager.mockUnifiedCodingSessions = []
+        await service.runTickForTesting() // session ended -> alert candidate
+
+        XCTAssertEqual(relay.sendHeartbeatChangeAlertCallCount, 1)
+        XCTAssertEqual(relay.lastHeartbeatChangeEvent?.eventType, .codingSessionEnded)
+    }
+
+    func testTickKeepsJournalWhenChangeAlertDisabled() async {
+        let settings = AppSettings()
+        settings.heartbeatEnabled = true
+        settings.heartbeatCheckCalendar = false
+        settings.heartbeatCheckKanban = false
+        settings.heartbeatCheckReminders = false
+        settings.heartbeatQuietHoursStart = 0
+        settings.heartbeatQuietHoursEnd = 0
+        settings.heartbeatNotificationChannel = NotificationChannel.telegramOnly.rawValue
+        settings.heartbeatChangeAlertEnabled = false
+
+        let service = HeartbeatService(settings: settings)
+        let externalToolManager = MockExternalToolSessionManager()
+        let relay = MockTelegramProactiveRelay()
+        let journal = MockHeartbeatChangeJournal()
+        service.setExternalToolManager(externalToolManager)
+        service.setTelegramRelay(relay)
+        service.setChangeJournalService(journal)
+
+        externalToolManager.mockGitRepositoryInsights = [makeGitInsight(path: "/tmp/repo-a")]
+        externalToolManager.mockUnifiedCodingSessions = [
+            makeUnifiedSession(
+                nativeSessionId: "session-1",
+                path: "tmux://session-1",
+                repositoryRoot: "/tmp/repo-a",
+                activityState: .active
+            ),
+        ]
+        await service.runTickForTesting() // baseline
+
+        externalToolManager.mockUnifiedCodingSessions = []
+        await service.runTickForTesting() // session ended
+
+        XCTAssertGreaterThan(journal.appendCallCount, 0)
+        XCTAssertTrue(journal.entries.contains { $0.event.eventType == .codingSessionEnded })
+        XCTAssertEqual(relay.sendHeartbeatChangeAlertCallCount, 0)
     }
 
     func testTickRefreshesSessionHistoryIndexWhenStale() async throws {

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -1269,12 +1269,14 @@ final class MockTelegramProactiveRelay: TelegramProactiveRelayProtocol {
     var stopCallCount = 0
     var sendHeartbeatAlertCallCount = 0
     var sendSuggestionCallCount = 0
+    var sendHeartbeatChangeAlertCallCount = 0
 
     var lastHeartbeatCalendar: String?
     var lastHeartbeatKanban: String?
     var lastHeartbeatReminder: String?
     var lastHeartbeatMemory: String?
     var lastSuggestion: ProactiveSuggestion?
+    var lastHeartbeatChangeEvent: HeartbeatChangeEvent?
 
     func start() {
         startCallCount += 1
@@ -1303,6 +1305,12 @@ final class MockTelegramProactiveRelay: TelegramProactiveRelayProtocol {
     func sendSuggestion(_ suggestion: ProactiveSuggestion) async {
         sendSuggestionCallCount += 1
         lastSuggestion = suggestion
+        todayTelegramNotificationCount += 1
+    }
+
+    func sendHeartbeatChangeAlert(_ event: HeartbeatChangeEvent) async {
+        sendHeartbeatChangeAlertCallCount += 1
+        lastHeartbeatChangeEvent = event
         todayTelegramNotificationCount += 1
     }
 }

--- a/DochiTests/NotificationCenterTests.swift
+++ b/DochiTests/NotificationCenterTests.swift
@@ -15,6 +15,8 @@ final class NotificationCenterTests: XCTestCase {
         XCTAssertTrue(settings.notificationMemoryEnabled)
         XCTAssertTrue(settings.notificationSoundEnabled)
         XCTAssertTrue(settings.notificationReplyEnabled)
+        XCTAssertTrue(settings.heartbeatChangeAlertEnabled)
+        XCTAssertGreaterThan(settings.heartbeatChangeAlertCooldownMinutes, 0)
     }
 
     func testNotificationSettingsPersistence() {
@@ -38,6 +40,12 @@ final class NotificationCenterTests: XCTestCase {
         settings.notificationReplyEnabled = false
         XCTAssertFalse(settings.notificationReplyEnabled)
 
+        settings.heartbeatChangeAlertEnabled = false
+        XCTAssertFalse(settings.heartbeatChangeAlertEnabled)
+
+        settings.heartbeatChangeAlertCooldownMinutes = 45
+        XCTAssertEqual(settings.heartbeatChangeAlertCooldownMinutes, 45)
+
         // Restore defaults
         settings.notificationCalendarEnabled = true
         settings.notificationKanbanEnabled = true
@@ -45,6 +53,8 @@ final class NotificationCenterTests: XCTestCase {
         settings.notificationMemoryEnabled = true
         settings.notificationSoundEnabled = true
         settings.notificationReplyEnabled = true
+        settings.heartbeatChangeAlertEnabled = true
+        settings.heartbeatChangeAlertCooldownMinutes = 30
     }
 
     // MARK: - NotificationManager Initialization
@@ -65,16 +75,18 @@ final class NotificationCenterTests: XCTestCase {
         XCTAssertEqual(NotificationManager.Category.reminder.rawValue, "dochi-reminder")
         XCTAssertEqual(NotificationManager.Category.memory.rawValue, "dochi-memory")
         XCTAssertEqual(NotificationManager.Category.proactive.rawValue, "dochi-proactive")
+        XCTAssertEqual(NotificationManager.Category.change.rawValue, "dochi-change")
     }
 
     func testNotificationCategoryAllCases() {
         let allCases = NotificationManager.Category.allCases
-        XCTAssertEqual(allCases.count, 5)
+        XCTAssertEqual(allCases.count, 6)
         XCTAssertTrue(allCases.contains(.calendar))
         XCTAssertTrue(allCases.contains(.kanban))
         XCTAssertTrue(allCases.contains(.reminder))
         XCTAssertTrue(allCases.contains(.memory))
         XCTAssertTrue(allCases.contains(.proactive))
+        XCTAssertTrue(allCases.contains(.change))
     }
 
     // MARK: - NotificationManager Action Constants
@@ -281,6 +293,7 @@ final class NotificationCenterTests: XCTestCase {
         viewModel.handleNotificationOpenApp(category: NotificationManager.Category.reminder.rawValue)
         viewModel.handleNotificationOpenApp(category: NotificationManager.Category.memory.rawValue)
         viewModel.handleNotificationOpenApp(category: NotificationManager.Category.proactive.rawValue)
+        viewModel.handleNotificationOpenApp(category: NotificationManager.Category.change.rawValue)
         viewModel.handleNotificationOpenApp(category: "unknown-category")
     }
 
@@ -471,6 +484,28 @@ final class NotificationCenterTests: XCTestCase {
 
         viewModel.handleNotificationOpenApp(category: "unknown-category")
         XCTAssertNil(viewModel.notificationRequestedSection)
+        XCTAssertFalse(viewModel.notificationShowMemoryPanel)
+    }
+
+    func testHandleNotificationOpenAppNavigatesToChatForChangeAlert() {
+        let settings = AppSettings()
+        let keychainService = MockKeychainService()
+        keychainService.store["openai_api_key"] = "sk-test"
+
+        let viewModel = DochiViewModel(
+            toolService: MockBuiltInToolService(),
+            contextService: MockContextService(),
+            conversationService: MockConversationService(),
+            keychainService: keychainService,
+            speechService: MockSpeechService(),
+            ttsService: MockTTSService(),
+            soundService: MockSoundService(),
+            settings: settings,
+            sessionContext: SessionContext(workspaceId: UUID())
+        )
+
+        viewModel.handleNotificationOpenApp(category: NotificationManager.Category.change.rawValue)
+        XCTAssertEqual(viewModel.notificationRequestedSection, "chat")
         XCTAssertFalse(viewModel.notificationShowMemoryPanel)
     }
 

--- a/DochiTests/TelegramProactiveRelayTests.swift
+++ b/DochiTests/TelegramProactiveRelayTests.swift
@@ -37,6 +37,8 @@ final class TelegramProactiveRelayTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: "heartbeatNotificationChannel")
         UserDefaults.standard.removeObject(forKey: "suggestionNotificationChannel")
         UserDefaults.standard.removeObject(forKey: "telegramSkipWhenAppActive")
+        UserDefaults.standard.removeObject(forKey: "heartbeatChangeAlertEnabled")
+        UserDefaults.standard.removeObject(forKey: "heartbeatChangeAlertCooldownMinutes")
     }
 
     // MARK: - NotificationChannel Enum
@@ -131,6 +133,40 @@ final class TelegramProactiveRelayTests: XCTestCase {
             memory: nil
         )
 
+        XCTAssertTrue(mockTelegramService.sentMessages.isEmpty)
+    }
+
+    func testHeartbeatChangeAlertRelay() async {
+        settings.heartbeatNotificationChannel = NotificationChannel.telegramOnly.rawValue
+        settings.telegramSkipWhenAppActive = false
+
+        let event = HeartbeatChangeEvent(
+            source: .codingSession,
+            eventType: .codingSessionEnded,
+            severity: .warning,
+            targetId: "codex|session-1|-|/tmp/repo",
+            title: "코딩 세션 종료",
+            detail: "codex 세션 session-1이 종료되었습니다."
+        )
+        await relay.sendHeartbeatChangeAlert(event)
+
+        XCTAssertEqual(mockTelegramService.sentMessages.count, 1)
+        XCTAssertTrue(mockTelegramService.sentMessages[0].text.contains("변화 알림"))
+        XCTAssertTrue(mockTelegramService.sentMessages[0].text.contains("코딩 세션 종료"))
+    }
+
+    func testHeartbeatChangeAlertAppOnlyDoesNotSend() async {
+        settings.heartbeatNotificationChannel = NotificationChannel.appOnly.rawValue
+
+        let event = HeartbeatChangeEvent(
+            source: .git,
+            eventType: .gitDirtySpike,
+            severity: .warning,
+            targetId: "/tmp/repo",
+            title: "작업 변경량 급증",
+            detail: "dirty +12"
+        )
+        await relay.sendHeartbeatChangeAlert(event)
         XCTAssertTrue(mockTelegramService.sentMessages.isEmpty)
     }
 


### PR DESCRIPTION
## Summary
- add heartbeat change-alert settings (`heartbeatChangeAlertEnabled`, `heartbeatChangeAlertCooldownMinutes`)
- extend change notification delivery with a dedicated category (`dochi-change`) and view-model routing
- add heartbeat-side change alert rule engine (session end/stale transition/dirty spike/ahead-behind surge)
- enforce dedupe key + cooldown suppression per change event
- relay heartbeat change alerts to Telegram when heartbeat channel includes Telegram

## Test Evidence
- `xcodebuild -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/HeartbeatServiceTests -only-testing:DochiTests/NotificationCenterTests -only-testing:DochiTests/TelegramProactiveRelayTests test`

## Spec Impact
- None (implementation detail change under existing heartbeat/proactive behavior)

Closes #432
