### PR TITLE
feat: 구독제 집계 소스 분리 및 외부 로그 토큰 집계 도입

### DIFF
--- a/Dochi/Models/ResourceOptimizerModels.swift
+++ b/Dochi/Models/ResourceOptimizerModels.swift
@@ -1,11 +1,37 @@
 import Foundation
 
+// MARK: - SubscriptionUsageSource
+
+enum SubscriptionUsageSource: String, Codable, CaseIterable, Sendable {
+    case externalToolLogs = "external_tool_logs"
+    case dochiUsageStore = "dochi_usage_store"
+
+    var displayName: String {
+        switch self {
+        case .externalToolLogs:
+            return "외부 구독 로그"
+        case .dochiUsageStore:
+            return "도치 종량제"
+        }
+    }
+
+    var detailText: String {
+        switch self {
+        case .externalToolLogs:
+            return "Claude/Codex 로컬 세션 로그에서 집계"
+        case .dochiUsageStore:
+            return "Dochi UsageStore 기반 집계"
+        }
+    }
+}
+
 // MARK: - SubscriptionPlan
 
 struct SubscriptionPlan: Codable, Sendable, Identifiable {
     let id: UUID
     var providerName: String
     var planName: String
+    var usageSource: SubscriptionUsageSource
     var monthlyTokenLimit: Int?  // nil = 무제한
     var resetDayOfMonth: Int     // 매월 N일 리셋
     var monthlyCostUSD: Double
@@ -15,6 +41,7 @@ struct SubscriptionPlan: Codable, Sendable, Identifiable {
         id: UUID = UUID(),
         providerName: String,
         planName: String,
+        usageSource: SubscriptionUsageSource = .dochiUsageStore,
         monthlyTokenLimit: Int? = nil,
         resetDayOfMonth: Int = 1,
         monthlyCostUSD: Double = 0,
@@ -23,6 +50,7 @@ struct SubscriptionPlan: Codable, Sendable, Identifiable {
         self.id = id
         self.providerName = providerName
         self.planName = planName
+        self.usageSource = usageSource
         self.monthlyTokenLimit = monthlyTokenLimit
         self.resetDayOfMonth = resetDayOfMonth
         self.monthlyCostUSD = monthlyCostUSD
@@ -34,6 +62,7 @@ struct SubscriptionPlan: Codable, Sendable, Identifiable {
         id = try container.decode(UUID.self, forKey: .id)
         providerName = try container.decode(String.self, forKey: .providerName)
         planName = try container.decode(String.self, forKey: .planName)
+        usageSource = try container.decodeIfPresent(SubscriptionUsageSource.self, forKey: .usageSource) ?? .dochiUsageStore
         monthlyTokenLimit = try container.decodeIfPresent(Int.self, forKey: .monthlyTokenLimit)
         resetDayOfMonth = try container.decodeIfPresent(Int.self, forKey: .resetDayOfMonth) ?? 1
         monthlyCostUSD = try container.decodeIfPresent(Double.self, forKey: .monthlyCostUSD) ?? 0

--- a/Dochi/Services/ResourceOptimizerService.swift
+++ b/Dochi/Services/ResourceOptimizerService.swift
@@ -11,20 +11,43 @@ final class ResourceOptimizerService: ResourceOptimizerProtocol {
     private(set) var subscriptions: [SubscriptionPlan] = []
     private(set) var autoTaskRecords: [AutoTaskRecord] = []
 
+    private struct UsageCacheKey: Hashable {
+        let source: SubscriptionUsageSource
+        let provider: String
+        let startDay: String
+    }
+
+    private struct UsageCacheEntry {
+        let tokens: Int
+        let updatedAt: Date
+    }
+
+    private var usageCache: [UsageCacheKey: UsageCacheEntry] = [:]
+
     // MARK: - Dependencies
 
     private let baseURL: URL
     private let usageStore: UsageStoreProtocol?
+    private let claudeProjectsRoots: [URL]
+    private let codexSessionsRoots: [URL]
 
     private let reserveBufferRatio = 0.08
+    private let externalUsageCacheTTL: TimeInterval = 45
 
     // MARK: - Init
 
-    init(baseURL: URL? = nil, usageStore: UsageStoreProtocol? = nil) {
+    init(
+        baseURL: URL? = nil,
+        usageStore: UsageStoreProtocol? = nil,
+        claudeProjectsRoots: [URL]? = nil,
+        codexSessionsRoots: [URL]? = nil
+    ) {
         let appSupport = baseURL ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
             .appendingPathComponent("Dochi")
         self.baseURL = appSupport
         self.usageStore = usageStore
+        self.claudeProjectsRoots = claudeProjectsRoots ?? Self.defaultClaudeProjectsRoots()
+        self.codexSessionsRoots = codexSessionsRoots ?? Self.defaultCodexSessionsRoots()
         loadFromDisk()
     }
 
@@ -109,7 +132,7 @@ final class ResourceOptimizerService: ResourceOptimizerProtocol {
         let elapsedDays = max(1, daysInPeriod - daysRemaining)
 
         // 현재 기간 사용 토큰 조회
-        let usedTokens = await tokensUsedByProvider(subscription.providerName, since: periodStart)
+        let usedTokens = await tokensUsed(for: subscription, since: periodStart)
 
         let usageRatio = subscription.monthlyTokenLimit.map { limit -> Double in
             guard limit > 0 else { return 0 }
@@ -548,7 +571,32 @@ final class ResourceOptimizerService: ResourceOptimizerProtocol {
 
     // MARK: - Token Usage Query
 
-    private func tokensUsedByProvider(_ providerName: String, since startDate: Date) async -> Int {
+    private func tokensUsed(for subscription: SubscriptionPlan, since startDate: Date) async -> Int {
+        let dayFormatter = DateFormatter()
+        dayFormatter.dateFormat = "yyyy-MM-dd"
+        dayFormatter.locale = Locale(identifier: "en_US_POSIX")
+        let key = UsageCacheKey(
+            source: subscription.usageSource,
+            provider: normalizedProviderKey(subscription.providerName),
+            startDay: dayFormatter.string(from: startDate)
+        )
+        if let cached = usageCache[key],
+           Date().timeIntervalSince(cached.updatedAt) < externalUsageCacheTTL {
+            return cached.tokens
+        }
+
+        let tokens: Int
+        switch subscription.usageSource {
+        case .dochiUsageStore:
+            tokens = await tokensUsedByUsageStore(subscription.providerName, since: startDate)
+        case .externalToolLogs:
+            tokens = await tokensUsedByExternalToolLogs(subscription.providerName, since: startDate)
+        }
+        usageCache[key] = UsageCacheEntry(tokens: tokens, updatedAt: Date())
+        return tokens
+    }
+
+    private func tokensUsedByUsageStore(_ providerName: String, since startDate: Date) async -> Int {
         guard let store = usageStore else { return 0 }
 
         let dayFormatter = DateFormatter()
@@ -575,5 +623,436 @@ final class ResourceOptimizerService: ResourceOptimizerProtocol {
         }
 
         return totalTokens
+    }
+
+    private func tokensUsedByExternalToolLogs(_ providerName: String, since startDate: Date) async -> Int {
+        let provider = Self.externalProviderKind(from: providerName)
+        switch provider {
+        case .claude:
+            let roots = claudeProjectsRoots
+            return await Task.detached(priority: .utility) {
+                Self.scanJSONLTokenUsage(roots: roots, since: startDate)
+            }.value
+        case .codex:
+            let roots = codexSessionsRoots
+            return await Task.detached(priority: .utility) {
+                Self.scanJSONLTokenUsage(roots: roots, since: startDate)
+            }.value
+        case .unknown:
+            return 0
+        }
+    }
+
+    private func normalizedProviderKey(_ providerName: String) -> String {
+        providerName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private enum ExternalProviderKind {
+        case claude
+        case codex
+        case unknown
+    }
+
+    private struct ParsedTokenUsage: Hashable {
+        let input: Int
+        let output: Int
+        let total: Int
+    }
+
+    nonisolated private static func defaultClaudeProjectsRoots() -> [URL] {
+        let env = ProcessInfo.processInfo.environment
+        let home = FileManager.default.homeDirectoryForCurrentUser
+
+        var rawRoots: [URL] = []
+        if let custom = env["CLAUDE_CONFIG_DIR"], !custom.isEmpty {
+            let expanded = NSString(string: custom).expandingTildeInPath
+            rawRoots.append(URL(fileURLWithPath: expanded).appendingPathComponent("projects", isDirectory: true))
+        }
+        rawRoots.append(home.appendingPathComponent(".claude/projects", isDirectory: true))
+        rawRoots.append(home.appendingPathComponent(".config/claude/projects", isDirectory: true))
+        return uniqueStandardizedPaths(rawRoots)
+    }
+
+    nonisolated private static func defaultCodexSessionsRoots() -> [URL] {
+        let env = ProcessInfo.processInfo.environment
+        let home = FileManager.default.homeDirectoryForCurrentUser
+
+        var rawRoots: [URL] = []
+        if let custom = env["CODEX_HOME"], !custom.isEmpty {
+            let expanded = NSString(string: custom).expandingTildeInPath
+            rawRoots.append(URL(fileURLWithPath: expanded).appendingPathComponent("sessions", isDirectory: true))
+        }
+        rawRoots.append(home.appendingPathComponent(".codex/sessions", isDirectory: true))
+        return uniqueStandardizedPaths(rawRoots)
+    }
+
+    nonisolated private static func uniqueStandardizedPaths(_ urls: [URL]) -> [URL] {
+        var seen = Set<String>()
+        var unique: [URL] = []
+        for url in urls {
+            let normalized = url.standardizedFileURL
+            let key = normalized.path
+            if seen.insert(key).inserted {
+                unique.append(normalized)
+            }
+        }
+        return unique
+    }
+
+    nonisolated private static func externalProviderKind(from providerName: String) -> ExternalProviderKind {
+        let normalized = providerName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized.contains("claude") || normalized.contains("anthropic") {
+            return .claude
+        }
+        if normalized.contains("codex")
+            || normalized.contains("chatgpt")
+            || normalized.contains("openai") {
+            return .codex
+        }
+        return .unknown
+    }
+
+    nonisolated private static func scanJSONLTokenUsage(roots: [URL], since startDate: Date) -> Int {
+        guard !roots.isEmpty else { return 0 }
+
+        let candidateFiles = collectJSONLFiles(roots: roots, modifiedAfter: startDate.addingTimeInterval(-2 * 24 * 60 * 60))
+        guard !candidateFiles.isEmpty else { return 0 }
+
+        var total = 0
+        for file in candidateFiles {
+            total += parseJSONLFile(
+                at: file.url,
+                fileModifiedAt: file.modifiedAt,
+                since: startDate
+            )
+        }
+        return max(0, total)
+    }
+
+    nonisolated private static func collectJSONLFiles(
+        roots: [URL],
+        modifiedAfter: Date
+    ) -> [(url: URL, modifiedAt: Date)] {
+        let fm = FileManager.default
+        var files: [(url: URL, modifiedAt: Date)] = []
+
+        for root in roots {
+            var isDirectory: ObjCBool = false
+            guard fm.fileExists(atPath: root.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+                continue
+            }
+            guard let enumerator = fm.enumerator(
+                at: root,
+                includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+                options: [.skipsHiddenFiles]
+            ) else {
+                continue
+            }
+
+            for case let url as URL in enumerator {
+                guard url.pathExtension == "jsonl" else { continue }
+                guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey]),
+                      values.isRegularFile == true else { continue }
+                let modifiedAt = values.contentModificationDate ?? .distantPast
+                guard modifiedAt >= modifiedAfter else { continue }
+                files.append((url: url, modifiedAt: modifiedAt))
+            }
+        }
+
+        return files
+            .sorted(by: { $0.modifiedAt > $1.modifiedAt })
+            .prefix(180)
+            .map { $0 }
+    }
+
+    nonisolated private static func parseJSONLFile(
+        at fileURL: URL,
+        fileModifiedAt: Date,
+        since startDate: Date
+    ) -> Int {
+        guard let handle = try? FileHandle(forReadingFrom: fileURL) else {
+            return 0
+        }
+        defer { try? handle.close() }
+
+        var buffer = Data()
+        var total = 0
+
+        while let chunk = try? handle.read(upToCount: 64 * 1024), !chunk.isEmpty {
+            buffer.append(chunk)
+
+            while let newline = buffer.firstIndex(of: 0x0A) {
+                let lineData = Data(buffer[..<newline])
+                buffer.removeSubrange(...newline)
+                total += parseJSONLLine(
+                    lineData,
+                    fileModifiedAt: fileModifiedAt,
+                    since: startDate
+                )
+            }
+        }
+
+        if !buffer.isEmpty {
+            total += parseJSONLLine(
+                buffer,
+                fileModifiedAt: fileModifiedAt,
+                since: startDate
+            )
+        }
+
+        return total
+    }
+
+    nonisolated private static func parseJSONLLine(
+        _ lineData: Data,
+        fileModifiedAt: Date,
+        since startDate: Date
+    ) -> Int {
+        guard !lineData.isEmpty,
+              let json = try? JSONSerialization.jsonObject(with: lineData) else {
+            return 0
+        }
+
+        let eventDate = extractEventDate(from: json) ?? fileModifiedAt
+        guard eventDate >= startDate else { return 0 }
+
+        var usages = Set<ParsedTokenUsage>()
+        collectParsedTokenUsages(from: json, into: &usages, depth: 0)
+        guard !usages.isEmpty else { return 0 }
+
+        return usages.reduce(0) { partial, usage in
+            let candidate = usage.total > 0 ? usage.total : (usage.input + usage.output)
+            return partial + max(0, candidate)
+        }
+    }
+
+    nonisolated private static func collectParsedTokenUsages(
+        from value: Any,
+        into results: inout Set<ParsedTokenUsage>,
+        depth: Int
+    ) {
+        guard depth <= 12 else { return }
+
+        if let dictionary = value as? [String: Any] {
+            if let parsed = parseTokenUsage(from: dictionary) {
+                results.insert(parsed)
+            }
+            for child in dictionary.values {
+                collectParsedTokenUsages(from: child, into: &results, depth: depth + 1)
+            }
+            return
+        }
+
+        if let array = value as? [Any] {
+            for child in array {
+                collectParsedTokenUsages(from: child, into: &results, depth: depth + 1)
+            }
+        }
+    }
+
+    nonisolated private static func parseTokenUsage(from dictionary: [String: Any]) -> ParsedTokenUsage? {
+        var input = 0
+        var output = 0
+        var total = 0
+        var found = false
+
+        for (key, value) in dictionary {
+            let normalized = normalizeUsageKey(key)
+            if inputTokenKeys.contains(normalized) {
+                input += parseInteger(value) ?? 0
+                found = true
+                continue
+            }
+            if outputTokenKeys.contains(normalized) {
+                output += parseInteger(value) ?? 0
+                found = true
+                continue
+            }
+            if totalTokenKeys.contains(normalized) {
+                total += parseInteger(value) ?? 0
+                found = true
+            }
+        }
+
+        guard found else { return nil }
+        return ParsedTokenUsage(
+            input: max(0, input),
+            output: max(0, output),
+            total: max(0, total)
+        )
+    }
+
+    nonisolated private static func extractEventDate(from value: Any) -> Date? {
+        extractEventDate(from: value, depth: 0)
+    }
+
+    nonisolated private static func extractEventDate(from value: Any, depth: Int) -> Date? {
+        guard depth <= 8 else { return nil }
+
+        if let dictionary = value as? [String: Any] {
+            for (key, rawValue) in dictionary {
+                let normalized = normalizeUsageKey(key)
+                if timestampKeys.contains(normalized),
+                   let parsed = parseDate(rawValue) {
+                    return parsed
+                }
+            }
+            for child in dictionary.values {
+                if let parsed = extractEventDate(from: child, depth: depth + 1) {
+                    return parsed
+                }
+            }
+            return nil
+        }
+
+        if let array = value as? [Any] {
+            for child in array {
+                if let parsed = extractEventDate(from: child, depth: depth + 1) {
+                    return parsed
+                }
+            }
+        }
+
+        return nil
+    }
+
+    nonisolated private static func parseInteger(_ value: Any?) -> Int? {
+        guard let value else { return nil }
+        if let intValue = value as? Int {
+            return intValue
+        }
+        if let number = value as? NSNumber {
+            return number.intValue
+        }
+        if let string = value as? String {
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let intValue = Int(trimmed) {
+                return intValue
+            }
+            if let doubleValue = Double(trimmed) {
+                return Int(doubleValue.rounded())
+            }
+            return nil
+        }
+        if let dictionary = value as? [String: Any] {
+            for key in ["total", "count", "value"] {
+                if let parsed = parseInteger(dictionary[key]) {
+                    return parsed
+                }
+            }
+            return nil
+        }
+        return nil
+    }
+
+    nonisolated private static func parseDate(_ value: Any?) -> Date? {
+        guard let value else { return nil }
+        if let number = value as? NSNumber {
+            return parseUnixTimestamp(number.doubleValue)
+        }
+        if let intValue = value as? Int {
+            return parseUnixTimestamp(Double(intValue))
+        }
+        if let doubleValue = value as? Double {
+            return parseUnixTimestamp(doubleValue)
+        }
+        if let string = value as? String {
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            if let unix = Double(trimmed) {
+                return parseUnixTimestamp(unix)
+            }
+            if let parsed = parseISO8601Date(trimmed) {
+                return parsed
+            }
+            if let parsed = parseFallbackDate(trimmed) {
+                return parsed
+            }
+        }
+        return nil
+    }
+
+    nonisolated private static func parseUnixTimestamp(_ raw: Double) -> Date? {
+        guard raw > 0 else { return nil }
+        if raw > 1_000_000_000_000 {
+            return Date(timeIntervalSince1970: raw / 1000.0)
+        }
+        if raw > 1_000_000_000 {
+            return Date(timeIntervalSince1970: raw)
+        }
+        return nil
+    }
+
+    nonisolated private static func normalizeUsageKey(_ key: String) -> String {
+        let lower = key.lowercased()
+        let scalars = lower.unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) }
+        return String(String.UnicodeScalarView(scalars))
+    }
+
+    nonisolated private static let inputTokenKeys: Set<String> = [
+        "inputtokens",
+        "inputtokencount",
+        "prompttokens",
+        "prompttokencount",
+        "cachecreationinputtokens",
+        "cachereadinputtokens",
+    ]
+
+    nonisolated private static let outputTokenKeys: Set<String> = [
+        "outputtokens",
+        "outputtokencount",
+        "completiontokens",
+        "completiontokencount",
+    ]
+
+    nonisolated private static let totalTokenKeys: Set<String> = [
+        "totaltokens",
+        "totaltokencount",
+        "tokencount",
+    ]
+
+    nonisolated private static let timestampKeys: Set<String> = [
+        "timestamp",
+        "createdat",
+        "createdtime",
+        "eventtime",
+        "time",
+        "datetime",
+        "updatedat",
+        "modified",
+    ]
+
+    nonisolated private static let fallbackDateFormats: [String] = {
+        let formats = [
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd HH:mm:ss.SSS",
+            "yyyy-MM-dd'T'HH:mm:ss",
+        ]
+        return formats
+    }()
+
+    nonisolated private static func parseISO8601Date(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let parsed = fractional.date(from: value) {
+            return parsed
+        }
+
+        let basic = ISO8601DateFormatter()
+        basic.formatOptions = [.withInternetDateTime]
+        return basic.date(from: value)
+    }
+
+    nonisolated private static func parseFallbackDate(_ value: String) -> Date? {
+        for format in fallbackDateFormats {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = format
+            if let parsed = formatter.date(from: value) {
+                return parsed
+            }
+        }
+        return nil
     }
 }

--- a/DochiTests/ResourceOptimizerTests.swift
+++ b/DochiTests/ResourceOptimizerTests.swift
@@ -412,6 +412,7 @@ final class ResourceOptimizerTests: XCTestCase {
 
         XCTAssertEqual(decoded.providerName, "OpenAI")
         XCTAssertEqual(decoded.planName, "Pro")
+        XCTAssertEqual(decoded.usageSource, .dochiUsageStore)
         XCTAssertNil(decoded.monthlyTokenLimit)
         XCTAssertEqual(decoded.resetDayOfMonth, 1)
         XCTAssertEqual(decoded.monthlyCostUSD, 0)
@@ -481,6 +482,80 @@ final class ResourceOptimizerTests: XCTestCase {
 
         XCTAssertEqual(util.usageRatio, 0)
         XCTAssertEqual(util.currentUnusedPercent, 0)
+    }
+
+    func testUtilizationUsesDochiUsageStoreWhenSourceIsDochiUsageStore() async {
+        let usageDir = tempDir.appendingPathComponent("usage-source-store")
+        try? FileManager.default.createDirectory(at: usageDir, withIntermediateDirectories: true)
+        let store = UsageStore(baseURL: usageDir)
+        let now = Date()
+
+        await store.record(ExchangeMetrics(
+            provider: "openai",
+            model: "gpt-4o",
+            inputTokens: 120,
+            outputTokens: 80,
+            totalTokens: 200,
+            firstByteLatency: 0.1,
+            totalLatency: 0.3,
+            timestamp: now,
+            wasFallback: false,
+            agentName: "도치"
+        ))
+        await store.flushToDisk()
+
+        let sourceService = ResourceOptimizerService(
+            baseURL: tempDir.appendingPathComponent("resource-store-source"),
+            usageStore: store,
+            claudeProjectsRoots: [tempDir.appendingPathComponent("empty-claude")],
+            codexSessionsRoots: [tempDir.appendingPathComponent("empty-codex")]
+        )
+        let plan = SubscriptionPlan(
+            providerName: "openai",
+            planName: "Metered",
+            usageSource: .dochiUsageStore,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+
+        let util = await sourceService.utilization(for: plan)
+        XCTAssertEqual(util.usedTokens, 200)
+    }
+
+    func testUtilizationUsesExternalToolLogsWhenSourceIsExternalToolLogs() async throws {
+        let claudeRoot = tempDir.appendingPathComponent("claude-projects")
+        let codexRoot = tempDir.appendingPathComponent("codex-sessions")
+        try FileManager.default.createDirectory(at: claudeRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: codexRoot, withIntermediateDirectories: true)
+
+        let activeTime = Date()
+        let inactiveTime = activeTime.addingTimeInterval(-40 * 24 * 60 * 60)
+        let iso = ISO8601DateFormatter()
+
+        let sessionURL = codexRoot.appendingPathComponent("session-1.jsonl")
+        let lines = [
+            "{\"timestamp\":\"\(iso.string(from: activeTime))\",\"usage\":{\"input_tokens\":300,\"output_tokens\":120}}",
+            "{\"timestamp\":\"\(iso.string(from: inactiveTime))\",\"usage\":{\"input_tokens\":999,\"output_tokens\":999}}",
+        ].joined(separator: "\n")
+        try lines.write(to: sessionURL, atomically: true, encoding: .utf8)
+
+        let sourceService = ResourceOptimizerService(
+            baseURL: tempDir.appendingPathComponent("resource-external-source"),
+            usageStore: nil,
+            claudeProjectsRoots: [claudeRoot],
+            codexSessionsRoots: [codexRoot]
+        )
+
+        let plan = SubscriptionPlan(
+            providerName: "ChatGPT Pro",
+            planName: "Plus",
+            usageSource: .externalToolLogs,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+
+        let util = await sourceService.utilization(for: plan)
+        XCTAssertEqual(util.usedTokens, 420)
     }
 
     // MARK: - Mock Tests


### PR DESCRIPTION
## Summary
- `SubscriptionPlan`에 `usageSource`를 추가해 구독제 사용량 집계 소스를 명시적으로 분리
- `ResourceOptimizerService`에서 `dochiUsageStore`/`externalToolLogs` 경로를 분기하고 외부 JSONL 로그 기반 토큰 집계 지원
- 외부 로그 집계에 루트 탐색, 파일 후보 필터링, 라인별 usage/timestamp 파싱, 45초 캐시를 추가
- 사용량 소스별 동작을 검증하는 테스트 2건과 backward compatibility 검증을 보강

## Test
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ResourceOptimizerTests`

Closes #460
