### PR TITLE
feat(UX): 사용량 대시보드에 구독/종량 축 분리 노출

### DIFF
--- a/Dochi/Views/Settings/SubscriptionEditSheet.swift
+++ b/Dochi/Views/Settings/SubscriptionEditSheet.swift
@@ -8,6 +8,7 @@ struct SubscriptionEditSheet: View {
 
     @State private var providerName: String = ""
     @State private var planName: String = ""
+    @State private var usageSource: SubscriptionUsageSource = .externalToolLogs
     @State private var isUnlimited: Bool = false
     @State private var monthlyTokenLimit: String = ""
     @State private var resetDay: Int = 1
@@ -39,6 +40,19 @@ struct SubscriptionEditSheet: View {
                 // Plan name
                 TextField("플랜명", text: $planName)
                     .textFieldStyle(.roundedBorder)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Picker("사용량 소스", selection: $usageSource) {
+                        ForEach(SubscriptionUsageSource.allCases, id: \.self) { source in
+                            Text(source.displayName).tag(source)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    Text(usageSource.detailText)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
 
                 // Token limit
                 Toggle("무제한", isOn: $isUnlimited)
@@ -93,34 +107,59 @@ struct SubscriptionEditSheet: View {
             }
             .padding()
         }
-        .frame(width: 420, height: 380)
+        .frame(width: 420, height: 430)
         .onAppear {
             if let sub = subscription {
                 providerName = sub.providerName
                 planName = sub.planName
+                usageSource = sub.usageSource
                 isUnlimited = sub.monthlyTokenLimit == nil
                 monthlyTokenLimit = sub.monthlyTokenLimit.map(String.init) ?? ""
                 resetDay = sub.resetDayOfMonth
                 monthlyCost = String(format: "%.2f", sub.monthlyCostUSD)
             } else {
                 providerName = providerOptions[0]
+                usageSource = .externalToolLogs
             }
         }
     }
 
     private func save() {
+        let plan = Self.makePlan(
+            subscription: subscription,
+            providerName: providerName,
+            planName: planName,
+            usageSource: usageSource,
+            isUnlimited: isUnlimited,
+            monthlyTokenLimit: monthlyTokenLimit,
+            resetDay: resetDay,
+            monthlyCost: monthlyCost
+        )
+        onSave(plan)
+    }
+
+    static func makePlan(
+        subscription: SubscriptionPlan?,
+        providerName: String,
+        planName: String,
+        usageSource: SubscriptionUsageSource,
+        isUnlimited: Bool,
+        monthlyTokenLimit: String,
+        resetDay: Int,
+        monthlyCost: String
+    ) -> SubscriptionPlan {
         let tokenLimit: Int? = isUnlimited ? nil : Int(monthlyTokenLimit)
         let cost = Double(monthlyCost) ?? 0
 
-        let plan = SubscriptionPlan(
+        return SubscriptionPlan(
             id: subscription?.id ?? UUID(),
             providerName: providerName,
             planName: planName,
+            usageSource: usageSource,
             monthlyTokenLimit: tokenLimit,
             resetDayOfMonth: resetDay,
             monthlyCostUSD: cost,
             createdAt: subscription?.createdAt ?? Date()
         )
-        onSave(plan)
     }
 }

--- a/Dochi/Views/Settings/UsageDashboardView.swift
+++ b/Dochi/Views/Settings/UsageDashboardView.swift
@@ -48,6 +48,12 @@ struct UsageDashboardView: View {
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
 
+                usageAxisHeader(
+                    title: "종량제 (Dochi API)",
+                    detail: "UsageStore 기반 토큰/비용 집계"
+                )
+                .padding(.horizontal)
+
                 if isLoading {
                     ProgressView("로딩 중...")
                         .frame(maxWidth: .infinity, minHeight: 200)
@@ -147,6 +153,16 @@ struct UsageDashboardView: View {
     }
 
     // MARK: - Summary Cards
+
+    private func usageAxisHeader(title: String, detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+            Text(detail)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+    }
 
     private func summaryCards(_ summary: MonthlyUsageSummary) -> some View {
         let filtered = filteredDays(from: summary)
@@ -542,8 +558,10 @@ struct UsageDashboardView: View {
 
     private func subscriptionCardsSection(_ optimizer: any ResourceOptimizerProtocol) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("구독 플랜 사용률")
-                .font(.system(size: 13, weight: .semibold))
+            usageAxisHeader(
+                title: "구독제 (Subscription)",
+                detail: "구독 플랜별 잔여량과 낭비 위험 추적"
+            )
 
             if utilizations.isEmpty {
                 VStack(spacing: 8) {
@@ -586,6 +604,14 @@ struct UsageDashboardView: View {
                     .foregroundStyle(.secondary)
                 Spacer()
                 riskBadge(util.riskLevel)
+            }
+
+            HStack(spacing: 6) {
+                usageSourceBadge(util.subscription.usageSource)
+                Text(util.subscription.usageSource.detailText)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
             }
 
             // Usage gauge
@@ -653,6 +679,25 @@ struct UsageDashboardView: View {
         case .caution: return .yellow
         case .wasteRisk: return .red
         case .normal: return .blue
+        }
+    }
+
+    private func usageSourceBadge(_ source: SubscriptionUsageSource) -> some View {
+        Text(source.displayName)
+            .font(.system(size: 9, weight: .medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(usageSourceColor(source).opacity(0.14))
+            .foregroundStyle(usageSourceColor(source))
+            .clipShape(Capsule())
+    }
+
+    private func usageSourceColor(_ source: SubscriptionUsageSource) -> Color {
+        switch source {
+        case .externalToolLogs:
+            return .indigo
+        case .dochiUsageStore:
+            return .teal
         }
     }
 
@@ -781,25 +826,29 @@ struct UsageDashboardView: View {
                     HStack(spacing: 8) {
                         Text(sub.providerName)
                             .font(.system(size: 11, weight: .medium))
-                            .frame(width: 80, alignment: .leading)
+                            .frame(width: 76, alignment: .leading)
                         Text(sub.planName)
                             .font(.system(size: 11))
-                            .frame(width: 80, alignment: .leading)
+                            .frame(width: 72, alignment: .leading)
                             .lineLimit(1)
+                        Text(sub.usageSource.displayName)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 82, alignment: .leading)
                         if let limit = sub.monthlyTokenLimit {
                             Text(formatTokens(limit))
                                 .font(.system(size: 10, design: .monospaced))
-                                .frame(width: 60, alignment: .trailing)
+                                .frame(width: 56, alignment: .trailing)
                         } else {
                             Text("무제한")
                                 .font(.system(size: 10))
                                 .foregroundStyle(.secondary)
-                                .frame(width: 60, alignment: .trailing)
+                                .frame(width: 56, alignment: .trailing)
                         }
                         Text("매월 \(sub.resetDayOfMonth)일")
                             .font(.system(size: 10))
                             .foregroundStyle(.secondary)
-                            .frame(width: 60, alignment: .trailing)
+                            .frame(width: 54, alignment: .trailing)
                         Spacer()
                         Button {
                             editingSubscription = sub

--- a/DochiTests/ResourceOptimizerTests.swift
+++ b/DochiTests/ResourceOptimizerTests.swift
@@ -375,6 +375,7 @@ final class ResourceOptimizerTests: XCTestCase {
         let plan = SubscriptionPlan(
             providerName: "OpenAI",
             planName: "Pro",
+            usageSource: .externalToolLogs,
             monthlyTokenLimit: 1_000_000,
             resetDayOfMonth: 15,
             monthlyCostUSD: 20.0
@@ -391,6 +392,7 @@ final class ResourceOptimizerTests: XCTestCase {
         XCTAssertEqual(decoded.id, plan.id)
         XCTAssertEqual(decoded.providerName, "OpenAI")
         XCTAssertEqual(decoded.planName, "Pro")
+        XCTAssertEqual(decoded.usageSource, .externalToolLogs)
         XCTAssertEqual(decoded.monthlyTokenLimit, 1_000_000)
         XCTAssertEqual(decoded.resetDayOfMonth, 15)
         XCTAssertEqual(decoded.monthlyCostUSD, 20.0)
@@ -416,6 +418,74 @@ final class ResourceOptimizerTests: XCTestCase {
         XCTAssertNil(decoded.monthlyTokenLimit)
         XCTAssertEqual(decoded.resetDayOfMonth, 1)
         XCTAssertEqual(decoded.monthlyCostUSD, 0)
+    }
+
+    func testSubscriptionEditSheetMakePlanUsesSelectedUsageSourceAndValues() {
+        let plan = SubscriptionEditSheet.makePlan(
+            subscription: nil,
+            providerName: "OpenAI",
+            planName: "Pro",
+            usageSource: .externalToolLogs,
+            isUnlimited: false,
+            monthlyTokenLimit: "1200000",
+            resetDay: 7,
+            monthlyCost: "20.50"
+        )
+
+        XCTAssertEqual(plan.providerName, "OpenAI")
+        XCTAssertEqual(plan.planName, "Pro")
+        XCTAssertEqual(plan.usageSource, .externalToolLogs)
+        XCTAssertEqual(plan.monthlyTokenLimit, 1_200_000)
+        XCTAssertEqual(plan.resetDayOfMonth, 7)
+        XCTAssertEqual(plan.monthlyCostUSD, 20.5, accuracy: 0.0001)
+    }
+
+    func testSubscriptionEditSheetMakePlanPreservesIdentityWhenEditing() {
+        let originalCreatedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let original = SubscriptionPlan(
+            id: UUID(),
+            providerName: "Anthropic",
+            planName: "Max",
+            usageSource: .dochiUsageStore,
+            monthlyTokenLimit: nil,
+            resetDayOfMonth: 1,
+            monthlyCostUSD: 30,
+            createdAt: originalCreatedAt
+        )
+
+        let edited = SubscriptionEditSheet.makePlan(
+            subscription: original,
+            providerName: "Anthropic",
+            planName: "Max Plus",
+            usageSource: .externalToolLogs,
+            isUnlimited: true,
+            monthlyTokenLimit: "999999",
+            resetDay: 1,
+            monthlyCost: "40"
+        )
+
+        XCTAssertEqual(edited.id, original.id)
+        XCTAssertEqual(edited.createdAt, originalCreatedAt)
+        XCTAssertEqual(edited.usageSource, .externalToolLogs)
+        XCTAssertEqual(edited.planName, "Max Plus")
+        XCTAssertNil(edited.monthlyTokenLimit)
+    }
+
+    func testSubscriptionEditSheetMakePlanUnlimitedDropsTokenLimitAndHandlesInvalidCost() {
+        let plan = SubscriptionEditSheet.makePlan(
+            subscription: nil,
+            providerName: "OpenAI",
+            planName: "Unlimited",
+            usageSource: .dochiUsageStore,
+            isUnlimited: true,
+            monthlyTokenLimit: "not-a-number",
+            resetDay: 12,
+            monthlyCost: "abc"
+        )
+
+        XCTAssertNil(plan.monthlyTokenLimit)
+        XCTAssertEqual(plan.monthlyCostUSD, 0, accuracy: 0.0001)
+        XCTAssertEqual(plan.usageSource, .dochiUsageStore)
     }
 
     func testAutoTaskRecordCodable() throws {


### PR DESCRIPTION
## Summary
- Usage Dashboard 상단에 `종량제 (Dochi API)` 축 헤더를 추가해 종량제 사용량 영역을 명시적으로 분리
- 구독 카드에 `사용량 소스` 배지와 소스 설명을 추가해 계산 기준(외부 로그 vs UsageStore)을 즉시 확인 가능하도록 개선
- 구독 플랜 관리 리스트에 소스 컬럼을 추가해 편집 전에도 현재 소스 구성을 빠르게 확인 가능
- `SubscriptionEditSheet`에 `사용량 소스` 선택 UI(세그먼트 + 설명 문구) 및 저장 경로 연결
- `SubscriptionEditSheet.makePlan` 경계 케이스를 검증하는 테스트 3건 추가, `SubscriptionPlan` Codable 테스트에 source roundtrip 검증 보강

## UX Notes
- 이슈 코멘트에 MVP UX 기획안 반영: https://github.com/midagedev/dochi/issues/461#issuecomment-3940112193

## Test
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ResourceOptimizerTests`

Closes #461
