### PR TITLE
feat: [K] heartbeat change tracking settings and status UI (#433)

### DIFF
--- a/Dochi/Models/AppSettings.swift
+++ b/Dochi/Models/AppSettings.swift
@@ -406,6 +406,16 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(heartbeatCheckReminders, forKey: "heartbeatCheckReminders") }
     }
 
+    /// Enables Git repository change detection during heartbeat ticks.
+    var heartbeatTrackGitChanges: Bool = UserDefaults.standard.object(forKey: "heartbeatTrackGitChanges") as? Bool ?? true {
+        didSet { UserDefaults.standard.set(heartbeatTrackGitChanges, forKey: "heartbeatTrackGitChanges") }
+    }
+
+    /// Enables coding session lifecycle/activity change detection during heartbeat ticks.
+    var heartbeatTrackCodingSessionChanges: Bool = UserDefaults.standard.object(forKey: "heartbeatTrackCodingSessionChanges") as? Bool ?? true {
+        didSet { UserDefaults.standard.set(heartbeatTrackCodingSessionChanges, forKey: "heartbeatTrackCodingSessionChanges") }
+    }
+
     var heartbeatQuietHoursStart: Int = UserDefaults.standard.object(forKey: "heartbeatQuietHoursStart") as? Int ?? 23 {
         didSet { UserDefaults.standard.set(heartbeatQuietHoursStart, forKey: "heartbeatQuietHoursStart") }
     }

--- a/Dochi/Services/HeartbeatService.swift
+++ b/Dochi/Services/HeartbeatService.swift
@@ -396,16 +396,20 @@ final class HeartbeatService: Observable {
         let currentGitSnapshot = Self.gitSnapshotIndex(from: gitInsights)
         let currentSessionSnapshot = Self.codingSessionSnapshotIndex(from: codingSessions)
 
-        let gitEvents = Self.diffGitSnapshot(
-            previous: previousGitInsightSnapshot,
-            current: currentGitSnapshot,
-            timestamp: timestamp
-        )
-        let sessionEvents = Self.diffCodingSessionSnapshot(
-            previous: previousCodingSessionSnapshot,
-            current: currentSessionSnapshot,
-            timestamp: timestamp
-        )
+        let gitEvents = settings.heartbeatTrackGitChanges
+            ? Self.diffGitSnapshot(
+                previous: previousGitInsightSnapshot,
+                current: currentGitSnapshot,
+                timestamp: timestamp
+            )
+            : []
+        let sessionEvents = settings.heartbeatTrackCodingSessionChanges
+            ? Self.diffCodingSessionSnapshot(
+                previous: previousCodingSessionSnapshot,
+                current: currentSessionSnapshot,
+                timestamp: timestamp
+            )
+            : []
 
         previousGitInsightSnapshot = currentGitSnapshot
         previousCodingSessionSnapshot = currentSessionSnapshot

--- a/Dochi/Views/SettingsView.swift
+++ b/Dochi/Views/SettingsView.swift
@@ -586,6 +586,52 @@ struct HeartbeatSettingsContent: View {
             )
         }
 
+        Section {
+            Toggle("Git 변화 추적", isOn: Binding(
+                get: { settings.heartbeatTrackGitChanges },
+                set: { settings.heartbeatTrackGitChanges = $0 }
+            ))
+            Text("저장소 추가/제거, 브랜치, 변경량, 원격 동기화 변화를 감지합니다")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Toggle("코딩세션 변화 추적", isOn: Binding(
+                get: { settings.heartbeatTrackCodingSessionChanges },
+                set: { settings.heartbeatTrackCodingSessionChanges = $0 }
+            ))
+            Text("세션 시작/종료, 활동 상태 전이, 저장소 바인딩 변화를 감지합니다")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Toggle("변화 알림", isOn: Binding(
+                get: { settings.heartbeatChangeAlertEnabled },
+                set: { settings.heartbeatChangeAlertEnabled = $0 }
+            ))
+
+            if settings.heartbeatChangeAlertEnabled {
+                Stepper(
+                    "중복 억제 쿨다운: \(settings.heartbeatChangeAlertCooldownMinutes)분",
+                    value: Binding(
+                        get: { settings.heartbeatChangeAlertCooldownMinutes },
+                        set: { settings.heartbeatChangeAlertCooldownMinutes = min(max($0, 1), 240) }
+                    ),
+                    in: 1...240
+                )
+            }
+
+            if !settings.heartbeatTrackGitChanges && !settings.heartbeatTrackCodingSessionChanges {
+                Text("감지 토글이 모두 꺼져 있으면 변화 알림이 발생하지 않습니다.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            SettingsSectionHeader(
+                title: "변화 추적",
+                helpContent: "하트비트가 감지할 변화 소스(Git/코딩세션)와 변화 알림 중복 억제 쿨다운을 제어합니다."
+            )
+        }
+        .disabled(!settings.heartbeatEnabled)
+
         // MARK: - Notification Center (H-3)
         Section {
             // Authorization status row
@@ -766,6 +812,12 @@ struct HeartbeatSettingsContent: View {
                         Text("\(result.itemsFound)건")
                             .foregroundStyle(result.itemsFound > 0 ? .primary : .secondary)
                     }
+                    HStack {
+                        Text("감지된 변화")
+                        Spacer()
+                        Text("\(result.detectedChanges.count)건")
+                            .foregroundStyle(result.detectedChanges.isEmpty ? .secondary : .primary)
+                    }
                     if result.notificationSent {
                         Text("알림 전송됨")
                             .foregroundStyle(.green)
@@ -791,6 +843,46 @@ struct HeartbeatSettingsContent: View {
                         Spacer()
                         Text("\(heartbeatService.consecutiveErrors)회")
                             .foregroundStyle(.red)
+                    }
+                }
+
+                let recentChanges = recentChangeEvents(from: heartbeatService, limit: 5)
+                if recentChanges.isEmpty {
+                    Text("아직 감지된 변화가 없습니다")
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                } else {
+                    ForEach(recentChanges) { event in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(changeSeverityLabel(event.severity))
+                                    .font(.caption2)
+                                    .fontWeight(.semibold)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 2)
+                                    .background(changeSeverityColor(event.severity).opacity(0.2))
+                                    .clipShape(Capsule())
+
+                                Text(changeSourceLabel(event.source))
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+
+                                Spacer()
+
+                                Text(event.timestamp, style: .relative)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Text(event.title)
+                                .font(.subheadline)
+                                .lineLimit(1)
+                            Text(changeTargetText(event))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        .padding(.vertical, 2)
                     }
                 }
             }
@@ -849,6 +941,60 @@ struct HeartbeatSettingsContent: View {
                 title: "프로액티브 제안",
                 helpContent: "프로액티브 세부 설정은 전용 화면(Settings > 프로액티브 제안)에서만 변경됩니다. 이 영역은 현재 상태 요약과 이동 링크만 제공합니다."
             )
+        }
+    }
+
+    private func recentChangeEvents(
+        from heartbeatService: HeartbeatService,
+        limit: Int
+    ) -> [HeartbeatChangeEvent] {
+        let events = heartbeatService.tickHistory.flatMap(\.detectedChanges)
+        return Array(events.sorted { $0.timestamp > $1.timestamp }.prefix(limit))
+    }
+
+    private func changeSeverityLabel(_ severity: HeartbeatChangeSeverity) -> String {
+        switch severity {
+        case .info:
+            return "정보"
+        case .warning:
+            return "주의"
+        case .critical:
+            return "중요"
+        }
+    }
+
+    private func changeSeverityColor(_ severity: HeartbeatChangeSeverity) -> Color {
+        switch severity {
+        case .info:
+            return .blue
+        case .warning:
+            return .orange
+        case .critical:
+            return .red
+        }
+    }
+
+    private func changeSourceLabel(_ source: HeartbeatChangeSource) -> String {
+        switch source {
+        case .git:
+            return "Git"
+        case .codingSession:
+            return "Coding Session"
+        }
+    }
+
+    private func changeTargetText(_ event: HeartbeatChangeEvent) -> String {
+        switch event.source {
+        case .git:
+            if let repository = event.metadata["repository"], !repository.isEmpty {
+                return repository
+            }
+            return URL(fileURLWithPath: event.targetId).lastPathComponent
+        case .codingSession:
+            let provider = event.metadata["provider"] ?? ""
+            let sessionId = event.metadata["sessionId"] ?? ""
+            let raw = "\(provider) \(sessionId)".trimmingCharacters(in: .whitespacesAndNewlines)
+            return raw.isEmpty ? event.targetId : raw
         }
     }
 }

--- a/DochiTests/HeartbeatServiceTests.swift
+++ b/DochiTests/HeartbeatServiceTests.swift
@@ -152,6 +152,8 @@ final class HeartbeatServiceTests: XCTestCase {
 
     func testDetectChangeEventsUsesBaselineWithoutEmitting() {
         let settings = AppSettings()
+        settings.heartbeatTrackGitChanges = true
+        settings.heartbeatTrackCodingSessionChanges = true
         let service = HeartbeatService(settings: settings)
 
         let baselineEvents = service.detectChangeEvents(
@@ -169,6 +171,8 @@ final class HeartbeatServiceTests: XCTestCase {
 
     func testDetectChangeEventsReportsGitAndCodingSessionTransitions() {
         let settings = AppSettings()
+        settings.heartbeatTrackGitChanges = true
+        settings.heartbeatTrackCodingSessionChanges = true
         let service = HeartbeatService(settings: settings)
 
         _ = service.detectChangeEvents(
@@ -206,6 +210,57 @@ final class HeartbeatServiceTests: XCTestCase {
         XCTAssertTrue(eventTypes.contains(.gitAheadBehindChanged))
         XCTAssertTrue(eventTypes.contains(.codingSessionActivityChanged))
         XCTAssertTrue(eventTypes.contains(.codingSessionRepositoryChanged))
+    }
+
+    func testDetectChangeEventsHonorsSourceTrackingSettings() {
+        func runChanges(service: HeartbeatService) -> [HeartbeatChangeEvent] {
+            _ = service.detectChangeEvents(
+                gitInsights: [makeGitInsight(path: "/tmp/repo-a", branch: "main", changedFileCount: 0, untrackedFileCount: 0)],
+                codingSessions: [makeUnifiedSession(
+                    nativeSessionId: "session-1",
+                    path: "tmux://session-1",
+                    repositoryRoot: "/tmp/repo-a",
+                    activityState: .active
+                )],
+                timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+
+            return service.detectChangeEvents(
+                gitInsights: [makeGitInsight(
+                    path: "/tmp/repo-a",
+                    branch: "feature/heartbeat",
+                    changedFileCount: 10,
+                    untrackedFileCount: 1,
+                    aheadCount: 2,
+                    behindCount: 1
+                )],
+                codingSessions: [makeUnifiedSession(
+                    nativeSessionId: "session-1",
+                    path: "tmux://session-1",
+                    repositoryRoot: "/tmp/repo-b",
+                    activityState: .stale
+                )],
+                timestamp: Date(timeIntervalSince1970: 1_700_000_060)
+            )
+        }
+
+        let gitDisabledSettings = AppSettings()
+        gitDisabledSettings.heartbeatTrackGitChanges = false
+        gitDisabledSettings.heartbeatTrackCodingSessionChanges = true
+        let gitDisabledEvents = runChanges(service: HeartbeatService(settings: gitDisabledSettings))
+        XCTAssertTrue(gitDisabledEvents.allSatisfy { $0.source == .codingSession })
+
+        let sessionDisabledSettings = AppSettings()
+        sessionDisabledSettings.heartbeatTrackGitChanges = true
+        sessionDisabledSettings.heartbeatTrackCodingSessionChanges = false
+        let sessionDisabledEvents = runChanges(service: HeartbeatService(settings: sessionDisabledSettings))
+        XCTAssertTrue(sessionDisabledEvents.allSatisfy { $0.source == .git })
+
+        let allDisabledSettings = AppSettings()
+        allDisabledSettings.heartbeatTrackGitChanges = false
+        allDisabledSettings.heartbeatTrackCodingSessionChanges = false
+        let allDisabledEvents = runChanges(service: HeartbeatService(settings: allDisabledSettings))
+        XCTAssertTrue(allDisabledEvents.isEmpty)
     }
 
     func testSelectChangeAlertsToSendAppliesRuleAndCooldown() {
@@ -424,6 +479,8 @@ final class HeartbeatServiceTests: XCTestCase {
         settings.heartbeatCheckCalendar = false
         settings.heartbeatCheckKanban = false
         settings.heartbeatCheckReminders = false
+        settings.heartbeatTrackGitChanges = true
+        settings.heartbeatTrackCodingSessionChanges = true
         settings.heartbeatQuietHoursStart = 0
         settings.heartbeatQuietHoursEnd = 0
 
@@ -473,6 +530,8 @@ final class HeartbeatServiceTests: XCTestCase {
         settings.heartbeatCheckCalendar = false
         settings.heartbeatCheckKanban = false
         settings.heartbeatCheckReminders = false
+        settings.heartbeatTrackGitChanges = true
+        settings.heartbeatTrackCodingSessionChanges = true
         settings.heartbeatQuietHoursStart = 0
         settings.heartbeatQuietHoursEnd = 0
 
@@ -507,6 +566,8 @@ final class HeartbeatServiceTests: XCTestCase {
         settings.heartbeatCheckCalendar = false
         settings.heartbeatCheckKanban = false
         settings.heartbeatCheckReminders = false
+        settings.heartbeatTrackGitChanges = true
+        settings.heartbeatTrackCodingSessionChanges = true
         settings.heartbeatQuietHoursStart = 0
         settings.heartbeatQuietHoursEnd = 0
         settings.heartbeatNotificationChannel = NotificationChannel.telegramOnly.rawValue
@@ -542,6 +603,8 @@ final class HeartbeatServiceTests: XCTestCase {
         settings.heartbeatCheckCalendar = false
         settings.heartbeatCheckKanban = false
         settings.heartbeatCheckReminders = false
+        settings.heartbeatTrackGitChanges = true
+        settings.heartbeatTrackCodingSessionChanges = true
         settings.heartbeatQuietHoursStart = 0
         settings.heartbeatQuietHoursEnd = 0
         settings.heartbeatNotificationChannel = NotificationChannel.telegramOnly.rawValue

--- a/DochiTests/NotificationCenterTests.swift
+++ b/DochiTests/NotificationCenterTests.swift
@@ -8,6 +8,11 @@ final class NotificationCenterTests: XCTestCase {
     // MARK: - AppSettings Notification Properties
 
     func testNotificationSettingsDefaults() {
+        UserDefaults.standard.removeObject(forKey: "heartbeatTrackGitChanges")
+        UserDefaults.standard.removeObject(forKey: "heartbeatTrackCodingSessionChanges")
+        UserDefaults.standard.removeObject(forKey: "heartbeatChangeAlertEnabled")
+        UserDefaults.standard.removeObject(forKey: "heartbeatChangeAlertCooldownMinutes")
+
         let settings = AppSettings()
         XCTAssertTrue(settings.notificationCalendarEnabled)
         XCTAssertTrue(settings.notificationKanbanEnabled)
@@ -15,6 +20,8 @@ final class NotificationCenterTests: XCTestCase {
         XCTAssertTrue(settings.notificationMemoryEnabled)
         XCTAssertTrue(settings.notificationSoundEnabled)
         XCTAssertTrue(settings.notificationReplyEnabled)
+        XCTAssertTrue(settings.heartbeatTrackGitChanges)
+        XCTAssertTrue(settings.heartbeatTrackCodingSessionChanges)
         XCTAssertTrue(settings.heartbeatChangeAlertEnabled)
         XCTAssertGreaterThan(settings.heartbeatChangeAlertCooldownMinutes, 0)
     }
@@ -46,6 +53,12 @@ final class NotificationCenterTests: XCTestCase {
         settings.heartbeatChangeAlertCooldownMinutes = 45
         XCTAssertEqual(settings.heartbeatChangeAlertCooldownMinutes, 45)
 
+        settings.heartbeatTrackGitChanges = false
+        XCTAssertFalse(settings.heartbeatTrackGitChanges)
+
+        settings.heartbeatTrackCodingSessionChanges = false
+        XCTAssertFalse(settings.heartbeatTrackCodingSessionChanges)
+
         // Restore defaults
         settings.notificationCalendarEnabled = true
         settings.notificationKanbanEnabled = true
@@ -53,6 +66,8 @@ final class NotificationCenterTests: XCTestCase {
         settings.notificationMemoryEnabled = true
         settings.notificationSoundEnabled = true
         settings.notificationReplyEnabled = true
+        settings.heartbeatTrackGitChanges = true
+        settings.heartbeatTrackCodingSessionChanges = true
         settings.heartbeatChangeAlertEnabled = true
         settings.heartbeatChangeAlertCooldownMinutes = 30
     }


### PR DESCRIPTION
## Summary
- add heartbeat change-tracking source toggles in settings model (`heartbeatTrackGitChanges`, `heartbeatTrackCodingSessionChanges`)
- apply source toggles in `HeartbeatService.detectChangeEvents` so Git/session change streams can be independently enabled/disabled
- extend Heartbeat settings UI with a new `변화 추적` section:
  - Git change tracking toggle
  - coding-session change tracking toggle
  - change alert toggle + cooldown stepper
- extend Heartbeat status UI with recent change list (up to 5), severity badge, source label, relative time, and empty state
- add/update tests for source-toggle behavior and settings persistence/defaults

## Test Evidence
- `xcodebuild -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/HeartbeatServiceTests -only-testing:DochiTests/NotificationCenterTests test`

## Spec Impact
- None

Closes #433
