### PR TITLE
fix: Heartbeat 자원 자동작업을 구독제 축 기준으로 보정

### DIFF
--- a/Dochi/Services/ResourceOptimizerService.swift
+++ b/Dochi/Services/ResourceOptimizerService.swift
@@ -257,7 +257,9 @@ final class ResourceOptimizerService: ResourceOptimizerProtocol {
             gitCandidates = []
         }
 
-        let utilizations = await allUtilizations()
+        let utilizations = (await allUtilizations()).filter {
+            $0.subscription.usageSource == .externalToolLogs
+        }
         let now = Date()
         var queuedCount = 0
 

--- a/DochiTests/HeartbeatServiceTests.swift
+++ b/DochiTests/HeartbeatServiceTests.swift
@@ -771,6 +771,63 @@ final class HeartbeatServiceTests: XCTestCase {
         XCTAssertEqual(Set(optimizer.lastEvaluatedTypes), Set([.research]))
     }
 
+    func testTickResourceAutoTaskUsesSubscriptionSourceAxis() async throws {
+        let settings = AppSettings()
+        settings.heartbeatEnabled = true
+        settings.heartbeatIntervalMinutes = 0
+        settings.heartbeatCheckCalendar = false
+        settings.heartbeatCheckKanban = false
+        settings.heartbeatCheckReminders = false
+        settings.heartbeatQuietHoursStart = 0
+        settings.heartbeatQuietHoursEnd = 0
+        settings.resourceAutoTaskEnabled = true
+        settings.resourceAutoTaskOnlyWasteRisk = false
+        settings.resourceAutoTaskTypes = [AutoTaskType.research.rawValue]
+
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("HeartbeatResourceOptimizer-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let optimizer = ResourceOptimizerService(
+            baseURL: tempRoot.appendingPathComponent("optimizer"),
+            usageStore: nil,
+            claudeProjectsRoots: [tempRoot.appendingPathComponent("claude-empty")],
+            codexSessionsRoots: [tempRoot.appendingPathComponent("codex-empty")]
+        )
+        let meteredPlan = SubscriptionPlan(
+            providerName: "OpenAI",
+            planName: "Metered",
+            usageSource: .dochiUsageStore,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+        let subscriptionPlan = SubscriptionPlan(
+            providerName: "ChatGPT Pro",
+            planName: "Plus",
+            usageSource: .externalToolLogs,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+        await optimizer.addSubscription(meteredPlan)
+        await optimizer.addSubscription(subscriptionPlan)
+
+        let service = HeartbeatService(settings: settings)
+        service.setResourceOptimizer(optimizer)
+
+        service.start()
+        defer { service.stop() }
+
+        let timeout = Date().addingTimeInterval(0.5)
+        while service.lastTickDate == nil && Date() < timeout {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertNotNil(service.lastTickDate)
+        XCTAssertEqual(optimizer.autoTaskRecords.count, 1)
+        XCTAssertEqual(optimizer.autoTaskRecords.first?.subscriptionId, subscriptionPlan.id)
+    }
+
     // MARK: - Proactive Handler
 
     func testProactiveHandlerIsCalled() {

--- a/DochiTests/ResourceOptimizerTests.swift
+++ b/DochiTests/ResourceOptimizerTests.swift
@@ -10,7 +10,16 @@ final class ResourceOptimizerTests: XCTestCase {
     override func setUp() async throws {
         tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        service = ResourceOptimizerService(baseURL: tempDir, usageStore: nil)
+        let emptyClaude = tempDir.appendingPathComponent("empty-claude")
+        let emptyCodex = tempDir.appendingPathComponent("empty-codex")
+        try FileManager.default.createDirectory(at: emptyClaude, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: emptyCodex, withIntermediateDirectories: true)
+        service = ResourceOptimizerService(
+            baseURL: tempDir,
+            usageStore: nil,
+            claudeProjectsRoots: [emptyClaude],
+            codexSessionsRoots: [emptyCodex]
+        )
     }
 
     override func tearDown() async throws {
@@ -180,6 +189,7 @@ final class ResourceOptimizerTests: XCTestCase {
         let plan = SubscriptionPlan(
             providerName: "OpenAI",
             planName: "Pro",
+            usageSource: .externalToolLogs,
             monthlyTokenLimit: 1_000_000,
             resetDayOfMonth: 1
         )
@@ -204,12 +214,14 @@ final class ResourceOptimizerTests: XCTestCase {
         let normalPlan = SubscriptionPlan(
             providerName: "OpenAI",
             planName: "Normal",
+            usageSource: .externalToolLogs,
             monthlyTokenLimit: 1_000_000,
             resetDayOfMonth: normalResetDay
         )
         let wasteRiskPlan = SubscriptionPlan(
             providerName: "Anthropic",
             planName: "Near reset",
+            usageSource: .externalToolLogs,
             monthlyTokenLimit: 1_000_000,
             resetDayOfMonth: wasteRiskResetDay
         )
@@ -231,6 +243,7 @@ final class ResourceOptimizerTests: XCTestCase {
         let plan = SubscriptionPlan(
             providerName: "OpenAI",
             planName: "Pro",
+            usageSource: .externalToolLogs,
             monthlyTokenLimit: 1_000_000,
             resetDayOfMonth: 1
         )
@@ -258,6 +271,7 @@ final class ResourceOptimizerTests: XCTestCase {
         let plan = SubscriptionPlan(
             providerName: "OpenAI",
             planName: "Pro",
+            usageSource: .externalToolLogs,
             monthlyTokenLimit: 1_000_000,
             resetDayOfMonth: 1
         )
@@ -284,6 +298,7 @@ final class ResourceOptimizerTests: XCTestCase {
         let plan = SubscriptionPlan(
             providerName: "OpenAI",
             planName: "Pro",
+            usageSource: .externalToolLogs,
             monthlyTokenLimit: 1_000_000,
             resetDayOfMonth: 1
         )
@@ -314,6 +329,7 @@ final class ResourceOptimizerTests: XCTestCase {
         let plan = SubscriptionPlan(
             providerName: "OpenAI",
             planName: "Pro",
+            usageSource: .externalToolLogs,
             monthlyTokenLimit: 1_000_000,
             resetDayOfMonth: 1
         )
@@ -327,6 +343,99 @@ final class ResourceOptimizerTests: XCTestCase {
 
         XCTAssertEqual(queued, 0)
         XCTAssertTrue(service.autoTaskRecords.isEmpty)
+    }
+
+    func testEvaluateAndQueueAutoTasksSkipsDochiUsageStoreSource() async {
+        let meteredPlan = SubscriptionPlan(
+            providerName: "OpenAI",
+            planName: "Metered",
+            usageSource: .dochiUsageStore,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+        let subscriptionPlan = SubscriptionPlan(
+            providerName: "ChatGPT Pro",
+            planName: "Plus",
+            usageSource: .externalToolLogs,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+        await service.addSubscription(meteredPlan)
+        await service.addSubscription(subscriptionPlan)
+
+        let queued = await service.evaluateAndQueueAutoTasks(
+            enabledTypes: [.research],
+            onlyWasteRisk: false
+        )
+
+        XCTAssertEqual(queued, 1)
+        XCTAssertEqual(service.autoTaskRecords.count, 1)
+        XCTAssertEqual(service.autoTaskRecords.first?.subscriptionId, subscriptionPlan.id)
+    }
+
+    func testEvaluateAndQueueAutoTasksOnlyWasteRiskWithMixedSourcesUsesSubscriptionAxis() async {
+        let calendar = Calendar.current
+        let todayDay = calendar.component(.day, from: Date())
+        let wasteRiskResetDay = todayDay < 28 ? todayDay + 1 : 1
+
+        let meteredWasteRiskPlan = SubscriptionPlan(
+            providerName: "OpenAI",
+            planName: "Metered",
+            usageSource: .dochiUsageStore,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: wasteRiskResetDay
+        )
+        let subscriptionWasteRiskPlan = SubscriptionPlan(
+            providerName: "Claude Max",
+            planName: "Max",
+            usageSource: .externalToolLogs,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: wasteRiskResetDay
+        )
+        await service.addSubscription(meteredWasteRiskPlan)
+        await service.addSubscription(subscriptionWasteRiskPlan)
+
+        let queued = await service.evaluateAndQueueAutoTasks(
+            enabledTypes: [.research],
+            onlyWasteRisk: true
+        )
+
+        XCTAssertEqual(queued, 1)
+        XCTAssertEqual(service.autoTaskRecords.count, 1)
+        XCTAssertEqual(service.autoTaskRecords.first?.subscriptionId, subscriptionWasteRiskPlan.id)
+    }
+
+    func testEvaluateAndQueueAutoTasksMaintainsSameDayDedupeWithMixedSources() async {
+        let meteredPlan = SubscriptionPlan(
+            providerName: "OpenAI",
+            planName: "Metered",
+            usageSource: .dochiUsageStore,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+        let subscriptionPlan = SubscriptionPlan(
+            providerName: "Claude Max",
+            planName: "Max",
+            usageSource: .externalToolLogs,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+        await service.addSubscription(meteredPlan)
+        await service.addSubscription(subscriptionPlan)
+
+        let first = await service.evaluateAndQueueAutoTasks(
+            enabledTypes: [.research],
+            onlyWasteRisk: false
+        )
+        let second = await service.evaluateAndQueueAutoTasks(
+            enabledTypes: [.research],
+            onlyWasteRisk: false
+        )
+
+        XCTAssertEqual(first, 1)
+        XCTAssertEqual(second, 0)
+        XCTAssertEqual(service.autoTaskRecords.count, 1)
+        XCTAssertEqual(service.autoTaskRecords.first?.subscriptionId, subscriptionPlan.id)
     }
 
     // MARK: - Utilization


### PR DESCRIPTION
## Summary
- Resource auto-task 평가 대상을 `externalToolLogs` 소스 구독으로 제한해 Heartbeat 자동작업이 `구독제 축` 기준으로만 동작하도록 보정
- `ResourceOptimizerTests`의 auto-task 관련 플랜을 source-aware 시나리오로 정리하고, 소스 혼합 상태에서의 onlyWasteRisk/동일일 dedupe 회귀 테스트를 추가
- 테스트 환경의 외부 로그 경로를 임시 빈 디렉터리로 고정해 로컬 세션 로그에 의한 비결정성 제거
- `HeartbeatServiceTests`에 실제 `ResourceOptimizerService`를 연결한 통합 테스트를 추가해 tick 시 subscription axis만 큐잉되는지 검증

## Test
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ResourceOptimizerTests -only-testing:DochiTests/HeartbeatServiceTests`

Closes #462
