### PR TITLE
feat: expose session work and latest commit context (#453)

### DIFF
--- a/Dochi/Services/GitRepositoryInsightScanner.swift
+++ b/Dochi/Services/GitRepositoryInsightScanner.swift
@@ -14,6 +14,8 @@ struct GitRepositoryInsight: Sendable, Codable, Equatable {
     let lastCommitEpoch: Int?
     let lastCommitISO8601: String?
     let lastCommitRelative: String
+    let lastCommitShortHash: String?
+    let lastCommitSubject: String?
     let upstreamLastCommitEpoch: Int?
     let upstreamLastCommitISO8601: String?
     let upstreamLastCommitRelative: String
@@ -24,6 +26,60 @@ struct GitRepositoryInsight: Sendable, Codable, Equatable {
     let aheadCount: Int?
     let behindCount: Int?
     let score: Int
+
+    init(
+        workDomain: String,
+        workDomainConfidence: Double,
+        workDomainReason: String,
+        path: String,
+        name: String,
+        branch: String,
+        originURL: String?,
+        remoteHost: String?,
+        remoteOwner: String?,
+        remoteRepository: String?,
+        lastCommitEpoch: Int?,
+        lastCommitISO8601: String?,
+        lastCommitRelative: String,
+        lastCommitShortHash: String? = nil,
+        lastCommitSubject: String? = nil,
+        upstreamLastCommitEpoch: Int?,
+        upstreamLastCommitISO8601: String?,
+        upstreamLastCommitRelative: String,
+        daysSinceLastCommit: Int?,
+        recentCommitCount30d: Int,
+        changedFileCount: Int,
+        untrackedFileCount: Int,
+        aheadCount: Int?,
+        behindCount: Int?,
+        score: Int
+    ) {
+        self.workDomain = workDomain
+        self.workDomainConfidence = workDomainConfidence
+        self.workDomainReason = workDomainReason
+        self.path = path
+        self.name = name
+        self.branch = branch
+        self.originURL = originURL
+        self.remoteHost = remoteHost
+        self.remoteOwner = remoteOwner
+        self.remoteRepository = remoteRepository
+        self.lastCommitEpoch = lastCommitEpoch
+        self.lastCommitISO8601 = lastCommitISO8601
+        self.lastCommitRelative = lastCommitRelative
+        self.lastCommitShortHash = lastCommitShortHash
+        self.lastCommitSubject = lastCommitSubject
+        self.upstreamLastCommitEpoch = upstreamLastCommitEpoch
+        self.upstreamLastCommitISO8601 = upstreamLastCommitISO8601
+        self.upstreamLastCommitRelative = upstreamLastCommitRelative
+        self.daysSinceLastCommit = daysSinceLastCommit
+        self.recentCommitCount30d = recentCommitCount30d
+        self.changedFileCount = changedFileCount
+        self.untrackedFileCount = untrackedFileCount
+        self.aheadCount = aheadCount
+        self.behindCount = behindCount
+        self.score = score
+    }
 }
 
 struct GitRepositoryActivityMetrics: Sendable, Equatable {
@@ -235,6 +291,8 @@ enum GitRepositoryInsightScanner {
             remoteInfo: remoteInfo,
             personalIdentity: personalIdentity
         )
+        let lastCommitHeadline = gitOutput(repoPath: path, args: ["log", "-1", "--format=%h%x1f%s"])
+        let parsedHeadline = parseLastCommitHeadline(lastCommitHeadline)
         let lastCommitEpoch = gitOutput(repoPath: path, args: ["log", "-1", "--format=%ct"]).flatMap { Int($0) }
         let upstreamLastCommitEpoch = gitOutput(repoPath: path, args: ["log", "-1", "--format=%ct", "@{upstream}"]).flatMap { Int($0) }
         let recentCommitCount30d = gitOutput(repoPath: path, args: ["rev-list", "--count", "--since=30 days ago", "HEAD"]).flatMap { Int($0) } ?? 0
@@ -275,6 +333,8 @@ enum GitRepositoryInsightScanner {
             lastCommitEpoch: lastCommitEpoch,
             lastCommitISO8601: lastCommitEpoch.map(iso8601(epoch:)),
             lastCommitRelative: relativeTimeDescription(daysSinceLastCommit: daysSinceLastCommit),
+            lastCommitShortHash: parsedHeadline.shortHash,
+            lastCommitSubject: parsedHeadline.subject,
             upstreamLastCommitEpoch: upstreamLastCommitEpoch,
             upstreamLastCommitISO8601: upstreamLastCommitEpoch.map(iso8601(epoch:)),
             upstreamLastCommitRelative: relativeTimeDescription(daysSinceLastCommit: upstreamLastCommitEpoch.map(daysSinceEpoch(_:))),
@@ -300,6 +360,23 @@ enum GitRepositoryInsightScanner {
             return (nil, nil)
         }
         return (ahead, behind)
+    }
+
+    private static func parseLastCommitHeadline(_ output: String?) -> (shortHash: String?, subject: String?) {
+        guard let output else { return (nil, nil) }
+        let tokens = output.split(separator: "\u{001F}", maxSplits: 1, omittingEmptySubsequences: false)
+        guard !tokens.isEmpty else { return (nil, nil) }
+
+        let hash = tokens.first.map(String.init)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let subjectRaw = tokens.count > 1 ? String(tokens[1]) : ""
+        let subject = subjectRaw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\n", with: " ")
+
+        let normalizedHash = (hash?.isEmpty == false) ? hash : nil
+        let normalizedSubject = subject.isEmpty ? nil : String(subject.prefix(120))
+        return (normalizedHash, normalizedSubject)
     }
 
     private struct RemoteInfo {

--- a/Dochi/Services/MCP/MCPService.swift
+++ b/Dochi/Services/MCP/MCPService.swift
@@ -771,21 +771,12 @@ final class MCPService: MCPServiceProtocol {
             return "[image: \(mimeType), \(data.count) bytes]"
         case .audio(let data, let mimeType):
             return "[audio: \(mimeType), \(data.count) bytes]"
-        case .resource(let resource, _, _):
-            if let text = resource.text, !text.isEmpty {
+        case let .resource(uri, mimeType, text):
+            if let text, !text.isEmpty {
                 return text
             }
-            let mimeType = resource.mimeType ?? "unknown"
-            if let blob = resource.blob, !blob.isEmpty {
-                return "[resource: \(resource.uri), \(mimeType), \(blob.count) chars(base64)]"
-            }
-            return "[resource: \(resource.uri), \(mimeType)]"
-        case let .resourceLink(uri, name, title, _, mimeType, _):
-            let label = title ?? name
-            if let mimeType, !mimeType.isEmpty {
-                return "[resource-link: \(label), \(mimeType), \(uri)]"
-            }
-            return "[resource-link: \(label), \(uri)]"
+            let effectiveMimeType = mimeType.trimmingCharacters(in: .whitespacesAndNewlines)
+            return "[resource: \(uri), \(effectiveMimeType.isEmpty ? "unknown" : effectiveMimeType)]"
         }
     }
 

--- a/Dochi/Views/Sidebar/ExternalToolListView.swift
+++ b/Dochi/Views/Sidebar/ExternalToolListView.swift
@@ -45,6 +45,8 @@ struct ExternalToolListView: View {
     @State private var startingProfileId: UUID?
     @State private var startErrorMessage: String?
     @State private var unifiedSessions: [UnifiedCodingSession] = []
+    @State private var discoveredSessions: [DiscoveredCodingSession] = []
+    @State private var gitInsights: [GitRepositoryInsight] = []
     @State private var isRefreshingUnified = false
     @State private var explorerFilter = SessionExplorerFilter()
     @State private var sortOption: SessionExplorerSortOption = .activity
@@ -119,6 +121,14 @@ struct ExternalToolListView: View {
         SessionExplorerViewStateBuilder.repositorySummaries(from: unifiedSessions)
     }
 
+    private var gitInsightByRepositoryPath: [String: GitRepositoryInsight] {
+        Dictionary(
+            uniqueKeysWithValues: gitInsights.map { insight in
+                (normalizedRepositoryPath(insight.path), insight)
+            }
+        )
+    }
+
     private var repositorySessionGroups: [RepositorySessionGroup] {
         SessionExplorerViewStateBuilder.repositoryGroups(
             sessions: filteredUnifiedSessions.filter { !$0.isUnassigned },
@@ -155,6 +165,28 @@ struct ExternalToolListView: View {
         unifiedSessions
             .filter(\.isUnassigned)
             .sorted(by: ExternalToolSessionManager.isPreferredUnifiedSessionOrder(_:_:))
+    }
+
+    private var recentDiscoveredSessions: [DiscoveredCodingSession] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let filtered = discoveredSessions.filter { session in
+            guard !query.isEmpty else { return true }
+            let haystack = [
+                session.provider,
+                session.sessionId,
+                session.path,
+                session.workingDirectory ?? "",
+                session.title ?? "",
+                session.summary ?? "",
+                session.originator ?? "",
+                session.sessionSource ?? "",
+                session.clientKind ?? "",
+            ]
+            .joined(separator: " ")
+            .lowercased()
+            return haystack.contains(query)
+        }
+        return Array(filtered.prefix(20))
     }
 
     private var repositoryFilterOptions: [String] {
@@ -291,6 +323,7 @@ struct ExternalToolListView: View {
                 observabilitySectionHeader
                 repoDashboardSection
                 sessionExplorerSection
+                discoveredSessionSection
                 orchestrationLoopSection
                 unassignedQueueSection
                 sessionHistorySection
@@ -333,7 +366,7 @@ struct ExternalToolListView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("세션 탐색기")
                     .font(.system(size: 13, weight: .semibold))
-                Text("Repo-first 탐색 / quick action / Unassigned 매핑")
+                Text("Repo-first 탐색 / 세션 메타 / Git 변화 지표")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }
@@ -368,6 +401,9 @@ struct ExternalToolListView: View {
                     ForEach(repositorySummaries) { summary in
                         let representative = representativeSession(for: summary.repositoryRoot)
                         let workSummary = representative.flatMap { sessionWorkSummary($0) }
+                        let insight = summary.repositoryRoot.flatMap { root in
+                            gitInsightByRepositoryPath[normalizedRepositoryPath(root)]
+                        }
                         let isFocused = focusedRepositoryKey == summary.id
                         let isHovered = hoveredRepositoryKey == summary.id
                         Button {
@@ -386,18 +422,30 @@ struct ExternalToolListView: View {
                                         .foregroundStyle(workSummaryColor(representative))
                                         .lineLimit(2)
                                 } else {
-                                    Text("현재 작업: 정보 없음")
+                                    Text("현재 작업: 현재 작업 정보 없음")
                                         .font(.system(size: 9))
                                         .foregroundStyle(.tertiary)
                                         .lineLimit(1)
                                 }
                                 if let repositoryRoot = summary.repositoryRoot {
-                                    let branch = managedRepositories.first(where: {
-                                        URL(fileURLWithPath: $0.rootPath).standardizedFileURL.path == repositoryRoot
-                                    })?.defaultBranch ?? "-"
+                                    let managedBranch = managedRepositories.first(where: {
+                                        normalizedRepositoryPath($0.rootPath) == normalizedRepositoryPath(repositoryRoot)
+                                    })?.defaultBranch
+                                    let branch = insight?.branch ?? managedBranch ?? "-"
                                     Text("브랜치 \(branch) · 업데이트 \(relativeTimestamp(representative?.updatedAt ?? summary.lastActivityAt))")
                                         .font(.system(size: 9))
                                         .foregroundStyle(.tertiary)
+                                    if let commitContext = repositoryCommitContext(insight) {
+                                        Text("최근 커밋: \(commitContext)")
+                                            .font(.system(size: 9))
+                                            .foregroundStyle(.tertiary)
+                                            .lineLimit(1)
+                                    } else {
+                                        Text("최근 커밋: 최근 커밋 정보 없음")
+                                            .font(.system(size: 9))
+                                            .foregroundStyle(.tertiary)
+                                            .lineLimit(1)
+                                    }
                                 } else {
                                     Text("Unassigned · 업데이트 \(relativeTimestamp(representative?.updatedAt ?? summary.lastActivityAt))")
                                         .font(.system(size: 9))
@@ -453,6 +501,63 @@ struct ExternalToolListView: View {
         }
         .padding(.horizontal, 10)
         .padding(.bottom, 6)
+    }
+
+    @ViewBuilder
+    private var discoveredSessionSection: some View {
+        sectionHeader("Recent File Sessions")
+
+        if recentDiscoveredSessions.isEmpty {
+            Text("표시할 최근 파일 세션이 없습니다.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 6)
+        } else {
+            ForEach(recentDiscoveredSessions, id: \.path) { session in
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text("[\(session.provider)] \(session.sessionId)")
+                            .font(.system(size: 11, weight: .medium))
+                            .lineLimit(1)
+                        Text("file")
+                            .font(.system(size: 9, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(Color.secondary.opacity(0.1))
+                            .clipShape(RoundedRectangle(cornerRadius: 3))
+                    }
+
+                    if let title = normalizedDiscoveredTitle(session) {
+                        Text(title)
+                            .font(.system(size: 10))
+                            .lineLimit(1)
+                    }
+
+                    if let summary = normalizedDiscoveredSummary(session) {
+                        Text(summary)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+
+                    if let descriptor = discoveredClientDescriptor(session) {
+                        Text(descriptor)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Text("업데이트 \(relativeTimestamp(session.updatedAt)) · \(session.workingDirectory ?? session.path)")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+            }
+        }
     }
 
     @ViewBuilder
@@ -954,6 +1059,23 @@ struct ExternalToolListView: View {
                                 .font(.system(size: 9))
                                 .foregroundStyle(workSummaryColor(session))
                                 .lineLimit(2)
+                        } else {
+                            Text("현재 작업: 현재 작업 정보 없음")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                        }
+
+                        if let commitContext = repositoryCommitContext(for: session.repositoryRoot) {
+                            Text("최근 커밋: \(commitContext)")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                        } else {
+                            Text("최근 커밋: 최근 커밋 정보 없음")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
                         }
 
                         if let clientDescriptor = sessionClientDescriptor(session) {
@@ -965,7 +1087,7 @@ struct ExternalToolListView: View {
 
                         Text("state=\(session.activityState.rawValue), score=\(session.activityScore), repo=\(session.repositoryRoot ?? "(unassigned)")")
                             .font(.system(size: 9))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(.tertiary)
                             .lineLimit(1)
 
                         Text("업데이트 \(relativeTimestamp(session.updatedAt))")
@@ -1152,7 +1274,12 @@ struct ExternalToolListView: View {
     private func refreshUnifiedSessions() async {
         guard !isRefreshingUnified else { return }
         isRefreshingUnified = true
-        unifiedSessions = await manager.listUnifiedCodingSessions(limit: 180)
+        async let unified = manager.listUnifiedCodingSessions(limit: 180)
+        async let discovered = manager.discoverLocalCodingSessions(limit: 120)
+        async let insights = manager.discoverGitRepositoryInsights(searchPaths: nil, limit: 60)
+        unifiedSessions = await unified
+        discoveredSessions = await discovered
+        gitInsights = await insights
         if let repositoryRoot = explorerFilter.repositoryRoot {
             explorerFilter.repositoryRoot = normalizedRepositoryPath(repositoryRoot)
         }
@@ -1601,7 +1728,91 @@ struct ExternalToolListView: View {
         return .secondary
     }
 
+    private func repositoryCommitContext(for repositoryRoot: String?) -> String? {
+        guard let repositoryRoot else { return nil }
+        let normalizedRoot = normalizedRepositoryPath(repositoryRoot)
+        guard let insight = gitInsightByRepositoryPath[normalizedRoot] else { return nil }
+        return repositoryCommitContext(insight)
+    }
+
+    private func repositoryCommitContext(_ insight: GitRepositoryInsight?) -> String? {
+        guard let insight else { return nil }
+        let shortHash = insight.lastCommitShortHash?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let subject = insight.lastCommitSubject?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\n", with: " ")
+        let relative = insight.lastCommitRelative.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let shortHash, !shortHash.isEmpty,
+           let subject, !subject.isEmpty {
+            return "\(shortHash) \(String(subject.prefix(90))) · \(relative)"
+        }
+        if let subject, !subject.isEmpty {
+            return "\(String(subject.prefix(90))) · \(relative)"
+        }
+        if let shortHash, !shortHash.isEmpty {
+            return "\(shortHash) · \(relative)"
+        }
+        if !relative.isEmpty, relative != "-" {
+            return relative
+        }
+        return nil
+    }
+
+    private func normalizedDiscoveredTitle(_ session: DiscoveredCodingSession) -> String? {
+        let raw = session.title ?? session.summary
+        let normalized = raw?
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let normalized, !normalized.isEmpty else { return nil }
+        return String(normalized.prefix(100))
+    }
+
+    private func normalizedDiscoveredSummary(_ session: DiscoveredCodingSession) -> String? {
+        guard let raw = session.summary else { return nil }
+        let normalized = raw
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return nil }
+        if let title = normalizedDiscoveredTitle(session), title == normalized {
+            return nil
+        }
+        return String(normalized.prefix(160))
+    }
+
     private func sessionClientDescriptor(_ session: UnifiedCodingSession) -> String? {
+        var parts: [String] = []
+        if session.provider.lowercased() == "codex" {
+            switch session.clientKind {
+            case "desktop":
+                parts.append("Codex Desktop")
+            case "cli":
+                parts.append("Codex CLI")
+            case "unknown":
+                parts.append("Codex")
+            default:
+                if let originator = session.originator {
+                    parts.append(originator)
+                }
+            }
+        } else if let originator = session.originator {
+            parts.append(originator)
+        }
+
+        if let sessionSource = session.sessionSource, !sessionSource.isEmpty {
+            parts.append("src=\(sessionSource)")
+        }
+
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: " · ")
+    }
+
+    private func discoveredClientDescriptor(_ session: DiscoveredCodingSession) -> String? {
         var parts: [String] = []
         if session.provider.lowercased() == "codex" {
             switch session.clientKind {

--- a/DochiTests/GitRepositoryInsightScorerTests.swift
+++ b/DochiTests/GitRepositoryInsightScorerTests.swift
@@ -60,6 +60,37 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
         XCTAssertGreaterThan(GitRepositoryInsightScorer.score(dirty), GitRepositoryInsightScorer.score(clean))
     }
 
+    func testDiscoverIncludesLatestCommitHeadlineContext() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dochi-insight-headline-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let repoPath = tempRoot.appendingPathComponent("headline-repo", isDirectory: true).path
+        let initializedPath = try ExternalToolSessionManager.initializeGitRepository(
+            atPath: repoPath,
+            defaultBranch: "main",
+            createReadme: false,
+            createGitignore: false
+        )
+
+        try runGit(args: ["config", "user.email", "dochi-tests@example.com"], at: initializedPath)
+        try runGit(args: ["config", "user.name", "Dochi Tests"], at: initializedPath)
+
+        let noteURL = URL(fileURLWithPath: initializedPath).appendingPathComponent("note.txt")
+        try "hello".data(using: .utf8)?.write(to: noteURL)
+        try runGit(args: ["add", "note.txt"], at: initializedPath)
+        try runGit(args: ["commit", "-m", "feat: expose latest commit context in explorer"], at: initializedPath)
+
+        let insights = GitRepositoryInsightScanner.discover(
+            searchPaths: [initializedPath],
+            limit: 10
+        )
+        let insight = try XCTUnwrap(insights.first(where: { $0.path == initializedPath }))
+        XCTAssertEqual(insight.lastCommitSubject, "feat: expose latest commit context in explorer")
+        XCTAssertNotNil(insight.lastCommitShortHash)
+        XCTAssertFalse(insight.lastCommitShortHash?.isEmpty ?? true)
+    }
+
     func testInitializeGitRepositoryCreatesExpectedFiles() throws {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("dochi-repo-init-\(UUID().uuidString)", isDirectory: true)
@@ -1314,5 +1345,22 @@ final class GitRepositoryInsightScorerTests: XCTestCase {
         XCTAssertEqual(item?.title, "브랜치 기반 매핑")
         XCTAssertEqual(item?.titleSource, "claude_sessions_index_git_branch_match")
         XCTAssertNotNil(item?.titleConfidence)
+    }
+
+    private func runGit(args: [String], at path: String) throws {
+        let process = Process()
+        let outputPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "-C", path] + args
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8) ?? ""
+            XCTFail("git command failed: git -C \(path) \(args.joined(separator: " "))\n\(output)")
+        }
     }
 }

--- a/DochiTests/MCPServiceContentExtractionTests.swift
+++ b/DochiTests/MCPServiceContentExtractionTests.swift
@@ -6,11 +6,9 @@ final class MCPServiceContentExtractionTests: XCTestCase {
 
     func testSummarizedToolContentReturnsEmbeddedResourceText() {
         let content: Tool.Content = .resource(
-            resource: .text(
-                "hello-world",
-                uri: "file:///tmp/readme.txt",
-                mimeType: "text/plain"
-            )
+            uri: "file:///tmp/readme.txt",
+            mimeType: "text/plain",
+            text: "hello-world"
         )
 
         let summary = MCPService.summarizedToolContent(content)
@@ -18,51 +16,41 @@ final class MCPServiceContentExtractionTests: XCTestCase {
         XCTAssertEqual(summary, "hello-world")
     }
 
-    func testSummarizedToolContentFormatsBinaryResource() {
-        let bytes = Data([0x01, 0x02, 0x03, 0x04])
+    func testSummarizedToolContentFormatsResourceWithoutText() {
         let content: Tool.Content = .resource(
-            resource: .binary(
-                bytes,
-                uri: "file:///tmp/archive.bin",
-                mimeType: "application/octet-stream"
-            )
+            uri: "file:///tmp/archive.bin",
+            mimeType: "application/octet-stream",
+            text: nil
         )
 
         let summary = MCPService.summarizedToolContent(content)
 
         XCTAssertEqual(
             summary,
-            "[resource: file:///tmp/archive.bin, application/octet-stream, 8 chars(base64)]"
+            "[resource: file:///tmp/archive.bin, application/octet-stream]"
         )
     }
 
-    func testSummarizedToolContentFormatsResourceLink() {
-        let content: Tool.Content = .resourceLink(
-            uri: "https://example.com/spec",
-            name: "spec",
-            title: "Spec Document",
-            description: "link",
-            mimeType: "text/html",
-            annotations: nil
+    func testSummarizedToolContentFormatsImage() {
+        let content: Tool.Content = .image(
+            data: "YWJjZA==",
+            mimeType: "image/png",
+            metadata: nil
         )
 
         let summary = MCPService.summarizedToolContent(content)
 
-        XCTAssertEqual(summary, "[resource-link: Spec Document, text/html, https://example.com/spec]")
+        XCTAssertEqual(summary, "[image: image/png, 8 bytes]")
     }
 
-    func testSummarizedToolContentFormatsResourceLinkFallback() {
-        let content: Tool.Content = .resourceLink(
-            uri: "https://example.com/no-meta",
-            name: "fallback-name",
-            title: nil,
-            description: nil,
-            mimeType: nil,
-            annotations: nil
+    func testSummarizedToolContentFormatsAudio() {
+        let content: Tool.Content = .audio(
+            data: "YWJjZA==",
+            mimeType: "audio/wav"
         )
 
         let summary = MCPService.summarizedToolContent(content)
 
-        XCTAssertEqual(summary, "[resource-link: fallback-name, https://example.com/no-meta]")
+        XCTAssertEqual(summary, "[audio: audio/wav, 8 bytes]")
     }
 }


### PR DESCRIPTION
## Summary
- surface explicit `현재 작업` fallback text in repository cards and unified session rows
- add `최근 커밋` context (short hash + subject + relative time) backed by repository insight scan
- fix MCP content summary parsing for current MCP SDK `Tool.Content.resource(uri:mimeType:text:)` shape
- refresh MCP content extraction tests and add scanner test for latest commit headline context

## UX Notes
- follows issue #453 UX intent: session file signal is primary for meaning, process signal is treated as runtime liveness overlay

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/MCPServiceContentExtractionTests -only-testing:DochiTests/GitRepositoryInsightScorerTests`

## Spec Impact
- None (UI signal clarity improvement within existing session explorer behavior)

Closes #453
