### PR TITLE
fix: harden orchestrator approval challenge flow

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -1691,6 +1691,7 @@ struct DochiApp: App {
         }
         let repositoryRoot = nonEmptyString(params["repository_root"])
         let ttlSeconds = intValue(params["ttl_seconds"])
+        let revealChallengeCode = boolValue(params["reveal_challenge_code"]) ?? false
 
         let challenge = await orchestrationApprovalStore.create(
             command: command,
@@ -1702,15 +1703,21 @@ struct DochiApp: App {
             "ControlPlane approval request created: id=\(snapshot.approvalId), expires=\(isoTimestamp(snapshot.expiresAt))"
         )
 
-        return .ok([
+        var payload: [String: Any] = [
             "approval_id": snapshot.approvalId,
-            "challenge_code": snapshot.challengeCode,
             "status": snapshot.status.rawValue,
             "command": snapshot.command,
             "repository_root": snapshot.repositoryRoot ?? NSNull(),
             "created_at": isoTimestamp(snapshot.createdAt),
             "expires_at": isoTimestamp(snapshot.expiresAt),
-        ])
+        ]
+        if revealChallengeCode {
+            payload["challenge_code"] = snapshot.challengeCode
+        } else {
+            payload["challenge_code_masked"] = maskChallengeCode(snapshot.challengeCode)
+        }
+
+        return .ok(payload)
     }
 
     nonisolated static func handleBridgeOrchestratorApprove(
@@ -2343,6 +2350,14 @@ struct DochiApp: App {
         guard let raw = value as? String else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    nonisolated private static func maskChallengeCode(_ code: String) -> String {
+        guard code.count > 2 else {
+            return String(repeating: "*", count: code.count)
+        }
+        let suffix = code.suffix(2)
+        return String(repeating: "*", count: code.count - 2) + suffix
     }
 
     nonisolated private static func boolValue(_ value: Any?) -> Bool? {

--- a/Dochi/Services/ControlPlane/OrchestrationExecutionApprovalStore.swift
+++ b/Dochi/Services/ControlPlane/OrchestrationExecutionApprovalStore.swift
@@ -4,6 +4,7 @@ enum OrchestrationExecutionApprovalFailureCode: String, Sendable {
     case approvalNotFound = "approval_not_found"
     case approvalExpired = "approval_expired"
     case approvalCodeMismatch = "approval_code_mismatch"
+    case approvalLocked = "approval_locked"
     case approvalNotApproved = "approval_not_approved"
     case approvalAlreadyConsumed = "approval_already_consumed"
     case approvalContextMismatch = "approval_context_mismatch"
@@ -13,6 +14,7 @@ struct OrchestrationExecutionApprovalSnapshot: Sendable {
     enum Status: String, Sendable {
         case pending
         case approved
+        case locked
         case expired
         case consumed
     }
@@ -26,6 +28,9 @@ struct OrchestrationExecutionApprovalSnapshot: Sendable {
     let expiresAt: Date
     let approvedAt: Date?
     let consumedAt: Date?
+    let failedAttemptCount: Int
+    let maxAttemptCount: Int
+    let lockedUntil: Date?
 }
 
 struct OrchestrationExecutionApprovalChallenge: Sendable {
@@ -69,6 +74,7 @@ actor OrchestrationExecutionApprovalStore {
         enum Status: Sendable {
             case pending
             case approved
+            case locked
             case expired
             case consumed
         }
@@ -82,21 +88,29 @@ actor OrchestrationExecutionApprovalStore {
         let expiresAt: Date
         var approvedAt: Date?
         var consumedAt: Date?
+        var failedAttemptCount: Int
+        var lockedUntil: Date?
     }
 
     private let defaultTTLSeconds: Int
     private let minTTLSeconds: Int
     private let maxTTLSeconds: Int
+    private let maxApproveAttempts: Int
+    private let lockoutSeconds: Int
     private var entries: [String: Entry] = [:]
 
     init(
         defaultTTLSeconds: Int = 120,
         minTTLSeconds: Int = 30,
-        maxTTLSeconds: Int = 900
+        maxTTLSeconds: Int = 900,
+        maxApproveAttempts: Int = 5,
+        lockoutSeconds: Int = 120
     ) {
         self.defaultTTLSeconds = max(1, defaultTTLSeconds)
         self.minTTLSeconds = max(1, minTTLSeconds)
         self.maxTTLSeconds = max(self.minTTLSeconds, maxTTLSeconds)
+        self.maxApproveAttempts = max(1, maxApproveAttempts)
+        self.lockoutSeconds = max(1, lockoutSeconds)
     }
 
     func create(
@@ -123,7 +137,9 @@ actor OrchestrationExecutionApprovalStore {
             createdAt: now,
             expiresAt: now.addingTimeInterval(TimeInterval(effectiveTTL)),
             approvedAt: nil,
-            consumedAt: nil
+            consumedAt: nil,
+            failedAttemptCount: 0,
+            lockedUntil: nil
         )
         entries[approvalId] = entry
 
@@ -189,12 +205,28 @@ actor OrchestrationExecutionApprovalStore {
             )
         }
 
-        if entry.expiresAt <= now, entry.status == .pending || entry.status == .approved {
+        if entry.expiresAt <= now, entry.status == .pending || entry.status == .approved || entry.status == .locked {
             entry.status = .expired
+            entry.lockedUntil = nil
+            entries[approvalId] = entry
+        }
+
+        if entry.status == .locked,
+           let lockedUntil = entry.lockedUntil,
+           lockedUntil <= now {
+            entry.status = .pending
+            entry.failedAttemptCount = 0
+            entry.lockedUntil = nil
             entries[approvalId] = entry
         }
 
         switch entry.status {
+        case .locked:
+            return .denied(
+                code: .approvalLocked,
+                message: lockoutMessage(from: entry, now: now),
+                snapshot: snapshot(from: entry)
+            )
         case .expired:
             return .denied(
                 code: .approvalExpired,
@@ -216,14 +248,31 @@ actor OrchestrationExecutionApprovalStore {
         if let challengeCode {
             let normalizedCode = challengeCode.trimmingCharacters(in: .whitespacesAndNewlines)
             guard normalizedCode == entry.challengeCode else {
+                entry.failedAttemptCount += 1
+                if entry.failedAttemptCount >= maxApproveAttempts {
+                    entry.status = .locked
+                    entry.lockedUntil = min(
+                        entry.expiresAt,
+                        now.addingTimeInterval(TimeInterval(lockoutSeconds))
+                    )
+                    entries[approvalId] = entry
+                    return .denied(
+                        code: .approvalLocked,
+                        message: lockoutMessage(from: entry, now: now),
+                        snapshot: snapshot(from: entry)
+                    )
+                }
+                entries[approvalId] = entry
                 return .denied(
                     code: .approvalCodeMismatch,
-                    message: "승인 코드가 일치하지 않습니다.",
+                    message: "승인 코드가 일치하지 않습니다. 남은 시도 횟수: \(maxApproveAttempts - entry.failedAttemptCount)",
                     snapshot: snapshot(from: entry)
                 )
             }
             entry.status = .approved
             entry.approvedAt = now
+            entry.failedAttemptCount = 0
+            entry.lockedUntil = nil
             entries[approvalId] = entry
             return .allowed(
                 message: "승인되었습니다.",
@@ -272,8 +321,10 @@ actor OrchestrationExecutionApprovalStore {
         var updated = entries
         for key in updated.keys {
             guard var entry = updated[key] else { continue }
-            if (entry.status == .pending || entry.status == .approved), entry.expiresAt <= now {
+            if (entry.status == .pending || entry.status == .approved || entry.status == .locked),
+               entry.expiresAt <= now {
                 entry.status = .expired
+                entry.lockedUntil = nil
                 updated[key] = entry
             }
         }
@@ -285,7 +336,7 @@ actor OrchestrationExecutionApprovalStore {
         entries = entries.filter { _, entry in
             let terminalAt: Date
             switch entry.status {
-            case .pending, .approved:
+            case .pending, .approved, .locked:
                 return true
             case .expired:
                 terminalAt = entry.expiresAt
@@ -308,6 +359,8 @@ actor OrchestrationExecutionApprovalStore {
             status = .pending
         case .approved:
             status = .approved
+        case .locked:
+            status = .locked
         case .expired:
             status = .expired
         case .consumed:
@@ -323,7 +376,10 @@ actor OrchestrationExecutionApprovalStore {
             createdAt: entry.createdAt,
             expiresAt: entry.expiresAt,
             approvedAt: entry.approvedAt,
-            consumedAt: entry.consumedAt
+            consumedAt: entry.consumedAt,
+            failedAttemptCount: entry.failedAttemptCount,
+            maxAttemptCount: maxApproveAttempts,
+            lockedUntil: entry.lockedUntil
         )
     }
 
@@ -339,5 +395,18 @@ actor OrchestrationExecutionApprovalStore {
 
     private static func makeChallengeCode() -> String {
         String(format: "%06d", Int.random(in: 0...999_999))
+    }
+
+    private func lockoutMessage(from entry: Entry, now _: Date) -> String {
+        if let lockedUntil = entry.lockedUntil {
+            return "승인 코드 입력 시도 횟수를 초과했습니다. \(isoTimestamp(lockedUntil)) 이후 다시 시도하세요."
+        }
+        return "승인 코드 입력 시도 횟수를 초과했습니다. 잠시 후 다시 시도하세요."
+    }
+
+    private func isoTimestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
     }
 }

--- a/Dochi/ViewModels/DochiViewModel.swift
+++ b/Dochi/ViewModels/DochiViewModel.swift
@@ -3028,7 +3028,10 @@ final class DochiViewModel {
             )
 
         case .orchRequest(let command, let repositoryRoot, let ttlSeconds):
-            var params: [String: Any] = ["command": command]
+            var params: [String: Any] = [
+                "command": command,
+                "reveal_challenge_code": true,
+            ]
             if let repositoryRoot {
                 params["repository_root"] = repositoryRoot
             }
@@ -3257,12 +3260,18 @@ final class DochiViewModel {
 
         case .orchRequest:
             let approvalId = result.result["approval_id"] as? String ?? "-"
-            let challengeCode = result.result["challenge_code"] as? String ?? "-"
+            let challengeCode = result.result["challenge_code"] as? String
             let expiresAt = result.result["expires_at"] as? String ?? "-"
+            let codeLine: String
+            if let challengeCode, !challengeCode.isEmpty {
+                codeLine = "- challenge_code: \(challengeCode)"
+            } else {
+                codeLine = "- challenge_code: (보안 정책으로 별도 채널에서 확인)"
+            }
             return """
             실행 승인 요청이 생성되었습니다.
             - approval_id: \(approvalId)
-            - challenge_code: \(challengeCode)
+            \(codeLine)
             - expires_at: \(expiresAt)
             다음 단계:
             1) /orch approve \(approvalId) <challenge_code>
@@ -3369,6 +3378,8 @@ final class DochiViewModel {
             return "승인된 command/repository와 실행 요청이 일치하지 않습니다. 같은 값으로 다시 시도해주세요."
         case "approval_code_mismatch":
             return "challenge_code가 일치하지 않습니다. 코드를 확인한 뒤 다시 시도해주세요."
+        case "approval_locked":
+            return "challenge_code 시도 횟수를 초과했습니다. \(message)"
         default:
             return "요청 실패 (\(code)): \(message)"
         }

--- a/DochiTests/OrchestrationExecutionApprovalStoreTests.swift
+++ b/DochiTests/OrchestrationExecutionApprovalStoreTests.swift
@@ -117,4 +117,62 @@ final class OrchestrationExecutionApprovalStoreTests: XCTestCase {
         XCTAssertFalse(mismatchedRepo.isAllowed)
         XCTAssertEqual(mismatchedRepo.failureCode, .approvalContextMismatch)
     }
+
+    func testApproveLocksAfterRepeatedMismatchesAndUnlocksAfterCooldown() async throws {
+        let store = OrchestrationExecutionApprovalStore(
+            defaultTTLSeconds: 120,
+            minTTLSeconds: 1,
+            maxTTLSeconds: 300,
+            maxApproveAttempts: 3,
+            lockoutSeconds: 10
+        )
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let challenge = await store.create(
+            command: "git status",
+            repositoryRoot: "/tmp/repo",
+            ttlSeconds: 120,
+            now: now
+        )
+
+        let wrong1 = await store.approve(
+            approvalId: challenge.snapshot.approvalId,
+            challengeCode: "111111",
+            now: now.addingTimeInterval(1)
+        )
+        XCTAssertFalse(wrong1.isAllowed)
+        XCTAssertEqual(wrong1.failureCode, .approvalCodeMismatch)
+
+        let wrong2 = await store.approve(
+            approvalId: challenge.snapshot.approvalId,
+            challengeCode: "222222",
+            now: now.addingTimeInterval(2)
+        )
+        XCTAssertFalse(wrong2.isAllowed)
+        XCTAssertEqual(wrong2.failureCode, .approvalCodeMismatch)
+
+        let locked = await store.approve(
+            approvalId: challenge.snapshot.approvalId,
+            challengeCode: "333333",
+            now: now.addingTimeInterval(3)
+        )
+        XCTAssertFalse(locked.isAllowed)
+        XCTAssertEqual(locked.failureCode, .approvalLocked)
+
+        let stillLocked = await store.approve(
+            approvalId: challenge.snapshot.approvalId,
+            challengeCode: challenge.snapshot.challengeCode,
+            now: now.addingTimeInterval(8)
+        )
+        XCTAssertFalse(stillLocked.isAllowed)
+        XCTAssertEqual(stillLocked.failureCode, .approvalLocked)
+
+        let approvedAfterCooldown = await store.approve(
+            approvalId: challenge.snapshot.approvalId,
+            challengeCode: challenge.snapshot.challengeCode,
+            now: now.addingTimeInterval(14)
+        )
+        XCTAssertTrue(approvedAfterCooldown.isAllowed)
+        XCTAssertEqual(approvedAfterCooldown.snapshot?.status, .approved)
+    }
 }

--- a/DochiTests/OrchestratorSessionSelectorTests.swift
+++ b/DochiTests/OrchestratorSessionSelectorTests.swift
@@ -505,6 +505,40 @@ final class DochiAppOrchestratorBridgeFlowTests: XCTestCase {
         XCTAssertTrue(summary?.contains("history_search_hit_rate") == true)
     }
 
+    func testHandleBridgeOrchestratorRequestMasksChallengeCodeByDefault() async throws {
+        let approvalStore = OrchestrationExecutionApprovalStore()
+        let result = await DochiApp.handleBridgeOrchestratorRequest(
+            params: [
+                "command": "git status",
+                "repository_root": "/tmp/repo",
+            ],
+            orchestrationApprovalStore: approvalStore
+        )
+
+        XCTAssertTrue(result.success)
+        XCTAssertNil(result.result["challenge_code"])
+        let masked = try XCTUnwrap(result.result["challenge_code_masked"] as? String)
+        XCTAssertEqual(masked.count, 6)
+        XCTAssertTrue(masked.hasPrefix("****"))
+    }
+
+    func testHandleBridgeOrchestratorRequestCanRevealChallengeCodeForTrustedChannel() async throws {
+        let approvalStore = OrchestrationExecutionApprovalStore()
+        let result = await DochiApp.handleBridgeOrchestratorRequest(
+            params: [
+                "command": "git status",
+                "repository_root": "/tmp/repo",
+                "reveal_challenge_code": true,
+            ],
+            orchestrationApprovalStore: approvalStore
+        )
+
+        XCTAssertTrue(result.success)
+        let challengeCode = try XCTUnwrap(result.result["challenge_code"] as? String)
+        XCTAssertEqual(challengeCode.count, 6)
+        XCTAssertNil(result.result["challenge_code_masked"])
+    }
+
     private func makeUnifiedSession(
         provider: String,
         nativeSessionId: String,


### PR DESCRIPTION
## Summary
- hide `challenge_code` by default from `bridge.orchestrator.request` responses and return masked value
- allow explicit code reveal only for trusted channel callers (`reveal_challenge_code=true`), used by Telegram command flow
- harden `OrchestrationExecutionApprovalStore` with attempt counting, temporary lockout, and unlock-after-cooldown behavior
- surface `approval_locked` errors back to Telegram users with actionable message
- add tests for lockout behavior and request-response masking/reveal behavior

## Linked Issue
- closes #441

## Test Evidence
- xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/OrchestrationExecutionApprovalStoreTests -only-testing:DochiTests/OrchestratorSessionSelectorTests -only-testing:DochiTests/DochiAppOrchestratorBridgeFlowTests -only-testing:DochiTests/NativeSessionRoutingTests -only-testing:DochiTests/TelegramBridgeCommandParserTests

## Spec Impact
- none
