### PR TITLE
feat: 세션 대시보드/리스트 클릭 액션 연결

### DIFF
--- a/Dochi/ViewModels/SessionExplorerViewModel.swift
+++ b/Dochi/ViewModels/SessionExplorerViewModel.swift
@@ -191,4 +191,15 @@ enum SessionExplorerViewStateBuilder {
         }
         return sortSessions(scoped, sort: .activity).first
     }
+
+    static func selectionFilter(for repositoryRoot: String?) -> SessionExplorerFilter {
+        let normalizedRoot = normalizedRepositoryPath(repositoryRoot)
+        return SessionExplorerFilter(
+            repositoryRoot: normalizedRoot,
+            provider: nil,
+            tier: nil,
+            activeOnly: false,
+            unassignedOnly: normalizedRoot == nil
+        )
+    }
 }

--- a/Dochi/Views/Sidebar/ExternalToolListView.swift
+++ b/Dochi/Views/Sidebar/ExternalToolListView.swift
@@ -1480,17 +1480,12 @@ struct ExternalToolListView: View {
         focusedRepositoryKey = summary.id
         searchText = ""
         selectedProfileId = nil
-        explorerFilter.activeOnly = false
+        explorerFilter = SessionExplorerViewStateBuilder.selectionFilter(for: summary.repositoryRoot)
 
-        if let repositoryRoot = summary.repositoryRoot {
-            let normalizedRoot = normalizedRepositoryPath(repositoryRoot)
-            explorerFilter.repositoryRoot = normalizedRoot
-            explorerFilter.unassignedOnly = false
+        if let normalizedRoot = explorerFilter.repositoryRoot {
             expandedRepositoryGroups.insert(normalizedRoot)
             orchestrationRepositoryRoot = normalizedRoot
         } else {
-            explorerFilter.repositoryRoot = nil
-            explorerFilter.unassignedOnly = true
             orchestrationRepositoryRoot = nil
         }
 
@@ -1508,9 +1503,7 @@ struct ExternalToolListView: View {
         focusedRepositoryKey = group.id
         searchText = ""
         selectedProfileId = nil
-        explorerFilter.activeOnly = false
-        explorerFilter.repositoryRoot = group.repositoryRoot
-        explorerFilter.unassignedOnly = false
+        explorerFilter = SessionExplorerViewStateBuilder.selectionFilter(for: group.repositoryRoot)
         orchestrationRepositoryRoot = group.repositoryRoot
         expandedRepositoryGroups.insert(group.repositoryRoot)
 

--- a/DochiTests/SessionExplorerViewModelTests.swift
+++ b/DochiTests/SessionExplorerViewModelTests.swift
@@ -239,6 +239,26 @@ final class SessionExplorerViewModelTests: XCTestCase {
         XCTAssertEqual(preferred?.nativeSessionId, "unassigned-idle")
     }
 
+    func testSelectionFilterForRepositoryNormalizesRootAndClearsScopedFilters() {
+        let filter = SessionExplorerViewStateBuilder.selectionFilter(for: "/tmp/repo-a/../repo-a")
+
+        XCTAssertEqual(filter.repositoryRoot, "/tmp/repo-a")
+        XCTAssertNil(filter.provider)
+        XCTAssertNil(filter.tier)
+        XCTAssertFalse(filter.activeOnly)
+        XCTAssertFalse(filter.unassignedOnly)
+    }
+
+    func testSelectionFilterForUnassignedEnablesUnassignedOnly() {
+        let filter = SessionExplorerViewStateBuilder.selectionFilter(for: nil)
+
+        XCTAssertNil(filter.repositoryRoot)
+        XCTAssertNil(filter.provider)
+        XCTAssertNil(filter.tier)
+        XCTAssertFalse(filter.activeOnly)
+        XCTAssertTrue(filter.unassignedOnly)
+    }
+
     func testFilteredSessionsNormalizesRepositoryRootComparison() {
         let sessions = [
             makeSession(


### PR DESCRIPTION
## Summary
- Repo Dashboard 카드 클릭 시 탐색기 필터/포커스/대표 세션 선택이 즉시 반영되도록 연결
- Repository 그룹 헤더 클릭 동작을 분리해 접기/펼치기와 선택 액션을 동시에 지원
- Unified 세션 행을 클릭 가능한 선택 영역으로 만들고 hover/selected 시각 피드백 추가
- 공통 대표 세션 선택 로직(`preferredSession`)을 `SessionExplorerViewStateBuilder`로 이동하고 테스트 추가

## UX 반영 포인트
- 카드/리스트 모두 클릭 즉시 "무반응"처럼 보이지 않도록 포커스 테두리와 강조 배경 제공
- 카드 클릭 시 해당 레포(또는 Unassigned) 중심으로 탐색 컨텍스트를 재설정
- 세션 클릭 시 상세 라우팅과 탐색 필터를 같은 흐름으로 맞춰 사용자가 현재 위치를 잃지 않게 유지

## Testing
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/SessionExplorerViewModelTests` (실패)
  - 기존 컴파일 오류로 테스트 차단: `Dochi/Services/MCP/MCPService.swift:763`, `Dochi/Services/MCP/MCPService.swift:772`
  - 추적 이슈: #449

## Spec Impact
- 기존 UX 기획안 준수: `spec/ux/session-explorer-clickable-ux.md`

Closes #445
