### PR TITLE
feat: Telegram bridge/orchestrator CLI parity expansion

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -1504,7 +1504,7 @@ struct DochiApp: App {
         ])
     }
 
-    nonisolated private static func handleBridgeRoots(
+    nonisolated static func handleBridgeRoots(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
@@ -2020,7 +2020,7 @@ struct DochiApp: App {
         ])
     }
 
-    nonisolated private static func handleBridgeOrchestratorInterrupt(
+    nonisolated static func handleBridgeOrchestratorInterrupt(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
@@ -2100,7 +2100,7 @@ struct DochiApp: App {
         ])
     }
 
-    nonisolated private static func handleBridgeRepositoryList(
+    nonisolated static func handleBridgeRepositoryList(
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
         let repositories = await MainActor.run {
@@ -2115,7 +2115,7 @@ struct DochiApp: App {
         ])
     }
 
-    nonisolated private static func handleBridgeRepositoryInit(
+    nonisolated static func handleBridgeRepositoryInit(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
@@ -2142,7 +2142,7 @@ struct DochiApp: App {
         }
     }
 
-    nonisolated private static func handleBridgeRepositoryClone(
+    nonisolated static func handleBridgeRepositoryClone(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
@@ -2169,7 +2169,7 @@ struct DochiApp: App {
         }
     }
 
-    nonisolated private static func handleBridgeRepositoryAttach(
+    nonisolated static func handleBridgeRepositoryAttach(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {
@@ -2188,7 +2188,7 @@ struct DochiApp: App {
         }
     }
 
-    nonisolated private static func handleBridgeRepositoryRemove(
+    nonisolated static func handleBridgeRepositoryRemove(
         params: [String: Any],
         externalToolManager: ExternalToolSessionManagerProtocol
     ) async -> LocalControlPlaneMethodResult {

--- a/Dochi/Services/Telegram/TelegramBridgeCommandParser.swift
+++ b/Dochi/Services/Telegram/TelegramBridgeCommandParser.swift
@@ -7,9 +7,16 @@ enum TelegramBridgeCommand: Equatable {
         workingDirectory: String?,
         forceWorkingDirectory: Bool
     )
+    case bridgeRoots(limit: Int, searchPaths: [String])
     case bridgeStatus(sessionId: String?)
     case bridgeSend(sessionId: String, command: String)
     case bridgeRead(sessionId: String, lines: Int)
+    case bridgeRepoList
+    case bridgeRepoInit(path: String, defaultBranch: String, createReadme: Bool, createGitignore: Bool)
+    case bridgeRepoClone(remoteURL: String, destinationPath: String, branch: String?)
+    case bridgeRepoAttach(path: String)
+    case bridgeRepoRemove(repositoryId: String, deleteDirectory: Bool)
+    case orchSelect(repositoryRoot: String?)
     case orchRequest(command: String, repositoryRoot: String?, ttlSeconds: Int?)
     case orchApprove(approvalId: String, challengeCode: String)
     case orchExecute(
@@ -19,6 +26,8 @@ enum TelegramBridgeCommand: Equatable {
         approvalId: String?
     )
     case orchStatus(repositoryRoot: String?, sessionId: String?, lines: Int)
+    case orchInterrupt(repositoryRoot: String?, sessionId: String?)
+    case orchSummarize(repositoryRoot: String?, sessionId: String?, lines: Int)
 }
 
 enum TelegramBridgeCommandRoute: Equatable {
@@ -58,12 +67,18 @@ enum TelegramBridgeCommandParser {
         switch subcommand {
         case "open":
             return parseBridgeOpen(rest)
+        case "roots":
+            return parseBridgeRoots(rest)
         case "status":
             return parseBridgeStatus(rest)
         case "send":
             return parseBridgeSend(rest)
         case "read":
             return parseBridgeRead(rest)
+        case "repo":
+            return parseBridgeRepo(rest)
+        case "orchestrator":
+            return parseOrchestrator(rest, usage: bridgeUsage, defaultToStatus: true)
         default:
             return .usageError(bridgeUsage)
         }
@@ -165,27 +180,192 @@ enum TelegramBridgeCommandParser {
         return .command(.bridgeRead(sessionId: sessionId, lines: max(1, min(500, lines))))
     }
 
+    private static func parseBridgeRoots(_ args: [String]) -> TelegramBridgeCommandRoute {
+        var limit = 20
+        var searchPaths: [String] = []
+
+        var index = 0
+        while index < args.count {
+            let token = args[index]
+            switch token {
+            case "--limit":
+                guard index + 1 < args.count, let parsed = Int(args[index + 1]) else {
+                    return .usageError(bridgeUsage)
+                }
+                limit = max(1, min(200, parsed))
+                index += 2
+            case "--path":
+                guard index + 1 < args.count else {
+                    return .usageError(bridgeUsage)
+                }
+                searchPaths.append(args[index + 1])
+                index += 2
+            default:
+                return .usageError(bridgeUsage)
+            }
+        }
+
+        return .command(.bridgeRoots(limit: limit, searchPaths: searchPaths))
+    }
+
+    private static func parseBridgeRepo(_ args: [String]) -> TelegramBridgeCommandRoute {
+        let subcommand = args.first?.lowercased() ?? "list"
+        let rest = Array(args.dropFirst())
+
+        switch subcommand {
+        case "list":
+            guard rest.isEmpty else {
+                return .usageError(bridgeUsage)
+            }
+            return .command(.bridgeRepoList)
+
+        case "init":
+            guard let path = rest.first, !path.hasPrefix("--") else {
+                return .usageError(bridgeUsage)
+            }
+
+            var defaultBranch = "main"
+            var createReadme = false
+            var createGitignore = false
+            var index = 1
+            while index < rest.count {
+                switch rest[index] {
+                case "--branch":
+                    guard index + 1 < rest.count else {
+                        return .usageError(bridgeUsage)
+                    }
+                    defaultBranch = rest[index + 1]
+                    index += 2
+                case "--readme":
+                    createReadme = true
+                    index += 1
+                case "--gitignore":
+                    createGitignore = true
+                    index += 1
+                default:
+                    return .usageError(bridgeUsage)
+                }
+            }
+
+            return .command(.bridgeRepoInit(
+                path: path,
+                defaultBranch: defaultBranch,
+                createReadme: createReadme,
+                createGitignore: createGitignore
+            ))
+
+        case "clone":
+            guard rest.count >= 2 else {
+                return .usageError(bridgeUsage)
+            }
+            let remoteURL = rest[0]
+            let destinationPath = rest[1]
+            var branch: String?
+            var index = 2
+            while index < rest.count {
+                switch rest[index] {
+                case "--branch":
+                    guard index + 1 < rest.count else {
+                        return .usageError(bridgeUsage)
+                    }
+                    branch = rest[index + 1]
+                    index += 2
+                default:
+                    return .usageError(bridgeUsage)
+                }
+            }
+
+            return .command(.bridgeRepoClone(
+                remoteURL: remoteURL,
+                destinationPath: destinationPath,
+                branch: nonEmpty(branch)
+            ))
+
+        case "attach":
+            guard rest.count == 1 else {
+                return .usageError(bridgeUsage)
+            }
+            return .command(.bridgeRepoAttach(path: rest[0]))
+
+        case "remove":
+            guard let repositoryId = rest.first else {
+                return .usageError(bridgeUsage)
+            }
+            var deleteDirectory = false
+            var index = 1
+            while index < rest.count {
+                switch rest[index] {
+                case "--delete-directory":
+                    deleteDirectory = true
+                    index += 1
+                default:
+                    return .usageError(bridgeUsage)
+                }
+            }
+            return .command(.bridgeRepoRemove(repositoryId: repositoryId, deleteDirectory: deleteDirectory))
+
+        default:
+            return .usageError(bridgeUsage)
+        }
+    }
+
     private static func parseOrch(_ args: [String]) -> TelegramBridgeCommandRoute {
+        parseOrchestrator(args, usage: orchUsage, defaultToStatus: false)
+    }
+
+    private static func parseOrchestrator(
+        _ args: [String],
+        usage: String,
+        defaultToStatus: Bool
+    ) -> TelegramBridgeCommandRoute {
         guard let subcommand = args.first?.lowercased() else {
-            return .usageError(orchUsage)
+            if defaultToStatus {
+                return .command(.orchStatus(repositoryRoot: nil, sessionId: nil, lines: 120))
+            }
+            return .usageError(usage)
         }
         let rest = Array(args.dropFirst())
 
         switch subcommand {
+        case "select":
+            return parseOrchSelect(rest, usage: usage)
         case "request":
-            return parseOrchRequest(rest)
+            return parseOrchRequest(rest, usage: usage)
         case "approve":
-            return parseOrchApprove(rest)
+            return parseOrchApprove(rest, usage: usage)
         case "execute":
-            return parseOrchExecute(rest)
+            return parseOrchExecute(rest, usage: usage)
         case "status":
-            return parseOrchStatus(rest)
+            return parseOrchStatus(rest, usage: usage)
+        case "interrupt":
+            return parseOrchInterrupt(rest, usage: usage)
+        case "summarize":
+            return parseOrchSummarize(rest, usage: usage)
         default:
-            return .usageError(orchUsage)
+            return .usageError(usage)
         }
     }
 
-    private static func parseOrchRequest(_ args: [String]) -> TelegramBridgeCommandRoute {
+    private static func parseOrchSelect(_ args: [String], usage: String) -> TelegramBridgeCommandRoute {
+        var repositoryRoot: String?
+        var index = 0
+        while index < args.count {
+            switch args[index] {
+            case "--repo", "--repository-root":
+                guard index + 1 < args.count else {
+                    return .usageError(usage)
+                }
+                repositoryRoot = args[index + 1]
+                index += 2
+            default:
+                return .usageError(usage)
+            }
+        }
+
+        return .command(.orchSelect(repositoryRoot: nonEmpty(repositoryRoot)))
+    }
+
+    private static func parseOrchRequest(_ args: [String], usage: String) -> TelegramBridgeCommandRoute {
         var repositoryRoot: String?
         var ttlSeconds: Int?
         var commandTokens: [String] = []
@@ -196,13 +376,13 @@ enum TelegramBridgeCommandParser {
             switch token {
             case "--repo", "--repository-root":
                 guard index + 1 < args.count else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 repositoryRoot = args[index + 1]
                 index += 2
             case "--ttl", "--ttl-seconds":
                 guard index + 1 < args.count, let parsed = Int(args[index + 1]) else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 ttlSeconds = parsed
                 index += 2
@@ -214,7 +394,7 @@ enum TelegramBridgeCommandParser {
 
         let command = commandTokens.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !command.isEmpty else {
-            return .usageError(orchUsage)
+            return .usageError(usage)
         }
 
         return .command(.orchRequest(
@@ -224,7 +404,7 @@ enum TelegramBridgeCommandParser {
         ))
     }
 
-    private static func parseOrchApprove(_ args: [String]) -> TelegramBridgeCommandRoute {
+    private static func parseOrchApprove(_ args: [String], usage: String) -> TelegramBridgeCommandRoute {
         if args.count == 2, !args[0].hasPrefix("--"), !args[1].hasPrefix("--") {
             return .command(.orchApprove(approvalId: args[0], challengeCode: args[1]))
         }
@@ -237,29 +417,29 @@ enum TelegramBridgeCommandParser {
             switch token {
             case "--id", "--approval-id":
                 guard index + 1 < args.count else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 approvalId = args[index + 1]
                 index += 2
             case "--code", "--challenge-code":
                 guard index + 1 < args.count else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 challengeCode = args[index + 1]
                 index += 2
             default:
-                return .usageError(orchUsage)
+                return .usageError(usage)
             }
         }
 
         guard let approvalId = nonEmpty(approvalId), let challengeCode = nonEmpty(challengeCode) else {
-            return .usageError(orchUsage)
+            return .usageError(usage)
         }
 
         return .command(.orchApprove(approvalId: approvalId, challengeCode: challengeCode))
     }
 
-    private static func parseOrchExecute(_ args: [String]) -> TelegramBridgeCommandRoute {
+    private static func parseOrchExecute(_ args: [String], usage: String) -> TelegramBridgeCommandRoute {
         var repositoryRoot: String?
         var confirmed = false
         var approvalId: String?
@@ -271,7 +451,7 @@ enum TelegramBridgeCommandParser {
             switch token {
             case "--repo", "--repository-root":
                 guard index + 1 < args.count else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 repositoryRoot = args[index + 1]
                 index += 2
@@ -280,7 +460,7 @@ enum TelegramBridgeCommandParser {
                 index += 1
             case "--approval-id":
                 guard index + 1 < args.count else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 approvalId = args[index + 1]
                 index += 2
@@ -292,7 +472,7 @@ enum TelegramBridgeCommandParser {
 
         let command = commandTokens.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !command.isEmpty else {
-            return .usageError(orchUsage)
+            return .usageError(usage)
         }
 
         return .command(.orchExecute(
@@ -303,7 +483,7 @@ enum TelegramBridgeCommandParser {
         ))
     }
 
-    private static func parseOrchStatus(_ args: [String]) -> TelegramBridgeCommandRoute {
+    private static func parseOrchStatus(_ args: [String], usage: String) -> TelegramBridgeCommandRoute {
         var repositoryRoot: String?
         var sessionId: String?
         var lines = 120
@@ -314,36 +494,122 @@ enum TelegramBridgeCommandParser {
             switch token {
             case "--repo", "--repository-root":
                 guard index + 1 < args.count else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 repositoryRoot = args[index + 1]
                 index += 2
             case "--session":
                 guard index + 1 < args.count else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 sessionId = args[index + 1]
                 index += 2
             case "--lines":
                 guard index + 1 < args.count, let parsed = Int(args[index + 1]) else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 lines = max(1, min(500, parsed))
                 index += 2
             default:
                 if token.hasPrefix("--") {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
                 if sessionId == nil {
                     sessionId = token
                     index += 1
                 } else {
-                    return .usageError(orchUsage)
+                    return .usageError(usage)
                 }
             }
         }
 
         return .command(.orchStatus(
+            repositoryRoot: nonEmpty(repositoryRoot),
+            sessionId: nonEmpty(sessionId),
+            lines: lines
+        ))
+    }
+
+    private static func parseOrchInterrupt(_ args: [String], usage: String) -> TelegramBridgeCommandRoute {
+        var repositoryRoot: String?
+        var sessionId: String?
+
+        var index = 0
+        while index < args.count {
+            let token = args[index]
+            switch token {
+            case "--repo", "--repository-root":
+                guard index + 1 < args.count else {
+                    return .usageError(usage)
+                }
+                repositoryRoot = args[index + 1]
+                index += 2
+            case "--session":
+                guard index + 1 < args.count else {
+                    return .usageError(usage)
+                }
+                sessionId = args[index + 1]
+                index += 2
+            default:
+                if token.hasPrefix("--") {
+                    return .usageError(usage)
+                }
+                if sessionId == nil {
+                    sessionId = token
+                    index += 1
+                } else {
+                    return .usageError(usage)
+                }
+            }
+        }
+
+        return .command(.orchInterrupt(
+            repositoryRoot: nonEmpty(repositoryRoot),
+            sessionId: nonEmpty(sessionId)
+        ))
+    }
+
+    private static func parseOrchSummarize(_ args: [String], usage: String) -> TelegramBridgeCommandRoute {
+        var repositoryRoot: String?
+        var sessionId: String?
+        var lines = 160
+
+        var index = 0
+        while index < args.count {
+            let token = args[index]
+            switch token {
+            case "--repo", "--repository-root":
+                guard index + 1 < args.count else {
+                    return .usageError(usage)
+                }
+                repositoryRoot = args[index + 1]
+                index += 2
+            case "--session":
+                guard index + 1 < args.count else {
+                    return .usageError(usage)
+                }
+                sessionId = args[index + 1]
+                index += 2
+            case "--lines":
+                guard index + 1 < args.count, let parsed = Int(args[index + 1]) else {
+                    return .usageError(usage)
+                }
+                lines = max(1, min(500, parsed))
+                index += 2
+            default:
+                if token.hasPrefix("--") {
+                    return .usageError(usage)
+                }
+                if sessionId == nil {
+                    sessionId = token
+                    index += 1
+                } else {
+                    return .usageError(usage)
+                }
+            }
+        }
+
+        return .command(.orchSummarize(
             repositoryRoot: nonEmpty(repositoryRoot),
             sessionId: nonEmpty(sessionId),
             lines: lines
@@ -415,16 +681,26 @@ enum TelegramBridgeCommandParser {
     private static let bridgeUsage = """
     브리지 명령 사용법
     - /bridge open [codex|claude|aider] [--profile NAME] [--cwd PATH] [--force-cwd]
+    - /bridge roots [--limit N] [--path DIR]...
     - /bridge status [SESSION_ID]
     - /bridge send SESSION_ID COMMAND...
     - /bridge read SESSION_ID [LINES]
+    - /bridge repo list
+    - /bridge repo init PATH [--branch NAME] [--readme] [--gitignore]
+    - /bridge repo clone REMOTE_URL DEST_PATH [--branch NAME]
+    - /bridge repo attach PATH
+    - /bridge repo remove REPO_ID [--delete-directory]
+    - /bridge orchestrator [select|request|approve|execute|status|interrupt|summarize] ...
     """
 
     private static let orchUsage = """
     오케스트레이터 명령 사용법
+    - /orch select [--repo PATH]
     - /orch request COMMAND... [--repo PATH] [--ttl SECONDS]
     - /orch approve APPROVAL_ID CHALLENGE_CODE
     - /orch execute COMMAND... [--repo PATH] [--approval-id ID] [--confirmed]
     - /orch status [--repo PATH] [--session ID] [--lines N]
+    - /orch interrupt [--repo PATH] [--session ID]
+    - /orch summarize [--repo PATH] [--session ID] [--lines N]
     """
 }

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -2935,6 +2935,16 @@ final class DochiViewModel {
                 externalToolManager: manager
             )
 
+        case .bridgeRoots(let limit, let searchPaths):
+            var params: [String: Any] = ["limit": limit]
+            if !searchPaths.isEmpty {
+                params["search_paths"] = searchPaths
+            }
+            result = await DochiApp.handleBridgeRoots(
+                params: params,
+                externalToolManager: manager
+            )
+
         case .bridgeStatus(let sessionId):
             var params: [String: Any] = [:]
             if let sessionId {
@@ -2960,6 +2970,60 @@ final class DochiViewModel {
                     "session_id": sessionId,
                     "lines": lines,
                 ],
+                externalToolManager: manager
+            )
+
+        case .bridgeRepoList:
+            result = await DochiApp.handleBridgeRepositoryList(
+                externalToolManager: manager
+            )
+
+        case .bridgeRepoInit(let path, let defaultBranch, let createReadme, let createGitignore):
+            result = await DochiApp.handleBridgeRepositoryInit(
+                params: [
+                    "path": path,
+                    "default_branch": defaultBranch,
+                    "create_readme": createReadme,
+                    "create_gitignore": createGitignore,
+                ],
+                externalToolManager: manager
+            )
+
+        case .bridgeRepoClone(let remoteURL, let destinationPath, let branch):
+            var params: [String: Any] = [
+                "remote_url": remoteURL,
+                "destination_path": destinationPath,
+            ]
+            if let branch {
+                params["branch"] = branch
+            }
+            result = await DochiApp.handleBridgeRepositoryClone(
+                params: params,
+                externalToolManager: manager
+            )
+
+        case .bridgeRepoAttach(let path):
+            result = await DochiApp.handleBridgeRepositoryAttach(
+                params: ["path": path],
+                externalToolManager: manager
+            )
+
+        case .bridgeRepoRemove(let repositoryId, let deleteDirectory):
+            result = await DochiApp.handleBridgeRepositoryRemove(
+                params: [
+                    "repository_id": repositoryId,
+                    "delete_directory": deleteDirectory,
+                ],
+                externalToolManager: manager
+            )
+
+        case .orchSelect(let repositoryRoot):
+            var params: [String: Any] = [:]
+            if let repositoryRoot {
+                params["repository_root"] = repositoryRoot
+            }
+            result = await DochiApp.handleBridgeOrchestratorSelectSession(
+                params: params,
                 externalToolManager: manager
             )
 
@@ -3015,6 +3079,33 @@ final class DochiViewModel {
                 externalToolManager: manager,
                 orchestrationSummaryService: telegramOrchestrationSummaryService
             )
+
+        case .orchInterrupt(let repositoryRoot, let sessionId):
+            var params: [String: Any] = [:]
+            if let repositoryRoot {
+                params["repository_root"] = repositoryRoot
+            }
+            if let sessionId {
+                params["session_id"] = sessionId
+            }
+            result = await DochiApp.handleBridgeOrchestratorInterrupt(
+                params: params,
+                externalToolManager: manager
+            )
+
+        case .orchSummarize(let repositoryRoot, let sessionId, let lines):
+            var params: [String: Any] = ["lines": lines]
+            if let repositoryRoot {
+                params["repository_root"] = repositoryRoot
+            }
+            if let sessionId {
+                params["session_id"] = sessionId
+            }
+            result = await DochiApp.handleBridgeOrchestratorSummarize(
+                params: params,
+                externalToolManager: manager,
+                orchestrationSummaryService: telegramOrchestrationSummaryService
+            )
         }
 
         let replyText = formatTelegramBridgeCommandResult(command: command, result: result)
@@ -3055,6 +3146,19 @@ final class DochiViewModel {
             - detail: \(detail)
             """
 
+        case .bridgeRoots:
+            let roots = result.result["roots"] as? [[String: Any]] ?? []
+            if roots.isEmpty {
+                return "발견된 Git 루트가 없습니다."
+            }
+            let lines = roots.prefix(10).map { root in
+                let path = root["path"] as? String ?? "-"
+                let branch = root["branch"] as? String ?? "-"
+                let score = root["score"] as? Int ?? 0
+                return "- \(path) (branch: \(branch), score: \(score))"
+            }
+            return lines.joined(separator: "\n")
+
         case .bridgeStatus:
             if let sessions = result.result["sessions"] as? [[String: Any]] {
                 if sessions.isEmpty {
@@ -3094,6 +3198,62 @@ final class DochiViewModel {
                 return "(출력 없음)"
             }
             return lines.joined(separator: "\n")
+
+        case .bridgeRepoList:
+            let repositories = result.result["repositories"] as? [[String: Any]] ?? []
+            if repositories.isEmpty {
+                return "관리 중인 리포지토리가 없습니다."
+            }
+            return repositories.prefix(20).map { repository in
+                let name = repository["name"] as? String ?? "-"
+                let rootPath = repository["root_path"] as? String ?? "-"
+                let source = repository["source"] as? String ?? "-"
+                let repositoryId = repository["repository_id"] as? String ?? "-"
+                return "- \(name) [\(source)] \(rootPath) (\(repositoryId))"
+            }.joined(separator: "\n")
+
+        case .bridgeRepoInit:
+            return formatTelegramRepositoryMutationResult(
+                title: "리포지토리를 초기화했습니다.",
+                result: result
+            )
+
+        case .bridgeRepoClone:
+            return formatTelegramRepositoryMutationResult(
+                title: "리포지토리를 클론했습니다.",
+                result: result
+            )
+
+        case .bridgeRepoAttach:
+            return formatTelegramRepositoryMutationResult(
+                title: "리포지토리를 연결했습니다.",
+                result: result
+            )
+
+        case .bridgeRepoRemove:
+            let repositoryId = result.result["repository_id"] as? String ?? "-"
+            let deleteDirectory = result.result["delete_directory"] as? Bool ?? false
+            return """
+            리포지토리를 제거했습니다.
+            - repository_id: \(repositoryId)
+            - delete_directory: \(deleteDirectory)
+            """
+
+        case .orchSelect:
+            let action = result.result["action"] as? String ?? "-"
+            let reason = result.result["reason"] as? String ?? "-"
+            let selected = result.result["selected_session"] as? [String: Any]
+            let sessionId = selected?["runtime_session_id"] as? String ?? (selected?["native_session_id"] as? String ?? "-")
+            let tier = selected?["controllability_tier"] as? String ?? "-"
+            let workingDirectory = selected?["working_directory"] as? String ?? "-"
+            return """
+            오케스트레이션 세션 선택 결과
+            - action: \(action)
+            - reason: \(reason)
+            - session_id: \(sessionId)
+            - tier: \(tier)
+            - working_directory: \(workingDirectory)
+            """
 
         case .orchRequest:
             let approvalId = result.result["approval_id"] as? String ?? "-"
@@ -3146,7 +3306,49 @@ final class DochiViewModel {
             }
             let highlightsText = highlights.prefix(5).map { "- \($0)" }.joined(separator: "\n")
             return "orchestrator.status kind=\(kind)\n\(summary)\n\(highlightsText)"
+
+        case .orchInterrupt:
+            let status = result.result["status"] as? String ?? "interrupted"
+            let session = result.result["session"] as? [String: Any]
+            let sessionId = session?["session_id"] as? String ?? "-"
+            let profile = session?["profile_name"] as? String ?? "-"
+            return """
+            오케스트레이터 세션 중단 완료
+            - status: \(status)
+            - profile: \(profile)
+            - session_id: \(sessionId)
+            """
+
+        case .orchSummarize:
+            let kind = result.result["result_kind"] as? String ?? "unknown"
+            let summary = result.result["summary"] as? String ?? "(요약 없음)"
+            let highlights = result.result["highlights"] as? [String] ?? []
+            if highlights.isEmpty {
+                return "orchestrator.summarize kind=\(kind)\n\(summary)"
+            }
+            let highlightsText = highlights.prefix(5).map { "- \($0)" }.joined(separator: "\n")
+            return "orchestrator.summarize kind=\(kind)\n\(summary)\n\(highlightsText)"
         }
+    }
+
+    private func formatTelegramRepositoryMutationResult(
+        title: String,
+        result: LocalControlPlaneMethodResult
+    ) -> String {
+        let repository = result.result["repository"] as? [String: Any]
+        let repositoryId = repository?["repository_id"] as? String ?? "-"
+        let name = repository?["name"] as? String ?? "-"
+        let rootPath = repository?["root_path"] as? String ?? "-"
+        let source = repository?["source"] as? String ?? "-"
+        let branch = repository?["default_branch"] as? String ?? "-"
+        return """
+        \(title)
+        - repository_id: \(repositoryId)
+        - name: \(name)
+        - root_path: \(rootPath)
+        - source: \(source)
+        - default_branch: \(branch)
+        """
     }
 
     private func formatTelegramBridgeCommandError(code: String, message: String) -> String {

--- a/DochiTests/NativeSessionRoutingTests.swift
+++ b/DochiTests/NativeSessionRoutingTests.swift
@@ -406,6 +406,103 @@ final class NativeSessionRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testTelegramBridgeRootsCommandBypassesNativeLoopAndListsRoots() async throws {
+        let adapter = StubNativeProviderAdapter(
+            provider: .anthropic,
+            eventsPerRequest: [[.done(text: "native-should-not-run")]]
+        )
+        let nativeService = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: MockBuiltInToolService()
+        )
+        let viewModel = makeViewModel(
+            provider: .anthropic,
+            nativeLoopService: nativeService,
+            telegramStreamReplies: false
+        )
+
+        let manager = MockExternalToolSessionManager()
+        manager.mockGitRepositoryInsights = [
+            GitRepositoryInsight(
+                workDomain: "dochi",
+                workDomainConfidence: 0.95,
+                workDomainReason: "matched owner",
+                path: "/tmp/project-alpha",
+                name: "project-alpha",
+                branch: "main",
+                originURL: "git@github.com:org/project-alpha.git",
+                remoteHost: "github.com",
+                remoteOwner: "org",
+                remoteRepository: "project-alpha",
+                lastCommitEpoch: 1_700_000_000,
+                lastCommitISO8601: "2023-11-14T00:00:00Z",
+                lastCommitRelative: "1h ago",
+                upstreamLastCommitEpoch: 1_700_000_000,
+                upstreamLastCommitISO8601: "2023-11-14T00:00:00Z",
+                upstreamLastCommitRelative: "1h ago",
+                daysSinceLastCommit: 0,
+                recentCommitCount30d: 20,
+                changedFileCount: 3,
+                untrackedFileCount: 1,
+                aheadCount: 0,
+                behindCount: 0,
+                score: 88
+            ),
+        ]
+        viewModel.configureExternalToolManager(manager)
+
+        let telegram = MockTelegramService()
+        viewModel.setTelegramService(telegram)
+
+        await viewModel.handleTelegramMessage(TelegramUpdate(
+            updateId: 2,
+            chatId: 123_456,
+            senderId: 42,
+            senderUsername: "tester",
+            text: "/bridge roots --limit 1"
+        ))
+
+        XCTAssertEqual(adapter.callCount, 0)
+        XCTAssertEqual(telegram.sentMessages.last?.chatId, 123_456)
+        XCTAssertTrue(telegram.sentMessages.last?.text.contains("/tmp/project-alpha") == true)
+    }
+
+    @MainActor
+    func testTelegramBridgeRepoInitCommandBypassesNativeLoop() async throws {
+        let adapter = StubNativeProviderAdapter(
+            provider: .anthropic,
+            eventsPerRequest: [[.done(text: "native-should-not-run")]]
+        )
+        let nativeService = NativeAgentLoopService(
+            adapters: [adapter],
+            toolService: MockBuiltInToolService()
+        )
+        let viewModel = makeViewModel(
+            provider: .anthropic,
+            nativeLoopService: nativeService,
+            telegramStreamReplies: false
+        )
+
+        let manager = MockExternalToolSessionManager()
+        viewModel.configureExternalToolManager(manager)
+
+        let telegram = MockTelegramService()
+        viewModel.setTelegramService(telegram)
+
+        await viewModel.handleTelegramMessage(TelegramUpdate(
+            updateId: 3,
+            chatId: 123_456,
+            senderId: 42,
+            senderUsername: "tester",
+            text: "/bridge repo init /tmp/new-repo --branch develop --readme --gitignore"
+        ))
+
+        XCTAssertEqual(adapter.callCount, 0)
+        XCTAssertEqual(manager.initializeRepositoryCallCount, 1)
+        XCTAssertTrue(telegram.sentMessages.last?.text.contains("default_branch: develop") == true)
+    }
+
+    @MainActor
     func testTelegramOrchestratorApprovalFlowConsumesTokenOnce() async throws {
         let adapter = StubNativeProviderAdapter(
             provider: .anthropic,

--- a/DochiTests/TelegramBridgeCommandParserTests.swift
+++ b/DochiTests/TelegramBridgeCommandParserTests.swift
@@ -31,6 +31,44 @@ final class TelegramBridgeCommandParserTests: XCTestCase {
         XCTAssertTrue(forceWorkingDirectory)
     }
 
+    func testParsesBridgeRootsWithLimitAndPaths() {
+        let route = TelegramBridgeCommandParser.route(
+            "/bridge roots --limit 5 --path /tmp/repo1 --path /tmp/repo2"
+        )
+
+        guard case .command(.bridgeRoots(let limit, let searchPaths)) = route else {
+            return XCTFail("expected bridgeRoots command")
+        }
+        XCTAssertEqual(limit, 5)
+        XCTAssertEqual(searchPaths, ["/tmp/repo1", "/tmp/repo2"])
+    }
+
+    func testParsesBridgeRepoCloneCommand() {
+        let route = TelegramBridgeCommandParser.route(
+            "/bridge repo clone git@github.com:org/repo.git /tmp/repo --branch develop"
+        )
+
+        guard case .command(.bridgeRepoClone(let remoteURL, let destinationPath, let branch)) = route else {
+            return XCTFail("expected bridgeRepoClone command")
+        }
+        XCTAssertEqual(remoteURL, "git@github.com:org/repo.git")
+        XCTAssertEqual(destinationPath, "/tmp/repo")
+        XCTAssertEqual(branch, "develop")
+    }
+
+    func testParsesBridgeOrchestratorSummarizeCommand() {
+        let route = TelegramBridgeCommandParser.route(
+            "/bridge orchestrator summarize --repo /tmp/repo --session abc --lines 42"
+        )
+
+        guard case .command(.orchSummarize(let repositoryRoot, let sessionId, let lines)) = route else {
+            return XCTFail("expected orchSummarize command")
+        }
+        XCTAssertEqual(repositoryRoot, "/tmp/repo")
+        XCTAssertEqual(sessionId, "abc")
+        XCTAssertEqual(lines, 42)
+    }
+
     func testParsesOrchRequestWithRepoAndTTL() {
         let route = TelegramBridgeCommandParser.route("/orch request npm run test --repo /tmp/repo --ttl 180")
 
@@ -63,5 +101,6 @@ final class TelegramBridgeCommandParserTests: XCTestCase {
             return XCTFail("expected usageError")
         }
         XCTAssertTrue(usage.contains("/bridge open"))
+        XCTAssertTrue(usage.contains("/bridge repo"))
     }
 }


### PR DESCRIPTION
## Summary
- expand Telegram command surface to cover CLI bridge parity commands (, ,  aliases)
- wire newly parsed commands to existing DochiApp bridge/orchestrator handlers
- add Telegram-friendly result formatting for roots/repo/select/interrupt/summarize paths
- add parser and routing tests for new command paths

## Linked Issue
- closes #439

## Test Evidence
- Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination platform=macOS "-only-testing:DochiTests/TelegramBridgeCommandParserTests" "-only-testing:DochiTests/NativeSessionRoutingTests" "-only-testing:DochiTests/OrchestrationExecutionApprovalStoreTests" "-only-testing:DochiTests/DochiAppOrchestratorBridgeFlowTests"

Resolve Package Graph


Resolved source packages:
  swift-asn1: https://github.com/apple/swift-asn1.git @ 1.5.1
  swift-crypto: https://github.com/apple/swift-crypto.git @ 4.2.0
  xctest-dynamic-overlay: https://github.com/pointfreeco/xctest-dynamic-overlay @ 1.8.1
  EventSource: https://github.com/mattt/eventsource.git @ 1.3.0
  mcp-swift-sdk: https://github.com/modelcontextprotocol/swift-sdk.git @ 0.10.2
  swift-concurrency-extras: https://github.com/pointfreeco/swift-concurrency-extras @ 1.3.2
  swift-system: https://github.com/apple/swift-system.git @ 1.6.4
  onnxruntime: https://github.com/microsoft/onnxruntime-swift-package-manager.git @ 1.20.0
  swift-clocks: https://github.com/pointfreeco/swift-clocks @ 1.0.6
  VRMKit: https://github.com/tattn/VRMKit.git @ 0.7.1
  swift-http-types: https://github.com/apple/swift-http-types.git @ 1.5.1
  swift-log: https://github.com/apple/swift-log.git @ 1.9.1
  Supabase: https://github.com/supabase/supabase-swift.git @ 2.41.1

ComputePackagePrebuildTargetDependencyGraph

Prepare packages

CreateBuildRequest

SendProjectDescription

CreateBuildOperation

ComputeTargetDependencyGraph
note: Building targets in dependency order
note: Target dependency graph (40 targets)
    Target 'DochiUITests' in project 'Dochi'
        ➜ Explicit dependency on target 'Dochi' in project 'Dochi'
    Target 'DochiTests' in project 'Dochi'
        ➜ Explicit dependency on target 'Dochi' in project 'Dochi'
    Target 'Dochi' in project 'Dochi'
        ➜ Explicit dependency on target 'onnxruntime' in project 'onnxruntime'
        ➜ Explicit dependency on target 'MCP' in project 'mcp-swift-sdk'
        ➜ Explicit dependency on target 'Supabase' in project 'Supabase'
        ➜ Explicit dependency on target 'VRMKit' in project 'VRMKit'
        ➜ Explicit dependency on target 'VRMRealityKit' in project 'VRMKit'
    Target 'VRMRealityKit' in project 'VRMKit'
        ➜ Explicit dependency on target 'VRMRealityKit' in project 'VRMKit'
        ➜ Explicit dependency on target 'VRMKit' in project 'VRMKit'
    Target 'VRMRealityKit' in project 'VRMKit'
        ➜ Explicit dependency on target 'VRMKit' in project 'VRMKit'
    Target 'VRMKit' in project 'VRMKit'
        ➜ Explicit dependency on target 'VRMKit' in project 'VRMKit'
    Target 'VRMKit' in project 'VRMKit' (no dependencies)
    Target 'Supabase' in project 'Supabase'
        ➜ Explicit dependency on target 'Supabase' in project 'Supabase'
        ➜ Explicit dependency on target 'Functions' in project 'Supabase'
        ➜ Explicit dependency on target 'PostgREST' in project 'Supabase'
        ➜ Explicit dependency on target 'Auth' in project 'Supabase'
        ➜ Explicit dependency on target 'Realtime' in project 'Supabase'
        ➜ Explicit dependency on target 'Storage' in project 'Supabase'
        ➜ Explicit dependency on target 'Helpers' in project 'Supabase'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'Crypto' in project 'swift-crypto'
        ➜ Explicit dependency on target 'IssueReporting' in project 'xctest-dynamic-overlay'
    Target 'Supabase' in project 'Supabase'
        ➜ Explicit dependency on target 'Helpers' in project 'Supabase'
        ➜ Explicit dependency on target 'Auth' in project 'Supabase'
        ➜ Explicit dependency on target 'Functions' in project 'Supabase'
        ➜ Explicit dependency on target 'PostgREST' in project 'Supabase'
        ➜ Explicit dependency on target 'Realtime' in project 'Supabase'
        ➜ Explicit dependency on target 'Storage' in project 'Supabase'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'Crypto' in project 'swift-crypto'
        ➜ Explicit dependency on target 'IssueReporting' in project 'xctest-dynamic-overlay'
    Target 'Storage' in project 'Supabase'
        ➜ Explicit dependency on target 'Helpers' in project 'Supabase'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
    Target 'Realtime' in project 'Supabase'
        ➜ Explicit dependency on target 'Helpers' in project 'Supabase'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'IssueReporting' in project 'xctest-dynamic-overlay'
    Target 'PostgREST' in project 'Supabase'
        ➜ Explicit dependency on target 'Helpers' in project 'Supabase'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
    Target 'Functions' in project 'Supabase'
        ➜ Explicit dependency on target 'Helpers' in project 'Supabase'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
    Target 'Auth' in project 'Supabase'
        ➜ Explicit dependency on target 'Helpers' in project 'Supabase'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'Crypto' in project 'swift-crypto'
    Target 'Crypto' in project 'swift-crypto'
        ➜ Explicit dependency on target 'Crypto' in project 'swift-crypto'
        ➜ Explicit dependency on target 'swift-crypto_Crypto' in project 'swift-crypto'
    Target 'Crypto' in project 'swift-crypto'
        ➜ Explicit dependency on target 'swift-crypto_Crypto' in project 'swift-crypto'
    Target 'swift-crypto_Crypto' in project 'swift-crypto' (no dependencies)
    Target 'Helpers' in project 'Supabase'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
    Target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'IssueReportingPackageSupport' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'IssueReporting' in project 'xctest-dynamic-overlay'
    Target 'XCTestDynamicOverlay' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'IssueReportingPackageSupport' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'IssueReporting' in project 'xctest-dynamic-overlay'
    Target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'IssueReporting' in project 'xctest-dynamic-overlay'
    Target 'Clocks' in project 'swift-clocks'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'IssueReporting' in project 'xctest-dynamic-overlay'
    Target 'IssueReporting' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'IssueReporting' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'IssueReportingPackageSupport' in project 'xctest-dynamic-overlay'
    Target 'IssueReporting' in project 'xctest-dynamic-overlay'
        ➜ Explicit dependency on target 'IssueReportingPackageSupport' in project 'xctest-dynamic-overlay'
    Target 'IssueReportingPackageSupport' in project 'xctest-dynamic-overlay' (no dependencies)
    Target 'HTTPTypes' in project 'swift-http-types'
        ➜ Explicit dependency on target 'HTTPTypes' in project 'swift-http-types'
    Target 'HTTPTypes' in project 'swift-http-types' (no dependencies)
    Target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
        ➜ Explicit dependency on target 'ConcurrencyExtras' in project 'swift-concurrency-extras'
    Target 'ConcurrencyExtras' in project 'swift-concurrency-extras' (no dependencies)
    Target 'MCP' in project 'mcp-swift-sdk'
        ➜ Explicit dependency on target 'MCP' in project 'mcp-swift-sdk'
        ➜ Explicit dependency on target 'SystemPackage' in project 'swift-system'
        ➜ Explicit dependency on target 'Logging' in project 'swift-log'
        ➜ Explicit dependency on target 'EventSource' in project 'EventSource'
    Target 'MCP' in project 'mcp-swift-sdk'
        ➜ Explicit dependency on target 'SystemPackage' in project 'swift-system'
        ➜ Explicit dependency on target 'Logging' in project 'swift-log'
        ➜ Explicit dependency on target 'EventSource' in project 'EventSource'
    Target 'EventSource' in project 'EventSource'
        ➜ Explicit dependency on target 'EventSource' in project 'EventSource'
    Target 'EventSource' in project 'EventSource' (no dependencies)
    Target 'Logging' in project 'swift-log'
        ➜ Explicit dependency on target 'Logging' in project 'swift-log'
    Target 'Logging' in project 'swift-log' (no dependencies)
    Target 'SystemPackage' in project 'swift-system'
        ➜ Explicit dependency on target 'SystemPackage' in project 'swift-system'
        ➜ Explicit dependency on target 'CSystem' in project 'swift-system'
    Target 'SystemPackage' in project 'swift-system'
        ➜ Explicit dependency on target 'CSystem' in project 'swift-system'
    Target 'CSystem' in project 'swift-system' (no dependencies)
    Target 'onnxruntime' in project 'onnxruntime'
        ➜ Explicit dependency on target 'OnnxRuntimeBindings' in project 'onnxruntime'
    Target 'OnnxRuntimeBindings' in project 'onnxruntime' (no dependencies)

GatherProvisioningInputs

CreateBuildDescription

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk -x objective-c++ -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk -x c -c /dev/null

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/usr/bin/actool --version --output-format xml1

ExecuteExternalTool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld -version_details

ReadFileContents /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/docc/features.json

Build description signature: 95e82cc3ecce68f5a3bd20ebb2ea67d8
Build description path: /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/XCBuildData/95e82cc3ecce68f5a3bd20ebb2ea67d8.xcbuilddata
ClangStatCache /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk /Users/hckim/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.2-25C57-00fa09913b459cbbc988d1f6730289ae.sdkstatcache
    cd /Users/hckim/repo/dochi/Dochi.xcodeproj
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-stat-cache /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk -o /Users/hckim/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/macosx26.2-25C57-00fa09913b459cbbc988d1f6730289ae.sdkstatcache

ProcessInfoPlistFile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/swift-crypto_Crypto.bundle/Contents/Info.plist /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/swift-crypto.build/Debug/swift-crypto_Crypto.build/empty-swift-crypto_Crypto.plist (in target 'swift-crypto_Crypto' from project 'swift-crypto')
    cd /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/SourcePackages/checkouts/swift-crypto
    builtin-infoPlistUtility /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/swift-crypto.build/Debug/swift-crypto_Crypto.build/empty-swift-crypto_Crypto.plist -producttype com.apple.product-type.bundle -expandbuildsettings -platform macosx -o /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/swift-crypto_Crypto.bundle/Contents/Info.plist

ProcessProductPackaging /Users/hckim/repo/dochi/Dochi/Dochi.entitlements /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/Dochi.build/Dochi.app.xcent (in target 'Dochi' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    
    Entitlements:
    
    {
    "com.apple.security.get-task-allow" = 1;
}
    
    builtin-productPackagingUtility /Users/hckim/repo/dochi/Dochi/Dochi.entitlements -entitlements -format xml -o /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/Dochi.build/Dochi.app.xcent

ProcessProductPackagingDER /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/Dochi.build/Dochi.app.xcent /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/Dochi.build/Dochi.app.xcent.der (in target 'Dochi' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    /usr/bin/derq query -f xml -i /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/Dochi.build/Dochi.app.xcent -o /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/Dochi.build/Dochi.app.xcent.der --raw

ProcessProductPackaging "" /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/DochiUITests.xctest.xcent (in target 'DochiUITests' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    
    Entitlements:
    
    {
    "com.apple.application-identifier" = "com.hckim.dochi.uitests.xctrunner";
    "com.apple.security.app-sandbox" = 1;
    "com.apple.security.get-task-allow" = 1;
    "com.apple.security.network.client" = 1;
    "com.apple.security.temporary-exception.files.absolute-path.read-only" =     (
        "/"
    );
    "com.apple.security.temporary-exception.mach-lookup.global-name" =     (
        "com.apple.testmanagerd",
        "com.apple.dt.testmanagerd.runner",
        "com.apple.coresymbolicationd",
        "com.apple.coredevice.version",
        "com.apple.coredevice.service",
        "com.apple.remoted"
    );
    "com.apple.security.temporary-exception.mach-lookup.local-name" =     (
        "com.apple.axserver"
    );
    "com.apple.security.temporary-exception.sbpl" =     (
        "(allow hid-control)",
        "(allow signal)"
    );
}
    
    builtin-productPackagingUtility -entitlements -format xml -o /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/DochiUITests.xctest.xcent

ProcessInfoPlistFile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/Info.plist /Users/hckim/repo/dochi/Dochi/Info.plist (in target 'Dochi' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    builtin-infoPlistUtility /Users/hckim/repo/dochi/Dochi/Info.plist -producttype com.apple.product-type.application -genpkginfo /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PkgInfo -expandbuildsettings -platform macosx -additionalcontentfile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/Dochi.build/assetcatalog_generated_info.plist -scanforprivacyfile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/Frameworks/onnxruntime.framework -scanforprivacyfile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/Resources/swift-crypto_Crypto.bundle -o /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/Info.plist

ProcessProductPackagingDER /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/DochiUITests.xctest.xcent /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/DochiUITests.xctest.xcent.der (in target 'DochiUITests' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    /usr/bin/derq query -f xml -i /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/DochiUITests.xctest.xcent -o /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/DochiUITests.xctest.xcent.der --raw

ProcessInfoPlistFile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/Info.plist /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiTests.build/empty-DochiTests.plist (in target 'DochiTests' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    builtin-infoPlistUtility /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiTests.build/empty-DochiTests.plist -producttype com.apple.product-type.bundle.unit-test -expandbuildsettings -platform macosx -scanforprivacyfile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/Resources/swift-crypto_Crypto.bundle -o /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/Info.plist

CopySwiftLibs /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest (in target 'DochiTests' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    builtin-swiftStdLibTool --copy --verbose --sign - --scan-executable /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/MacOS/DochiTests --scan-folder /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/Frameworks --scan-folder /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/PlugIns --scan-folder /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/Library/SystemExtensions --scan-folder /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/PlugIns/DochiTests.xctest/Contents/Frameworks --strip-bitcode --scan-executable /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiTests.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span

CodeSign /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/MacOS/Dochi.debug.dylib (in target 'Dochi' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    
    Signing Identity:     "Apple Development: HYEONCHEOL KIM (3VNXGXF7ZK)"
    
    /usr/bin/codesign --force --sign 36ACBCCCBC0B136F205D8111D3238CE2D7A0D9E4 --timestamp\=none --generate-entitlement-der /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/MacOS/Dochi.debug.dylib
/Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/MacOS/Dochi.debug.dylib: replacing existing signature

CodeSign /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/MacOS/__preview.dylib (in target 'Dochi' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    
    Signing Identity:     "Apple Development: HYEONCHEOL KIM (3VNXGXF7ZK)"
    
    /usr/bin/codesign --force --sign 36ACBCCCBC0B136F205D8111D3238CE2D7A0D9E4 --timestamp\=none --generate-entitlement-der /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/MacOS/__preview.dylib
/Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app/Contents/MacOS/__preview.dylib: replacing existing signature

CodeSign /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app (in target 'Dochi' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    
    Signing Identity:     "Apple Development: HYEONCHEOL KIM (3VNXGXF7ZK)"
    
    /usr/bin/codesign --force --sign 36ACBCCCBC0B136F205D8111D3238CE2D7A0D9E4 --entitlements /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/Dochi.build/Dochi.app.xcent --timestamp\=none --generate-entitlement-der /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app
/Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app: replacing existing signature

Validate /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app (in target 'Dochi' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    builtin-validationUtility /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app -no-validate-extension -infoplist-subpath Contents/Info.plist

RegisterWithLaunchServices /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app (in target 'Dochi' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/Dochi.app

CopySwiftLibs /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest (in target 'DochiUITests' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    builtin-swiftStdLibTool --copy --verbose --sign - --scan-executable /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest/Contents/MacOS/DochiUITests --scan-folder /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest/Contents/Frameworks --scan-folder /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest/Contents/PlugIns --scan-folder /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest/Contents/Library/SystemExtensions --scan-folder /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest/Contents/Extensions --platform macosx --toolchain /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain --destination /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest/Contents/Frameworks --strip-bitcode --scan-executable /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib --strip-bitcode-tool /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/bitcode_strip --emit-dependency-info /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/SwiftStdLibToolInputDependencies.dep --filter-for-swift-os --back-deploy-swift-span

ProcessInfoPlistFile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest/Contents/Info.plist /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/empty-DochiUITests.plist (in target 'DochiUITests' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    builtin-infoPlistUtility /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/empty-DochiUITests.plist -producttype com.apple.product-type.bundle.ui-testing -expandbuildsettings -platform macosx -additionalcontentfile /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/ProductTypeInfoPlistAdditions.plist -o /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest/Contents/Info.plist

CodeSign /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest (in target 'DochiUITests' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    
    Signing Identity:     "Sign to Run Locally"
    
    /usr/bin/codesign --force --sign - --entitlements /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/DochiUITests.xctest.xcent --timestamp\=none --generate-entitlement-der /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest
/Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app/Contents/PlugIns/DochiUITests.xctest: replacing existing signature

CodeSign /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app (in target 'DochiUITests' from project 'Dochi')
    cd /Users/hckim/repo/dochi
    
    Signing Identity:     "Sign to Run Locally"
    
    /usr/bin/codesign --force --sign - --entitlements /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Intermediates.noindex/Dochi.build/Debug/DochiUITests.build/DochiUITests.xctest.xcent --timestamp\=none --generate-entitlement-der /Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app
/Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Build/Products/Debug/DochiUITests-Runner.app: replacing existing signature

2026-02-22 05:43:36.821359+0900 Dochi[93904:86732757] [STT] SpeechService initialised with locale ko-KR
2026-02-22 05:43:36.826375+0900 Dochi[93904:86732757] [TTS] Scanned installed ONNX models: 0 found
2026-02-22 05:43:36.829219+0900 Dochi[93904:86732757] [App] Plugin scan complete: 0 plugin(s) found
2026-02-22 05:43:36.830597+0900 Dochi[93904:86732757] [Tool] BuiltInToolService initialized with 114 tools
2026-02-22 05:43:36.830897+0900 Dochi[93904:86732757] [App] TerminalService initialized (maxSessions: 8)
2026-02-22 05:43:36.830989+0900 Dochi[93904:86732757] [App] InterestDiscoveryService initialized
2026-02-22 05:43:36.831972+0900 Dochi[93904:86732757] [App] Loaded 2 external tool profiles
2026-02-22 05:43:36.859707+0900 Dochi[93904:86732757] [App] ProactiveSuggestionService initialized
2026-02-22 05:43:36.859802+0900 Dochi[93904:86732757] [Telegram] TelegramProactiveRelay initialized
2026-02-22 05:43:36.859892+0900 Dochi[93904:86732757] [App] SpotlightIndexer initialized
2026-02-22 05:43:36.866965+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:36.867889+0900 Dochi[93904:86732757] [Storage] Migration check completed
2026-02-22 05:43:36.868120+0900 Dochi[93904:86732757] [App] DochiShortcutService configured
2026-02-22 05:43:36.869301+0900 Dochi[93904:86732757] [App] NotificationManager: registered 6 notification categories (replyEnabled: true)
2026-02-22 05:43:36.869702+0900 Dochi[93904:86732757] [MCP] Server added: coding-git (id: 87FA5396-7D3E-45C8-AC51-07D4EDA3B904)
2026-02-22 05:43:36.869725+0900 Dochi[93904:86732757] [App] Restored 1 MCP server(s) from settings
2026-02-22 05:43:36.929423+0900 Dochi[93904:86732757] ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to /var/folders/yj/gyjvw4lx4bjf7kz9y9j11vxr0000gn/T/com.hckim.dochi.savedState
2026-02-22 05:43:36.950653+0900 Dochi[93904:86732757] [MCP] Connecting to server: coding-git
2026-02-22 05:43:37.353460+0900 Dochi[93904:86732757] [App] Restored native session conversation: E15D8D5A-CAB4-4209-9847-9694FF0874CB
2026-02-22 05:43:37.353547+0900 Dochi[93904:86732757] [App] HeartbeatService stopped
2026-02-22 05:43:37.353552+0900 Dochi[93904:86732757] [App] HeartbeatService stopped
2026-02-22 05:43:37.353557+0900 Dochi[93904:86732757] [App] HeartbeatService started (interval: 0min)
2026-02-22 05:43:37.353583+0900 Dochi[93904:86732757] [App] SpotlightIndexer configured
2026-02-22 05:43:37.353599+0900 Dochi[93904:86732757] [App] DocumentIndexer configured
2026-02-22 05:43:37.353604+0900 Dochi[93904:86732757] [App] MemoryConsolidator configured
2026-02-22 05:43:37.353728+0900 Dochi[93904:86732757] [App] FeedbackStore configured
2026-02-22 05:43:37.353750+0900 Dochi[93904:86732757] [App] DelegationManager configured
2026-02-22 05:43:37.353766+0900 Dochi[93904:86732757] [App] PluginManager configured
2026-02-22 05:43:37.353782+0900 Dochi[93904:86732757] [App] ResourceOptimizerService configured
2026-02-22 05:43:37.353787+0900 Dochi[93904:86732757] [App] SchedulerService configured
2026-02-22 05:43:37.353854+0900 Dochi[93904:86732757] [App] Scheduler stopped
2026-02-22 05:43:37.353965+0900 Dochi[93904:86732757] [App] Loaded 0 schedule(s)
2026-02-22 05:43:37.354041+0900 Dochi[93904:86732757] [App] Loaded 0 execution history record(s)
2026-02-22 05:43:37.354055+0900 Dochi[93904:86732757] [App] Scheduler started
2026-02-22 05:43:37.354071+0900 Dochi[93904:86732757] [App] TerminalService configured
2026-02-22 05:43:37.354075+0900 Dochi[93904:86732757] [Tool] TerminalService injected into TerminalRunTool
2026-02-22 05:43:37.354081+0900 Dochi[93904:86732757] [App] ProactiveSuggestionService configured
2026-02-22 05:43:37.354103+0900 Dochi[93904:86732757] [App] TelegramProactiveRelay configured
2026-02-22 05:43:37.354113+0900 Dochi[93904:86732757] [Telegram] TelegramProactiveRelay started
2026-02-22 05:43:37.354183+0900 Dochi[93904:86732757] [App] InterestDiscoveryService configured
2026-02-22 05:43:37.354205+0900 Dochi[93904:86732757] [App] ExternalToolSessionManager configured
2026-02-22 05:43:37.354227+0900 Dochi[93904:86732757] [App] OrchestrationExecutionApprovalStore configured
2026-02-22 05:43:37.354272+0900 Dochi[93904:86732757] [Tool] Registered 6 external tool management tools (K-4)
2026-02-22 05:43:37.354332+0900 Dochi[93904:86732757] [Tool] Registered 6 dochi dev bridge tools
2026-02-22 05:43:37.355200+0900 Dochi[93904:86732757] [App] ControlPlane started at /Users/hckim/Library/Application Support/Dochi/run/dochi.sock
2026-02-22 05:43:37.355754+0900 Dochi[93904:86732757] [App] DevicePolicyService configured
2026-02-22 05:43:37.378527+0900 Dochi[93904:86732757] [App] MenuBarManager: global shortcut registered (Cmd+Shift+D)
2026-02-22 05:43:37.378542+0900 Dochi[93904:86732757] [App] MenuBarManager: setup completed
2026-02-22 05:43:37.586743+0900 Dochi[93904:86732795] [Common] Unable to obtain a task name port right for pid 401: (os/kern) failure (0x5)
2026-02-22 05:43:37.658647+0900 Dochi[93904:86732757] [Cloud] DeviceHeartbeat stopped
Test Suite 'Selected tests' started at 2026-02-22 05:43:37.836.
Test Suite 'DochiTests.xctest' started at 2026-02-22 05:43:37.836.
Test Suite 'DochiAppOrchestratorBridgeFlowTests' started at 2026-02-22 05:43:37.837.
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeOrchestratorExecuteConsumesChallengeApproval]' started.
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeOrchestratorExecuteConsumesChallengeApproval]' passed (0.007 seconds).
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeOrchestratorExecuteRequiresApprovalWithoutConfirmed]' started.
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeOrchestratorExecuteRequiresApprovalWithoutConfirmed]' passed (0.001 seconds).
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeOrchestratorExecuteReturnsSelectionAndGuardPayload]' started.
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeOrchestratorExecuteReturnsSelectionAndGuardPayload]' passed (0.001 seconds).
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeOrchestratorStatusBuildsSummaryContract]' started.
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeOrchestratorStatusBuildsSummaryContract]' passed (0.001 seconds).
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeSessionMetricsIncludesRequiredKPIFields]' started.
Test Case '-[DochiTests.DochiAppOrchestratorBridgeFlowTests testHandleBridgeSessionMetricsIncludesRequiredKPIFields]' passed (0.001 seconds).
Test Suite 'DochiAppOrchestratorBridgeFlowTests' passed at 2026-02-22 05:43:37.849.
	 Executed 5 tests, with 0 failures (0 unexpected) in 0.011 (0.012) seconds
Test Suite 'NativeSessionRoutingTests' started at 2026-02-22 05:43:37.849.
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopCancelledDoesNotTriggerFallbackRetry]' started.
2026-02-22 05:43:37.856378+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:37.866262+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:37.866606+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=anthropic/claude-sonnet-4-5-20250514 [primary], candidates=2, skipped=0
2026-02-22 05:43:37.867055+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=8, after=8, dropped=0, fallback=false
2026-02-22 05:43:37.867264+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace 721B9C74-70F8-4E70-B102-CE91ACCAEBDC
2026-02-22 05:43:37.867497+0900 Dochi[93904:86732757] [Runtime] Native loop cancelled
2026-02-22 05:43:37.867529+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopCancelledDoesNotTriggerFallbackRetry]' passed (0.436 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopEnabledRoutesToNativePath]' started.
2026-02-22 05:43:38.292798+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:38.300949+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:38.301047+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=anthropic/claude-sonnet-4-5-20250514 [primary], candidates=2, skipped=1
2026-02-22 05:43:38.301217+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=8, after=8, dropped=0, fallback=false
2026-02-22 05:43:38.301348+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace 0D192089-985F-4645-931C-3B7F22ABFB5C
2026-02-22 05:43:38.305858+0900 Dochi[93904:86732757] [LLM] Exchange metrics: anthropic/claude-sonnet-4-5-20250514 — N/A tokens, 0.0s
2026-02-22 05:43:38.305898+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopEnabledRoutesToNativePath]' passed (0.238 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopFailureSetsErrorWithoutSDKFallback]' started.
2026-02-22 05:43:38.531948+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:38.540273+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:38.540389+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=anthropic/claude-sonnet-4-5-20250514 [primary], candidates=2, skipped=1
2026-02-22 05:43:38.540582+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=8, after=8, dropped=0, fallback=false
2026-02-22 05:43:38.540722+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace 776820B7-6BAA-4EF4-908B-EC3071F7F076
2026-02-22 05:43:38.540857+0900 Dochi[93904:86732757] [Runtime] Native loop failed: network down
2026-02-22 05:43:38.540889+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopFailureSetsErrorWithoutSDKFallback]' passed (0.249 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopFallsBackToConfiguredProviderWhenPrimaryFails]' started.
2026-02-22 05:43:38.780780+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:38.789448+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:38.789581+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=anthropic/claude-sonnet-4-5-20250514 [primary], candidates=2, skipped=0
2026-02-22 05:43:38.789766+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=8, after=8, dropped=0, fallback=false
2026-02-22 05:43:38.789902+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace 1CD749CB-7A4B-4099-B6FB-1936C1291A54
2026-02-22 05:43:38.789996+0900 Dochi[93904:86732757] [Runtime] Native loop failed: primary down
2026-02-22 05:43:38.790010+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 fallback attempt 2/2: openai/gpt-4o-mini
2026-02-22 05:43:38.790112+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=7, after=7, dropped=0, fallback=false
2026-02-22 05:43:38.790217+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace 1CD749CB-7A4B-4099-B6FB-1936C1291A54
2026-02-22 05:43:38.794702+0900 Dochi[93904:86732757] [LLM] Exchange metrics: openai/gpt-4o-mini — N/A tokens, 0.0s [fallback]
2026-02-22 05:43:38.794734+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopFallsBackToConfiguredProviderWhenPrimaryFails]' passed (0.343 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopRecordsNilUsageWhenProviderDoesNotReturnUsage]' started.
2026-02-22 05:43:39.123318+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:39.131626+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:39.131760+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=ollama/llama3 [primary], candidates=2, skipped=1
2026-02-22 05:43:39.131932+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=7, after=7, dropped=0, fallback=false
2026-02-22 05:43:39.132073+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace F809ABFE-7340-4FE5-91FC-946F8C1A955C
2026-02-22 05:43:39.136364+0900 Dochi[93904:86732757] [LLM] Exchange metrics: ollama/llama3 — N/A tokens, 0.0s
2026-02-22 05:43:39.136403+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
2026-02-22 05:43:39.140468+0900 Dochi[93904:86733376] [connection] nw_socket_handle_socket_event [C1.1.1:2] Socket SO_ERROR [61: Connection refused]
2026-02-22 05:43:39.140520+0900 Dochi[93904:86733376] [connection] nw_endpoint_flow_failed_with_error [C1.1.1 ::1.11434 in_progress socket-flow (satisfied (Path is satisfied), viable, interface: lo0)] already failing, returning
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopRecordsNilUsageWhenProviderDoesNotReturnUsage]' passed (0.375 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopRecordsUsageMetricsFromDoneEvent]' started.
2026-02-22 05:43:39.499332+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:39.507645+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:39.507767+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=openai/gpt-4o [primary], candidates=2, skipped=0
2026-02-22 05:43:39.507958+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=7, after=7, dropped=0, fallback=false
2026-02-22 05:43:39.508092+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace 713A9EF6-E2B3-4F78-B997-0E02A06967C5
2026-02-22 05:43:39.512693+0900 Dochi[93904:86732757] [LLM] Token estimator deviation: openai/gpt-4o est=87 actual=21 err=66 (314.3%)
2026-02-22 05:43:39.512814+0900 Dochi[93904:86732757] [LLM] Exchange metrics: openai/gpt-4o — 29 tokens, 0.0s
2026-02-22 05:43:39.512845+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopRecordsUsageMetricsFromDoneEvent]' passed (0.368 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopUnsupportedProviderSetsErrorWithoutSDKFallback]' started.
2026-02-22 05:43:39.866709+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:39.874667+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:39.874768+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=none, candidates=2, skipped=2
2026-02-22 05:43:39.874779+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeLoopUnsupportedProviderSetsErrorWithoutSDKFallback]' passed (0.183 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeRequestDropsToolsWhenCapabilityUnsupported]' started.
2026-02-22 05:43:40.050487+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:40.058040+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:40.058145+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=lmStudio/tinyllama [primary], candidates=2, skipped=1
2026-02-22 05:43:40.058534+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=7, after=7, dropped=0, fallback=false
2026-02-22 05:43:40.058545+0900 Dochi[93904:86732757] [Runtime] Capability fallback applied: disabling tools for lmStudio/tinyllama
2026-02-22 05:43:40.058686+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace CF326B6F-25C7-4101-9075-58DEDDDD0D1B
2026-02-22 05:43:40.060561+0900 Dochi[93904:86732795] [connection] nw_socket_handle_socket_event [C2.1.1:2] Socket SO_ERROR [61: Connection refused]
2026-02-22 05:43:40.060600+0900 Dochi[93904:86732795] [connection] nw_endpoint_flow_failed_with_error [C2.1.1 ::1.1234 in_progress socket-flow (satisfied (Path is satisfied), viable, interface: lo0)] already failing, returning
2026-02-22 05:43:40.060795+0900 Dochi[93904:86732795] [connection] nw_socket_handle_socket_event [C2.1.2:2] Socket SO_ERROR [61: Connection refused]
2026-02-22 05:43:40.060819+0900 Dochi[93904:86732795] [connection] nw_endpoint_flow_failed_with_error [C2.1.2 127.0.0.1:1234 in_progress socket-flow (satisfied (Path is satisfied), viable, interface: lo0)] already failing, returning
2026-02-22 05:43:40.060846+0900 Dochi[93904:86732795] [connection] nw_endpoint_flow_failed_with_error [C2.1.2 127.0.0.1:1234 cancelled socket-flow ((null))] already failing, returning
2026-02-22 05:43:40.060869+0900 Dochi[93904:86732795] [Default] Connection 2: received failure notification
2026-02-22 05:43:40.060885+0900 Dochi[93904:86732795] [Default] Connection 2: failed to connect 1:61, reason -1
2026-02-22 05:43:40.060887+0900 Dochi[93904:86732795] [Default] Connection 2: encountered error(1:61)
2026-02-22 05:43:40.060967+0900 Dochi[93904:86732795] [Default] Task <41DD9D83-F20A-4AB5-9A1A-9346AB4F59C1>.<2> HTTP load failed, 0/0 bytes (error code: -1004 [1:61])
2026-02-22 05:43:40.061673+0900 Dochi[93904:86732795] [Default] Task <41DD9D83-F20A-4AB5-9A1A-9346AB4F59C1>.<2> finished with error [-1004] Error Domain=NSURLErrorDomain Code=-1004 "Could not connect to the server." UserInfo={_kCFStreamErrorCodeKey=61, NSUnderlyingError=0x8f45bef10 {Error Domain=kCFErrorDomainCFNetwork Code=-1004 "(null)" UserInfo={_NSURLErrorNWPathKey=satisfied (Path is satisfied), interface: lo0, _kCFStreamErrorCodeKey=61, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <41DD9D83-F20A-4AB5-9A1A-9346AB4F59C1>.<2>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <41DD9D83-F20A-4AB5-9A1A-9346AB4F59C1>.<2>"
), NSLocalizedDescription=Could not connect to the server., NSErrorFailingURLStringKey=http://localhost:1234/v1/models, NSErrorFailingURLKey=http://localhost:1234/v1/models, _kCFStreamErrorDomainKey=1}
2026-02-22 05:43:40.062744+0900 Dochi[93904:86732757] [LLM] Exchange metrics: lmStudio/tinyllama — N/A tokens, 0.0s
2026-02-22 05:43:40.062773+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeRequestDropsToolsWhenCapabilityUnsupported]' passed (0.247 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeRequestKeepsToolsWhenCapabilitySupported]' started.
2026-02-22 05:43:40.298649+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:40.307119+0900 Dochi[93904:86732757] [App] Interaction: idle → processing
2026-02-22 05:43:40.307244+0900 Dochi[93904:86732757] [Runtime] ModelRouterV2 decision: complexity=light, selected=ollama/llama3.2 [primary], candidates=2, skipped=1
2026-02-22 05:43:40.307655+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=7, after=7, dropped=0, fallback=false
2026-02-22 05:43:40.307894+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace B92371EC-676B-43EF-82D4-3CCF602A2A45
2026-02-22 05:43:40.312381+0900 Dochi[93904:86732757] [LLM] Exchange metrics: ollama/llama3.2 — N/A tokens, 0.0s
2026-02-22 05:43:40.312420+0900 Dochi[93904:86732757] [App] Interaction: processing → idle
2026-02-22 05:43:40.313562+0900 Dochi[93904:86733307] [connection] nw_socket_handle_socket_event [C3.1.1:2] Socket SO_ERROR [61: Connection refused]
2026-02-22 05:43:40.313601+0900 Dochi[93904:86733307] [connection] nw_endpoint_flow_failed_with_error [C3.1.1 ::1.1234 in_progress socket-flow (satisfied (Path is satisfied), viable, interface: lo0)] already failing, returning
2026-02-22 05:43:40.313762+0900 Dochi[93904:86733307] [connection] nw_socket_handle_socket_event [C3.1.2:2] Socket SO_ERROR [61: Connection refused]
2026-02-22 05:43:40.313780+0900 Dochi[93904:86733307] [connection] nw_endpoint_flow_failed_with_error [C3.1.2 127.0.0.1:1234 in_progress socket-flow (satisfied (Path is satisfied), viable, interface: lo0)] already failing, returning
2026-02-22 05:43:40.313809+0900 Dochi[93904:86733307] [connection] nw_endpoint_flow_failed_with_error [C3.1.2 127.0.0.1:1234 cancelled socket-flow ((null))] already failing, returning
2026-02-22 05:43:40.313868+0900 Dochi[93904:86733307] [Default] Connection 3: received failure notification
2026-02-22 05:43:40.313882+0900 Dochi[93904:86733307] [Default] Connection 3: failed to connect 1:61, reason -1
2026-02-22 05:43:40.313885+0900 Dochi[93904:86733307] [Default] Connection 3: encountered error(1:61)
2026-02-22 05:43:40.313975+0900 Dochi[93904:86733307] [Default] Task <21749077-783D-41FD-9107-3404B5266CCE>.<4> HTTP load failed, 0/0 bytes (error code: -1004 [1:61])
2026-02-22 05:43:40.314070+0900 Dochi[93904:86733307] [Default] Task <21749077-783D-41FD-9107-3404B5266CCE>.<4> finished with error [-1004] Error Domain=NSURLErrorDomain Code=-1004 "Could not connect to the server." UserInfo={_kCFStreamErrorCodeKey=61, NSUnderlyingError=0x8f1b07a20 {Error Domain=kCFErrorDomainCFNetwork Code=-1004 "(null)" UserInfo={_NSURLErrorNWPathKey=satisfied (Path is satisfied), interface: lo0, _kCFStreamErrorCodeKey=61, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <21749077-783D-41FD-9107-3404B5266CCE>.<4>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <21749077-783D-41FD-9107-3404B5266CCE>.<4>"
), NSLocalizedDescription=Could not connect to the server., NSErrorFailingURLStringKey=http://localhost:1234/v1/models, NSErrorFailingURLKey=http://localhost:1234/v1/models, _kCFStreamErrorDomainKey=1}
Test Case '-[DochiTests.NativeSessionRoutingTests testNativeRequestKeepsToolsWhenCapabilitySupported]' passed (0.239 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramBridgeCommandBypassesNativeLoop]' started.
2026-02-22 05:43:40.537120+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:40.537152+0900 Dochi[93904:86732757] [App] ExternalToolSessionManager configured
2026-02-22 05:43:40.537220+0900 Dochi[93904:86732757] [Telegram] Processing Telegram message from tester
2026-02-22 05:43:40.538241+0900 Dochi[93904:86732757] [Telegram] Created new Telegram conversation for chat 123456
2026-02-22 05:43:40.538279+0900 Dochi[93904:86732757] [Telegram] Sent Telegram command response to chat 123456
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramBridgeCommandBypassesNativeLoop]' passed (0.006 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramBridgeRepoInitCommandBypassesNativeLoop]' started.
2026-02-22 05:43:40.543595+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:40.543615+0900 Dochi[93904:86732757] [App] ExternalToolSessionManager configured
2026-02-22 05:43:40.543626+0900 Dochi[93904:86732757] [Telegram] Processing Telegram message from tester
2026-02-22 05:43:40.544315+0900 Dochi[93904:86732757] [Telegram] Created new Telegram conversation for chat 123456
2026-02-22 05:43:40.544347+0900 Dochi[93904:86732757] [Telegram] Sent Telegram command response to chat 123456
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramBridgeRepoInitCommandBypassesNativeLoop]' passed (0.006 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramBridgeRootsCommandBypassesNativeLoopAndListsRoots]' started.
2026-02-22 05:43:40.549986+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:40.550010+0900 Dochi[93904:86732757] [App] ExternalToolSessionManager configured
2026-02-22 05:43:40.550023+0900 Dochi[93904:86732757] [Telegram] Processing Telegram message from tester
2026-02-22 05:43:40.550226+0900 Dochi[93904:86732757] [Telegram] Created new Telegram conversation for chat 123456
2026-02-22 05:43:40.550245+0900 Dochi[93904:86732757] [Telegram] Sent Telegram command response to chat 123456
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramBridgeRootsCommandBypassesNativeLoopAndListsRoots]' passed (0.106 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramMessageUsesNativeLoop]' started.
2026-02-22 05:43:40.655712+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:40.655731+0900 Dochi[93904:86732757] [Telegram] Processing Telegram message from tester
2026-02-22 05:43:40.655957+0900 Dochi[93904:86732757] [Telegram] Created new Telegram conversation for chat 123456
2026-02-22 05:43:40.656112+0900 Dochi[93904:86732757] [LLM] Context compaction metrics: before=7, after=7, dropped=0, fallback=false
2026-02-22 05:43:40.656217+0900 Dochi[93904:86732757] [Runtime] Memory pipeline attached to MemoryCandidateHook for workspace 05AB0EAE-B3CD-4E6E-991C-2F8BC2AAB8BE
2026-02-22 05:43:40.656319+0900 Dochi[93904:86732757] [Telegram] Sent Telegram response to chat 123456
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramMessageUsesNativeLoop]' passed (0.106 seconds).
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramOrchestratorApprovalFlowConsumesTokenOnce]' started.
2026-02-22 05:43:40.762102+0900 Dochi[93904:86732757] [App] DochiViewModel initialized
2026-02-22 05:43:40.762128+0900 Dochi[93904:86732757] [App] ExternalToolSessionManager configured
2026-02-22 05:43:40.762138+0900 Dochi[93904:86732757] [Telegram] Processing Telegram message from tester
2026-02-22 05:43:40.762410+0900 Dochi[93904:86733307] [Runtime] ControlPlane approval request created: id=FB9B84C9-F82D-421B-B8A4-7AD4F2E5F993, expires=2026-02-21T20:45:40.762Z
2026-02-22 05:43:40.762866+0900 Dochi[93904:86732757] [Telegram] Created new Telegram conversation for chat 123456
2026-02-22 05:43:40.762888+0900 Dochi[93904:86732757] [Telegram] Sent Telegram command response to chat 123456
2026-02-22 05:43:40.762955+0900 Dochi[93904:86732757] [Telegram] Processing Telegram message from tester
2026-02-22 05:43:40.762996+0900 Dochi[93904:86733307] [Runtime] ControlPlane approval confirmed: id=FB9B84C9-F82D-421B-B8A4-7AD4F2E5F993
2026-02-22 05:43:40.763250+0900 Dochi[93904:86732757] [Telegram] Sent Telegram command response to chat 123456
2026-02-22 05:43:40.763263+0900 Dochi[93904:86732757] [Telegram] Processing Telegram message from tester
2026-02-22 05:43:40.763850+0900 Dochi[93904:86732757] [Telegram] Sent Telegram command response to chat 123456
2026-02-22 05:43:40.763869+0900 Dochi[93904:86732757] [Telegram] Processing Telegram message from tester
2026-02-22 05:43:40.764005+0900 Dochi[93904:86732757] [Telegram] Sent Telegram command response to chat 123456
Test Case '-[DochiTests.NativeSessionRoutingTests testTelegramOrchestratorApprovalFlowConsumesTokenOnce]' passed (0.006 seconds).
Test Suite 'NativeSessionRoutingTests' passed at 2026-02-22 05:43:40.764.
	 Executed 14 tests, with 0 failures (0 unexpected) in 2.910 (2.915) seconds
Test Suite 'OrchestrationExecutionApprovalStoreTests' started at 2026-02-22 05:43:40.765.
Test Case '-[DochiTests.OrchestrationExecutionApprovalStoreTests testApproveAndConsumeSucceedsOnce]' started.
Test Case '-[DochiTests.OrchestrationExecutionApprovalStoreTests testApproveAndConsumeSucceedsOnce]' passed (0.001 seconds).
Test Case '-[DochiTests.OrchestrationExecutionApprovalStoreTests testApproveFailsAfterExpiry]' started.
Test Case '-[DochiTests.OrchestrationExecutionApprovalStoreTests testApproveFailsAfterExpiry]' passed (0.001 seconds).
Test Case '-[DochiTests.OrchestrationExecutionApprovalStoreTests testApproveFailsOnWrongChallengeCode]' started.
Test Case '-[DochiTests.OrchestrationExecutionApprovalStoreTests testApproveFailsOnWrongChallengeCode]' passed (0.001 seconds).
Test Case '-[DochiTests.OrchestrationExecutionApprovalStoreTests testConsumeFailsOnCommandOrRepositoryMismatch]' started.
Test Case '-[DochiTests.OrchestrationExecutionApprovalStoreTests testConsumeFailsOnCommandOrRepositoryMismatch]' passed (0.102 seconds).
Test Suite 'OrchestrationExecutionApprovalStoreTests' passed at 2026-02-22 05:43:40.869.
	 Executed 4 tests, with 0 failures (0 unexpected) in 0.104 (0.105) seconds
Test Suite 'TelegramBridgeCommandParserTests' started at 2026-02-22 05:43:40.869.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeOpenWithFlags]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeOpenWithFlags]' passed (0.000 seconds).
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeOrchestratorSummarizeCommand]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeOrchestratorSummarizeCommand]' passed (0.001 seconds).
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeRepoCloneCommand]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeRepoCloneCommand]' passed (0.000 seconds).
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeRootsWithLimitAndPaths]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeRootsWithLimitAndPaths]' passed (0.000 seconds).
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeSendCommand]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesBridgeSendCommand]' passed (0.000 seconds).
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesOrchExecuteWithApproval]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesOrchExecuteWithApproval]' passed (0.000 seconds).
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesOrchRequestWithRepoAndTTL]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testParsesOrchRequestWithRepoAndTTL]' passed (0.000 seconds).
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testReturnsUsageErrorForInvalidBridgeCommand]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testReturnsUsageErrorForInvalidBridgeCommand]' passed (0.000 seconds).
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testRouteReturnsNotCommandForPlainText]' started.
Test Case '-[DochiTests.TelegramBridgeCommandParserTests testRouteReturnsNotCommandForPlainText]' passed (0.000 seconds).
Test Suite 'TelegramBridgeCommandParserTests' passed at 2026-02-22 05:43:40.875.
	 Executed 9 tests, with 0 failures (0 unexpected) in 0.004 (0.005) seconds
Test Suite 'DochiTests.xctest' passed at 2026-02-22 05:43:40.875.
	 Executed 32 tests, with 0 failures (0 unexpected) in 3.029 (3.038) seconds
Test Suite 'Selected tests' passed at 2026-02-22 05:43:40.875.
	 Executed 32 tests, with 0 failures (0 unexpected) in 3.029 (3.039) seconds

Test session results, code coverage, and logs:
	/Users/hckim/Library/Developer/Xcode/DerivedData/Dochi-fvcerrzpbqssspbcabodnzxiwpdx/Logs/Test/Test-Dochi-2026.02.22_05-43-32-+0900.xcresult

** TEST SUCCEEDED **

Testing started

## Spec Impact
- none
