### PR TITLE
feat: orchestration 실행 챌린지 승인 게이트 추가

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -118,6 +118,7 @@ struct DochiApp: App {
     private let deviceHeartbeatService: DeviceHeartbeatService
     private let controlPlaneService: LocalControlPlaneService
     private let controlPlaneTokenManager: ControlPlaneTokenManager
+    private let orchestrationApprovalStore: OrchestrationExecutionApprovalStore
 
     init() {
         let settings = AppSettings()
@@ -274,6 +275,8 @@ struct DochiApp: App {
 
         let controlPlaneTokenManager = ControlPlaneTokenManager()
         self.controlPlaneTokenManager = controlPlaneTokenManager
+        let orchestrationApprovalStore = OrchestrationExecutionApprovalStore()
+        self.orchestrationApprovalStore = orchestrationApprovalStore
         let orchestrationSummaryService = OrchestrationSummaryService()
         self.controlPlaneService = LocalControlPlaneService(
             methodHandler: { method, params in
@@ -284,7 +287,8 @@ struct DochiApp: App {
                     toolService: toolService,
                     externalToolManager: externalToolManager,
                     tokenManager: controlPlaneTokenManager,
-                    orchestrationSummaryService: orchestrationSummaryService
+                    orchestrationSummaryService: orchestrationSummaryService,
+                    orchestrationApprovalStore: orchestrationApprovalStore
                 )
             },
             authTokenProvider: { controlPlaneTokenManager.currentToken() }
@@ -767,7 +771,8 @@ struct DochiApp: App {
         toolService: BuiltInToolService,
         externalToolManager: ExternalToolSessionManagerProtocol,
         tokenManager: ControlPlaneTokenManager,
-        orchestrationSummaryService: any OrchestrationSummaryServiceProtocol
+        orchestrationSummaryService: any OrchestrationSummaryServiceProtocol,
+        orchestrationApprovalStore: OrchestrationExecutionApprovalStore
     ) async -> LocalControlPlaneMethodResult {
         switch method {
         case "app.ping":
@@ -952,8 +957,24 @@ struct DochiApp: App {
         case "bridge.orchestrator.guard_command":
             return await handleBridgeOrchestratorGuardCommand(params: params, externalToolManager: externalToolManager)
 
+        case "bridge.orchestrator.request":
+            return await handleBridgeOrchestratorRequest(
+                params: params,
+                orchestrationApprovalStore: orchestrationApprovalStore
+            )
+
+        case "bridge.orchestrator.approve":
+            return await handleBridgeOrchestratorApprove(
+                params: params,
+                orchestrationApprovalStore: orchestrationApprovalStore
+            )
+
         case "bridge.orchestrator.execute":
-            return await handleBridgeOrchestratorExecute(params: params, externalToolManager: externalToolManager)
+            return await handleBridgeOrchestratorExecute(
+                params: params,
+                externalToolManager: externalToolManager,
+                orchestrationApprovalStore: orchestrationApprovalStore
+            )
 
         case "bridge.orchestrator.status":
             return await handleBridgeOrchestratorStatus(
@@ -1660,6 +1681,73 @@ struct DochiApp: App {
         ])
     }
 
+    nonisolated private static func handleBridgeOrchestratorRequest(
+        params: [String: Any],
+        orchestrationApprovalStore: OrchestrationExecutionApprovalStore
+    ) async -> LocalControlPlaneMethodResult {
+        guard let command = nonEmptyString(params["command"]) else {
+            return .failure(code: "missing_command", message: "command가 필요합니다.")
+        }
+        let repositoryRoot = nonEmptyString(params["repository_root"])
+        let ttlSeconds = intValue(params["ttl_seconds"])
+
+        let challenge = await orchestrationApprovalStore.create(
+            command: command,
+            repositoryRoot: repositoryRoot,
+            ttlSeconds: ttlSeconds
+        )
+        let snapshot = challenge.snapshot
+        Log.runtime.info(
+            "ControlPlane approval request created: id=\(snapshot.approvalId), expires=\(isoTimestamp(snapshot.expiresAt))"
+        )
+
+        return .ok([
+            "approval_id": snapshot.approvalId,
+            "challenge_code": snapshot.challengeCode,
+            "status": snapshot.status.rawValue,
+            "command": snapshot.command,
+            "repository_root": snapshot.repositoryRoot ?? NSNull(),
+            "created_at": isoTimestamp(snapshot.createdAt),
+            "expires_at": isoTimestamp(snapshot.expiresAt),
+        ])
+    }
+
+    nonisolated private static func handleBridgeOrchestratorApprove(
+        params: [String: Any],
+        orchestrationApprovalStore: OrchestrationExecutionApprovalStore
+    ) async -> LocalControlPlaneMethodResult {
+        guard let approvalId = nonEmptyString(params["approval_id"]) else {
+            return .failure(code: "missing_approval_id", message: "approval_id가 필요합니다.")
+        }
+        guard let challengeCode = nonEmptyString(params["challenge_code"]) else {
+            return .failure(code: "missing_challenge_code", message: "challenge_code가 필요합니다.")
+        }
+
+        let decision = await orchestrationApprovalStore.approve(
+            approvalId: approvalId,
+            challengeCode: challengeCode
+        )
+
+        guard decision.isAllowed else {
+            return .failure(
+                code: decision.failureCode?.rawValue ?? "approval_failed",
+                message: decision.message
+            )
+        }
+
+        guard let snapshot = decision.snapshot else {
+            return .failure(code: "approval_missing_snapshot", message: "승인 상태를 확인할 수 없습니다.")
+        }
+        Log.runtime.info("ControlPlane approval confirmed: id=\(snapshot.approvalId)")
+
+        return .ok([
+            "approval_id": snapshot.approvalId,
+            "status": snapshot.status.rawValue,
+            "approved_at": snapshot.approvedAt.map(isoTimestamp(_:)) ?? NSNull(),
+            "expires_at": isoTimestamp(snapshot.expiresAt),
+        ])
+    }
+
     nonisolated static func handleBridgeOrchestratorSelectSession(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
@@ -1727,13 +1815,21 @@ struct DochiApp: App {
 
     nonisolated static func handleBridgeOrchestratorExecute(
         params: [String: Any],
-        externalToolManager: ExternalToolSessionManagerProtocol
+        externalToolManager: ExternalToolSessionManagerProtocol,
+        orchestrationApprovalStore: OrchestrationExecutionApprovalStore
     ) async -> LocalControlPlaneMethodResult {
         guard let command = nonEmptyString(params["command"]) else {
             return .failure(code: "missing_command", message: "command가 필요합니다.")
         }
         let repositoryRoot = nonEmptyString(params["repository_root"])
         let confirmed = boolValue(params["confirmed"]) ?? false
+        let approvalId = nonEmptyString(params["approval_id"])
+        if !confirmed, approvalId == nil {
+            return .failure(
+                code: "approval_required",
+                message: "실행 전 승인 요청이 필요합니다. bridge.orchestrator.request/approve를 먼저 호출하거나 confirmed=true를 사용하세요."
+            )
+        }
         let selection = await externalToolManager.selectSessionForOrchestration(repositoryRoot: repositoryRoot)
 
         switch selection.action {
@@ -1751,13 +1847,39 @@ struct DochiApp: App {
             if decision.kind == .denied {
                 return .failure(code: decision.policyCode.rawValue, message: decision.reason)
             }
-            if decision.kind == .confirmationRequired, !confirmed {
+            if decision.kind == .confirmationRequired, !confirmed, approvalId == nil {
                 return .failure(code: decision.policyCode.rawValue, message: decision.reason)
             }
 
             guard let runtimeSessionId = session.runtimeSessionId,
                   let runtimeUUID = UUID(uuidString: runtimeSessionId) else {
                 return .failure(code: "runtime_session_missing", message: "실행 가능한 runtime_session_id를 찾을 수 없습니다.")
+            }
+
+            var approvalPayload: [String: Any] = [
+                "mode": confirmed ? "legacy_confirmed" : "challenge_required"
+            ]
+            if let approvalId {
+                let approvalDecision = await orchestrationApprovalStore.consumeExecution(
+                    approvalId: approvalId,
+                    command: command,
+                    repositoryRoot: repositoryRoot
+                )
+                guard approvalDecision.isAllowed else {
+                    return .failure(
+                        code: approvalDecision.failureCode?.rawValue ?? "approval_failed",
+                        message: approvalDecision.message
+                    )
+                }
+                if let snapshot = approvalDecision.snapshot {
+                    approvalPayload = [
+                        "mode": "challenge",
+                        "approval_id": snapshot.approvalId,
+                        "status": snapshot.status.rawValue,
+                        "consumed_at": snapshot.consumedAt.map(isoTimestamp(_:)) ?? NSNull(),
+                        "expires_at": isoTimestamp(snapshot.expiresAt),
+                    ]
+                }
             }
 
             do {
@@ -1773,6 +1895,7 @@ struct DochiApp: App {
                         "reason": decision.reason,
                         "is_destructive_command": decision.isDestructiveCommand,
                     ],
+                    "approval": approvalPayload,
                 ])
             } catch {
                 return .failure(code: "bridge_send_failed", message: error.localizedDescription)
@@ -2237,6 +2360,19 @@ struct DochiApp: App {
             default:
                 return nil
             }
+        default:
+            return nil
+        }
+    }
+
+    nonisolated private static func intValue(_ value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            return int
+        case let number as NSNumber:
+            return number.intValue
+        case let string as String:
+            return Int(string.trimmingCharacters(in: .whitespacesAndNewlines))
         default:
             return nil
         }

--- a/Dochi/Services/ControlPlane/OrchestrationExecutionApprovalStore.swift
+++ b/Dochi/Services/ControlPlane/OrchestrationExecutionApprovalStore.swift
@@ -1,0 +1,343 @@
+import Foundation
+
+enum OrchestrationExecutionApprovalFailureCode: String, Sendable {
+    case approvalNotFound = "approval_not_found"
+    case approvalExpired = "approval_expired"
+    case approvalCodeMismatch = "approval_code_mismatch"
+    case approvalNotApproved = "approval_not_approved"
+    case approvalAlreadyConsumed = "approval_already_consumed"
+    case approvalContextMismatch = "approval_context_mismatch"
+}
+
+struct OrchestrationExecutionApprovalSnapshot: Sendable {
+    enum Status: String, Sendable {
+        case pending
+        case approved
+        case expired
+        case consumed
+    }
+
+    let approvalId: String
+    let challengeCode: String
+    let command: String
+    let repositoryRoot: String?
+    let status: Status
+    let createdAt: Date
+    let expiresAt: Date
+    let approvedAt: Date?
+    let consumedAt: Date?
+}
+
+struct OrchestrationExecutionApprovalChallenge: Sendable {
+    let snapshot: OrchestrationExecutionApprovalSnapshot
+}
+
+struct OrchestrationExecutionApprovalValidation: Sendable {
+    let isAllowed: Bool
+    let failureCode: OrchestrationExecutionApprovalFailureCode?
+    let message: String
+    let snapshot: OrchestrationExecutionApprovalSnapshot?
+
+    static func allowed(
+        message: String,
+        snapshot: OrchestrationExecutionApprovalSnapshot?
+    ) -> OrchestrationExecutionApprovalValidation {
+        OrchestrationExecutionApprovalValidation(
+            isAllowed: true,
+            failureCode: nil,
+            message: message,
+            snapshot: snapshot
+        )
+    }
+
+    static func denied(
+        code: OrchestrationExecutionApprovalFailureCode,
+        message: String,
+        snapshot: OrchestrationExecutionApprovalSnapshot?
+    ) -> OrchestrationExecutionApprovalValidation {
+        OrchestrationExecutionApprovalValidation(
+            isAllowed: false,
+            failureCode: code,
+            message: message,
+            snapshot: snapshot
+        )
+    }
+}
+
+actor OrchestrationExecutionApprovalStore {
+    private struct Entry: Sendable {
+        enum Status: Sendable {
+            case pending
+            case approved
+            case expired
+            case consumed
+        }
+
+        let approvalId: String
+        let challengeCode: String
+        let command: String
+        let repositoryRoot: String?
+        var status: Status
+        let createdAt: Date
+        let expiresAt: Date
+        var approvedAt: Date?
+        var consumedAt: Date?
+    }
+
+    private let defaultTTLSeconds: Int
+    private let minTTLSeconds: Int
+    private let maxTTLSeconds: Int
+    private var entries: [String: Entry] = [:]
+
+    init(
+        defaultTTLSeconds: Int = 120,
+        minTTLSeconds: Int = 30,
+        maxTTLSeconds: Int = 900
+    ) {
+        self.defaultTTLSeconds = max(1, defaultTTLSeconds)
+        self.minTTLSeconds = max(1, minTTLSeconds)
+        self.maxTTLSeconds = max(self.minTTLSeconds, maxTTLSeconds)
+    }
+
+    func create(
+        command: String,
+        repositoryRoot: String?,
+        ttlSeconds: Int?,
+        now: Date = Date()
+    ) -> OrchestrationExecutionApprovalChallenge {
+        pruneExpired(now: now)
+        pruneTerminalEntries(now: now)
+
+        let effectiveTTL = clampTTL(ttlSeconds)
+        let approvalId = UUID().uuidString
+        let challengeCode = Self.makeChallengeCode()
+        let normalizedCommand = normalizeCommand(command)
+        let normalizedRoot = normalizeRepositoryRoot(repositoryRoot)
+
+        let entry = Entry(
+            approvalId: approvalId,
+            challengeCode: challengeCode,
+            command: normalizedCommand,
+            repositoryRoot: normalizedRoot,
+            status: .pending,
+            createdAt: now,
+            expiresAt: now.addingTimeInterval(TimeInterval(effectiveTTL)),
+            approvedAt: nil,
+            consumedAt: nil
+        )
+        entries[approvalId] = entry
+
+        return OrchestrationExecutionApprovalChallenge(snapshot: snapshot(from: entry))
+    }
+
+    func approve(
+        approvalId: String,
+        challengeCode: String,
+        now: Date = Date()
+    ) -> OrchestrationExecutionApprovalValidation {
+        mutateAndResolve(
+            approvalId: approvalId,
+            now: now,
+            expectedCommand: nil,
+            expectedRepositoryRoot: nil,
+            challengeCode: challengeCode,
+            consume: false
+        )
+    }
+
+    func consumeExecution(
+        approvalId: String,
+        command: String,
+        repositoryRoot: String?,
+        now: Date = Date()
+    ) -> OrchestrationExecutionApprovalValidation {
+        mutateAndResolve(
+            approvalId: approvalId,
+            now: now,
+            expectedCommand: command,
+            expectedRepositoryRoot: repositoryRoot,
+            challengeCode: nil,
+            consume: true
+        )
+    }
+
+    func snapshot(
+        approvalId: String,
+        now: Date = Date()
+    ) -> OrchestrationExecutionApprovalSnapshot? {
+        pruneExpired(now: now)
+        guard let entry = entries[approvalId] else { return nil }
+        return snapshot(from: entry)
+    }
+
+    private func mutateAndResolve(
+        approvalId rawApprovalId: String,
+        now: Date,
+        expectedCommand: String?,
+        expectedRepositoryRoot: String?,
+        challengeCode: String?,
+        consume: Bool
+    ) -> OrchestrationExecutionApprovalValidation {
+        pruneExpired(now: now)
+
+        let approvalId = rawApprovalId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !approvalId.isEmpty, var entry = entries[approvalId] else {
+            return .denied(
+                code: .approvalNotFound,
+                message: "승인 요청을 찾을 수 없습니다.",
+                snapshot: nil
+            )
+        }
+
+        if entry.expiresAt <= now, entry.status == .pending || entry.status == .approved {
+            entry.status = .expired
+            entries[approvalId] = entry
+        }
+
+        switch entry.status {
+        case .expired:
+            return .denied(
+                code: .approvalExpired,
+                message: "승인 요청이 만료되었습니다.",
+                snapshot: snapshot(from: entry)
+            )
+        case .consumed:
+            return .denied(
+                code: .approvalAlreadyConsumed,
+                message: "이미 사용된 승인 요청입니다.",
+                snapshot: snapshot(from: entry)
+            )
+        case .pending:
+            break
+        case .approved:
+            break
+        }
+
+        if let challengeCode {
+            let normalizedCode = challengeCode.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard normalizedCode == entry.challengeCode else {
+                return .denied(
+                    code: .approvalCodeMismatch,
+                    message: "승인 코드가 일치하지 않습니다.",
+                    snapshot: snapshot(from: entry)
+                )
+            }
+            entry.status = .approved
+            entry.approvedAt = now
+            entries[approvalId] = entry
+            return .allowed(
+                message: "승인되었습니다.",
+                snapshot: snapshot(from: entry)
+            )
+        }
+
+        if let expectedCommand {
+            let normalizedCommand = normalizeCommand(expectedCommand)
+            let normalizedRoot = normalizeRepositoryRoot(expectedRepositoryRoot)
+            guard normalizedCommand == entry.command, normalizedRoot == entry.repositoryRoot else {
+                return .denied(
+                    code: .approvalContextMismatch,
+                    message: "승인 요청의 실행 컨텍스트가 다릅니다.",
+                    snapshot: snapshot(from: entry)
+                )
+            }
+        }
+
+        guard entry.status == .approved else {
+            return .denied(
+                code: .approvalNotApproved,
+                message: "아직 승인되지 않은 요청입니다.",
+                snapshot: snapshot(from: entry)
+            )
+        }
+
+        if consume {
+            entry.status = .consumed
+            entry.consumedAt = now
+            entries[approvalId] = entry
+            return .allowed(
+                message: "승인 요청이 사용되었습니다.",
+                snapshot: snapshot(from: entry)
+            )
+        }
+
+        return .allowed(
+            message: "승인 상태입니다.",
+            snapshot: snapshot(from: entry)
+        )
+    }
+
+    private func pruneExpired(now: Date) {
+        guard !entries.isEmpty else { return }
+        var updated = entries
+        for key in updated.keys {
+            guard var entry = updated[key] else { continue }
+            if (entry.status == .pending || entry.status == .approved), entry.expiresAt <= now {
+                entry.status = .expired
+                updated[key] = entry
+            }
+        }
+        entries = updated
+    }
+
+    private func pruneTerminalEntries(now: Date) {
+        let retentionSeconds: TimeInterval = 86_400
+        entries = entries.filter { _, entry in
+            let terminalAt: Date
+            switch entry.status {
+            case .pending, .approved:
+                return true
+            case .expired:
+                terminalAt = entry.expiresAt
+            case .consumed:
+                terminalAt = entry.consumedAt ?? entry.expiresAt
+            }
+            return now.timeIntervalSince(terminalAt) < retentionSeconds
+        }
+    }
+
+    private func clampTTL(_ ttlSeconds: Int?) -> Int {
+        guard let ttlSeconds else { return defaultTTLSeconds }
+        return min(max(ttlSeconds, minTTLSeconds), maxTTLSeconds)
+    }
+
+    private func snapshot(from entry: Entry) -> OrchestrationExecutionApprovalSnapshot {
+        let status: OrchestrationExecutionApprovalSnapshot.Status
+        switch entry.status {
+        case .pending:
+            status = .pending
+        case .approved:
+            status = .approved
+        case .expired:
+            status = .expired
+        case .consumed:
+            status = .consumed
+        }
+
+        return OrchestrationExecutionApprovalSnapshot(
+            approvalId: entry.approvalId,
+            challengeCode: entry.challengeCode,
+            command: entry.command,
+            repositoryRoot: entry.repositoryRoot,
+            status: status,
+            createdAt: entry.createdAt,
+            expiresAt: entry.expiresAt,
+            approvedAt: entry.approvedAt,
+            consumedAt: entry.consumedAt
+        )
+    }
+
+    private func normalizeCommand(_ command: String) -> String {
+        command.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func normalizeRepositoryRoot(_ repositoryRoot: String?) -> String? {
+        guard let repositoryRoot else { return nil }
+        let trimmed = repositoryRoot.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func makeChallengeCode() -> String {
+        String(format: "%06d", Int.random(in: 0...999_999))
+    }
+}

--- a/DochiTests/OrchestrationExecutionApprovalStoreTests.swift
+++ b/DochiTests/OrchestrationExecutionApprovalStoreTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import Dochi
+
+final class OrchestrationExecutionApprovalStoreTests: XCTestCase {
+    func testApproveAndConsumeSucceedsOnce() async throws {
+        let store = OrchestrationExecutionApprovalStore(defaultTTLSeconds: 120)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let challenge = await store.create(
+            command: "make test",
+            repositoryRoot: "/tmp/repo",
+            ttlSeconds: 120,
+            now: now
+        )
+        let approvalId = challenge.snapshot.approvalId
+        let code = challenge.snapshot.challengeCode
+
+        let approved = await store.approve(
+            approvalId: approvalId,
+            challengeCode: code,
+            now: now.addingTimeInterval(1)
+        )
+        XCTAssertTrue(approved.isAllowed)
+
+        let consumed = await store.consumeExecution(
+            approvalId: approvalId,
+            command: "make test",
+            repositoryRoot: "/tmp/repo",
+            now: now.addingTimeInterval(2)
+        )
+        XCTAssertTrue(consumed.isAllowed)
+        XCTAssertEqual(consumed.snapshot?.status, .consumed)
+
+        let reused = await store.consumeExecution(
+            approvalId: approvalId,
+            command: "make test",
+            repositoryRoot: "/tmp/repo",
+            now: now.addingTimeInterval(3)
+        )
+        XCTAssertFalse(reused.isAllowed)
+        XCTAssertEqual(reused.failureCode, .approvalAlreadyConsumed)
+    }
+
+    func testApproveFailsOnWrongChallengeCode() async throws {
+        let store = OrchestrationExecutionApprovalStore(defaultTTLSeconds: 120)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let challenge = await store.create(
+            command: "git status",
+            repositoryRoot: nil,
+            ttlSeconds: 120,
+            now: now
+        )
+
+        let approved = await store.approve(
+            approvalId: challenge.snapshot.approvalId,
+            challengeCode: "000000",
+            now: now.addingTimeInterval(1)
+        )
+        XCTAssertFalse(approved.isAllowed)
+        XCTAssertEqual(approved.failureCode, .approvalCodeMismatch)
+    }
+
+    func testApproveFailsAfterExpiry() async throws {
+        let store = OrchestrationExecutionApprovalStore(defaultTTLSeconds: 30, minTTLSeconds: 1, maxTTLSeconds: 60)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let challenge = await store.create(
+            command: "npm run build",
+            repositoryRoot: "/tmp/repo",
+            ttlSeconds: 1,
+            now: now
+        )
+        let approvalId = challenge.snapshot.approvalId
+        let code = challenge.snapshot.challengeCode
+
+        let expired = await store.approve(
+            approvalId: approvalId,
+            challengeCode: code,
+            now: now.addingTimeInterval(5)
+        )
+        XCTAssertFalse(expired.isAllowed)
+        XCTAssertEqual(expired.failureCode, .approvalExpired)
+    }
+
+    func testConsumeFailsOnCommandOrRepositoryMismatch() async throws {
+        let store = OrchestrationExecutionApprovalStore(defaultTTLSeconds: 120)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let challenge = await store.create(
+            command: "swift test",
+            repositoryRoot: "/tmp/repo-a",
+            ttlSeconds: 120,
+            now: now
+        )
+        _ = await store.approve(
+            approvalId: challenge.snapshot.approvalId,
+            challengeCode: challenge.snapshot.challengeCode,
+            now: now.addingTimeInterval(1)
+        )
+
+        let mismatchedCommand = await store.consumeExecution(
+            approvalId: challenge.snapshot.approvalId,
+            command: "swift build",
+            repositoryRoot: "/tmp/repo-a",
+            now: now.addingTimeInterval(2)
+        )
+        XCTAssertFalse(mismatchedCommand.isAllowed)
+        XCTAssertEqual(mismatchedCommand.failureCode, .approvalContextMismatch)
+
+        let mismatchedRepo = await store.consumeExecution(
+            approvalId: challenge.snapshot.approvalId,
+            command: "swift test",
+            repositoryRoot: "/tmp/repo-b",
+            now: now.addingTimeInterval(3)
+        )
+        XCTAssertFalse(mismatchedRepo.isAllowed)
+        XCTAssertEqual(mismatchedRepo.failureCode, .approvalContextMismatch)
+    }
+}

--- a/DochiTests/OrchestratorSessionSelectorTests.swift
+++ b/DochiTests/OrchestratorSessionSelectorTests.swift
@@ -244,8 +244,10 @@ final class DochiAppOrchestratorBridgeFlowTests: XCTestCase {
             params: [
                 "repository_root": "/tmp/repo",
                 "command": "git status",
+                "confirmed": true,
             ],
-            externalToolManager: manager
+            externalToolManager: manager,
+            orchestrationApprovalStore: OrchestrationExecutionApprovalStore()
         )
 
         XCTAssertTrue(result.success)
@@ -259,6 +261,144 @@ final class DochiAppOrchestratorBridgeFlowTests: XCTestCase {
         let guardPayload = try XCTUnwrap(result.result["guard"] as? [String: Any])
         XCTAssertEqual(guardPayload["decision"] as? String, "allowed")
         XCTAssertEqual(guardPayload["policy_code"] as? String, "policy_t1_allow_non_destructive")
+    }
+
+    func testHandleBridgeOrchestratorExecuteRequiresApprovalWithoutConfirmed() async throws {
+        let manager = MockExternalToolSessionManager()
+        let profile = ExternalToolProfile(
+            name: "Codex",
+            command: "codex",
+            workingDirectory: "/tmp/repo"
+        )
+        manager.saveProfile(profile)
+
+        let runtimeSessionId = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        manager.sessions = [
+            ExternalToolSession(
+                id: runtimeSessionId,
+                profileId: profile.id,
+                tmuxSessionName: "mock-session",
+                status: .idle,
+                startedAt: Date()
+            ),
+        ]
+
+        manager.mockOrchestrationSelection = OrchestrationSessionSelection(
+            action: .attachT1,
+            reason: "attach path",
+            repositoryRoot: "/tmp/repo",
+            selectedSession: makeUnifiedSession(
+                provider: "codex",
+                nativeSessionId: "sess-approval-required",
+                runtimeSessionId: runtimeSessionId.uuidString,
+                tier: .t1Attach,
+                state: .active,
+                repositoryRoot: "/tmp/repo"
+            )
+        )
+        manager.mockOrchestrationDecision = OrchestrationExecutionDecision(
+            kind: .allowed,
+            policyCode: .t1AllowNonDestructive,
+            commandClass: .nonDestructive,
+            reason: "allowed",
+            isDestructiveCommand: false
+        )
+
+        let result = await DochiApp.handleBridgeOrchestratorExecute(
+            params: [
+                "repository_root": "/tmp/repo",
+                "command": "git status",
+            ],
+            externalToolManager: manager,
+            orchestrationApprovalStore: OrchestrationExecutionApprovalStore()
+        )
+
+        XCTAssertFalse(result.success)
+        XCTAssertEqual(result.errorCode, "approval_required")
+        XCTAssertEqual(manager.sendCommandCallCount, 0)
+    }
+
+    func testHandleBridgeOrchestratorExecuteConsumesChallengeApproval() async throws {
+        let manager = MockExternalToolSessionManager()
+        let profile = ExternalToolProfile(
+            name: "Codex",
+            command: "codex",
+            workingDirectory: "/tmp/repo"
+        )
+        manager.saveProfile(profile)
+
+        let runtimeSessionId = UUID(uuidString: "44444444-4444-4444-4444-444444444444")!
+        manager.sessions = [
+            ExternalToolSession(
+                id: runtimeSessionId,
+                profileId: profile.id,
+                tmuxSessionName: "mock-session",
+                status: .idle,
+                startedAt: Date()
+            ),
+        ]
+
+        manager.mockOrchestrationSelection = OrchestrationSessionSelection(
+            action: .attachT1,
+            reason: "attach path",
+            repositoryRoot: "/tmp/repo",
+            selectedSession: makeUnifiedSession(
+                provider: "codex",
+                nativeSessionId: "sess-challenge",
+                runtimeSessionId: runtimeSessionId.uuidString,
+                tier: .t1Attach,
+                state: .active,
+                repositoryRoot: "/tmp/repo"
+            )
+        )
+        manager.mockOrchestrationDecision = OrchestrationExecutionDecision(
+            kind: .allowed,
+            policyCode: .t1AllowNonDestructive,
+            commandClass: .nonDestructive,
+            reason: "allowed",
+            isDestructiveCommand: false
+        )
+
+        let approvalStore = OrchestrationExecutionApprovalStore()
+        let challenge = await approvalStore.create(
+            command: "git status",
+            repositoryRoot: "/tmp/repo",
+            ttlSeconds: 120
+        )
+        _ = await approvalStore.approve(
+            approvalId: challenge.snapshot.approvalId,
+            challengeCode: challenge.snapshot.challengeCode
+        )
+
+        let firstResult = await DochiApp.handleBridgeOrchestratorExecute(
+            params: [
+                "repository_root": "/tmp/repo",
+                "command": "git status",
+                "approval_id": challenge.snapshot.approvalId,
+            ],
+            externalToolManager: manager,
+            orchestrationApprovalStore: approvalStore
+        )
+
+        XCTAssertTrue(firstResult.success)
+        XCTAssertEqual(manager.sendCommandCallCount, 1)
+        let approval = try XCTUnwrap(firstResult.result["approval"] as? [String: Any])
+        XCTAssertEqual(approval["mode"] as? String, "challenge")
+        XCTAssertEqual(approval["status"] as? String, "consumed")
+
+        let secondResult = await DochiApp.handleBridgeOrchestratorExecute(
+            params: [
+                "repository_root": "/tmp/repo",
+                "command": "git status",
+                "approval_id": challenge.snapshot.approvalId,
+            ],
+            externalToolManager: manager,
+            orchestrationApprovalStore: approvalStore
+        )
+
+        XCTAssertFalse(secondResult.success)
+        XCTAssertEqual(secondResult.errorCode, "approval_already_consumed")
+        XCTAssertEqual(manager.sendCommandCallCount, 1)
     }
 
     func testHandleBridgeOrchestratorStatusBuildsSummaryContract() async throws {


### PR DESCRIPTION
## Summary
- add `OrchestrationExecutionApprovalStore` actor for challenge issuance, approval, one-time consume, and expiry/terminal pruning
- add control-plane methods `bridge.orchestrator.request` and `bridge.orchestrator.approve`
- require approval for `bridge.orchestrator.execute` unless legacy `confirmed=true` is provided, and consume `approval_id` with command/repo context binding
- extend orchestrator bridge tests for approval-required and challenge-consume flows

## Linked Issue
- Closes #438

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/OrchestrationExecutionApprovalStoreTests -only-testing:DochiTests/DochiAppOrchestratorBridgeFlowTests`

## Spec Impact
- None (implementation hardening for existing control-plane orchestrator flow)
