### PR TITLE
test: stabilize AppSettings default sync settings test

### DIFF
--- a/DochiTests/SyncEngineTests.swift
+++ b/DochiTests/SyncEngineTests.swift
@@ -589,7 +589,35 @@ final class SyncModelsTests: XCTestCase {
 @MainActor
 final class AppSettingsSyncTests: XCTestCase {
 
+    private let syncDefaultKeys = [
+        "autoSyncEnabled",
+        "realtimeSyncEnabled",
+        "syncConversations",
+        "syncMemory",
+        "syncKanban",
+        "syncProfiles",
+        "conflictResolutionStrategy",
+    ]
+
     func testDefaultSyncSettings() {
+        let defaults = UserDefaults.standard
+        var snapshot: [String: Any] = [:]
+        for key in syncDefaultKeys {
+            if let value = defaults.object(forKey: key) {
+                snapshot[key] = value
+            }
+            defaults.removeObject(forKey: key)
+        }
+        defer {
+            for key in syncDefaultKeys {
+                if let value = snapshot[key] {
+                    defaults.set(value, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+        }
+
         let settings = AppSettings()
         XCTAssertTrue(settings.autoSyncEnabled)
         XCTAssertTrue(settings.realtimeSyncEnabled)


### PR DESCRIPTION
## Summary
- isolate `AppSettingsSyncTests.testDefaultSyncSettings()` from shared `UserDefaults.standard` state
- snapshot and restore sync-setting keys with `defer` so the test does not leak state to other tests
- keep the default-value assertion behavior unchanged

## Linked Issue
Closes #476

## Spec Impact
- No spec doc changes (`spec/` impact: none)

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/AppSettingsSyncTests` ✅
- `xcodebuild ... -only-testing:DochiTests/AppSettingsSyncTests/testDefaultSyncSettings` repeated 20 runs ✅ (20/20 pass)
