### PR TITLE
perf: index UsageStore latest provider day for freshness lookups (#484)

### DIFF
--- a/Dochi/Services/Protocols/UsageStoreProtocol.swift
+++ b/Dochi/Services/Protocols/UsageStoreProtocol.swift
@@ -17,4 +17,7 @@ protocol UsageStoreProtocol: Sendable {
 
     /// Get total cost for the current month.
     func currentMonthCost() async -> Double
+
+    /// Get latest recorded day for a provider.
+    func latestRecordDay(for provider: String) async -> Date?
 }

--- a/Dochi/Services/ResourceOptimizerService.swift
+++ b/Dochi/Services/ResourceOptimizerService.swift
@@ -649,14 +649,6 @@ final class ResourceOptimizerService: ResourceOptimizerProtocol {
         return formatter.string(from: date)
     }
 
-    nonisolated private static func parseUsageStoreDay(_ value: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone.current
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.date(from: value)
-    }
-
     nonisolated private static func lineCountForText(_ text: String) -> Int {
         guard !text.isEmpty else { return 0 }
         var count = 0
@@ -766,21 +758,10 @@ final class ResourceOptimizerService: ResourceOptimizerProtocol {
         guard let store = usageStore else { return [:] }
         guard !normalizedProviders.isEmpty else { return [:] }
 
-        let months = await store.allMonths()
         var latestMap: [String: Date] = [:]
-
-        for month in months {
-            let records = await store.dailyRecords(for: month)
-            for day in records {
-                guard let recordDate = Self.parseUsageStoreDay(day.date) else { continue }
-                for entry in day.entries {
-                    let key = normalizedProviderKey(entry.provider)
-                    guard normalizedProviders.contains(key) else { continue }
-                    if let current = latestMap[key], current >= recordDate {
-                        continue
-                    }
-                    latestMap[key] = recordDate
-                }
+        for normalizedProvider in normalizedProviders {
+            if let latest = await store.latestRecordDay(for: normalizedProvider) {
+                latestMap[normalizedProvider] = latest
             }
         }
 

--- a/Dochi/Services/UsageStore.swift
+++ b/Dochi/Services/UsageStore.swift
@@ -6,10 +6,17 @@ import os
 @MainActor
 @Observable
 final class UsageStore: UsageStoreProtocol {
+    private struct ProviderLatestIndexFile: Codable, Sendable {
+        var version: Int = 1
+        var latestDayByProvider: [String: String] = [:]
+    }
 
     private let baseURL: URL
     private var cache: [String: MonthlyUsageFile] = [:]
     private var dirtyMonths: Set<String> = []
+    private var providerLatestDayIndex: [String: String] = [:]
+    private var isProviderLatestIndexLoaded = false
+    private var isProviderLatestIndexDirty = false
     private var saveTask: Task<Void, Never>?
     private static let debounceInterval: TimeInterval = 5.0
 
@@ -38,6 +45,7 @@ final class UsageStore: UsageStoreProtocol {
     // MARK: - UsageStoreProtocol
 
     func record(_ metrics: ExchangeMetrics) async {
+        await ensureProviderLatestIndexLoaded()
         let monthKey = Self.monthFormatter.string(from: metrics.timestamp)
         let dayKey = Self.dayFormatter.string(from: metrics.timestamp)
 
@@ -66,6 +74,8 @@ final class UsageStore: UsageStoreProtocol {
         } else {
             file.days.append(DailyUsageRecord(date: dayKey, entries: [entry]))
         }
+
+        updateProviderLatestDayIndex(provider: metrics.provider, dayKey: dayKey)
 
         cache[monthKey] = file
         dirtyMonths.insert(monthKey)
@@ -102,7 +112,11 @@ final class UsageStore: UsageStoreProtocol {
             return []
         }
         return files
-            .filter { $0.pathExtension == "json" }
+            .filter { url in
+                guard url.pathExtension == "json" else { return false }
+                let name = url.deletingPathExtension().lastPathComponent
+                return name.range(of: #"^\d{4}-\d{2}$"#, options: .regularExpression) != nil
+            }
             .map { $0.deletingPathExtension().lastPathComponent }
             .sorted()
     }
@@ -111,6 +125,14 @@ final class UsageStore: UsageStoreProtocol {
         let monthKey = Self.monthFormatter.string(from: Date())
         let summary = await monthlySummary(for: monthKey)
         return summary.totalCostUSD
+    }
+
+    func latestRecordDay(for provider: String) async -> Date? {
+        await ensureProviderLatestIndexLoaded()
+        let key = Self.normalizedProviderKey(provider)
+        guard !key.isEmpty else { return nil }
+        guard let dayKey = providerLatestDayIndex[key] else { return nil }
+        return Self.dayFormatter.date(from: dayKey)
     }
 
     // MARK: - File I/O
@@ -170,6 +192,7 @@ final class UsageStore: UsageStoreProtocol {
                 }
             }
             dirtyMonths.removeAll()
+            saveProviderLatestIndexIfNeeded()
         }
     }
 
@@ -191,11 +214,83 @@ final class UsageStore: UsageStoreProtocol {
             }
         }
         dirtyMonths.removeAll()
+        saveProviderLatestIndexIfNeeded()
     }
 
     private func usageFileURL(for monthKey: String) -> URL {
         baseURL
             .appendingPathComponent("usage", isDirectory: true)
             .appendingPathComponent("\(monthKey).json")
+    }
+
+    private func providerLatestIndexURL() -> URL {
+        baseURL
+            .appendingPathComponent("usage", isDirectory: true)
+            .appendingPathComponent("provider-latest-index.json")
+    }
+
+    private func updateProviderLatestDayIndex(provider: String, dayKey: String) {
+        let key = Self.normalizedProviderKey(provider)
+        guard !key.isEmpty else { return }
+        if let current = providerLatestDayIndex[key], current >= dayKey {
+            return
+        }
+        providerLatestDayIndex[key] = dayKey
+        isProviderLatestIndexDirty = true
+    }
+
+    private func ensureProviderLatestIndexLoaded() async {
+        guard !isProviderLatestIndexLoaded else { return }
+        isProviderLatestIndexLoaded = true
+
+        let fileURL = providerLatestIndexURL()
+        if let data = try? Data(contentsOf: fileURL),
+           let file = try? JSONDecoder().decode(ProviderLatestIndexFile.self, from: data) {
+            providerLatestDayIndex = file.latestDayByProvider
+            return
+        }
+
+        providerLatestDayIndex = await rebuildProviderLatestDayIndexFromUsageFiles()
+        isProviderLatestIndexDirty = true
+    }
+
+    private func rebuildProviderLatestDayIndexFromUsageFiles() async -> [String: String] {
+        let months = await allMonths()
+        var latest: [String: String] = [:]
+
+        for month in months {
+            let records = await dailyRecords(for: month)
+            for day in records {
+                for entry in day.entries {
+                    let key = Self.normalizedProviderKey(entry.provider)
+                    guard !key.isEmpty else { continue }
+                    if let current = latest[key], current >= day.date {
+                        continue
+                    }
+                    latest[key] = day.date
+                }
+            }
+        }
+
+        return latest
+    }
+
+    private func saveProviderLatestIndexIfNeeded() {
+        guard isProviderLatestIndexDirty else { return }
+        let file = ProviderLatestIndexFile(latestDayByProvider: providerLatestDayIndex)
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(file)
+            try data.write(to: providerLatestIndexURL(), options: .atomic)
+            isProviderLatestIndexDirty = false
+            Log.storage.debug("Usage provider index saved")
+        } catch {
+            Log.storage.error("Failed to save provider latest index: \(error.localizedDescription)")
+        }
+    }
+
+    nonisolated private static func normalizedProviderKey(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -492,13 +492,22 @@ final class MockSupabaseService: SupabaseServiceProtocol {
 final class MockUsageStore: UsageStoreProtocol {
     var recordedMetrics: [ExchangeMetrics] = []
     var stubbedCost: Double = 0.0
+    var latestDayByProvider: [String: Date] = [:]
+    var dailyRecordsCallCount = 0
+    var allMonthsCallCount = 0
+    var latestRecordDayCallCount = 0
 
     func record(_ metrics: ExchangeMetrics) async {
         recordedMetrics.append(metrics)
+        let key = metrics.provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if !key.isEmpty {
+            latestDayByProvider[key] = metrics.timestamp
+        }
     }
 
     func dailyRecords(for month: String) async -> [DailyUsageRecord] {
-        []
+        dailyRecordsCallCount += 1
+        return []
     }
 
     func monthlySummary(for month: String) async -> MonthlyUsageSummary {
@@ -513,11 +522,18 @@ final class MockUsageStore: UsageStoreProtocol {
     }
 
     func allMonths() async -> [String] {
-        []
+        allMonthsCallCount += 1
+        return []
     }
 
     func currentMonthCost() async -> Double {
         stubbedCost
+    }
+
+    func latestRecordDay(for provider: String) async -> Date? {
+        latestRecordDayCallCount += 1
+        let key = provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return latestDayByProvider[key]
     }
 }
 

--- a/DochiTests/ResourceOptimizerTests.swift
+++ b/DochiTests/ResourceOptimizerTests.swift
@@ -740,6 +740,31 @@ final class ResourceOptimizerTests: XCTestCase {
         XCTAssertNotNil(snapshot.lastCollectedAt)
     }
 
+    func testMonitoringSnapshotUsesUsageStoreLatestRecordDayIndexAPI() async {
+        let mockStore = MockUsageStore()
+        mockStore.latestDayByProvider["openai"] = Date()
+
+        let sourceService = ResourceOptimizerService(
+            baseURL: tempDir.appendingPathComponent("resource-monitoring-store-index"),
+            usageStore: mockStore,
+            claudeProjectsRoots: [tempDir.appendingPathComponent("empty-claude")],
+            codexSessionsRoots: [tempDir.appendingPathComponent("empty-codex")]
+        )
+        let plan = SubscriptionPlan(
+            providerName: "openai",
+            planName: "Metered",
+            usageSource: .dochiUsageStore,
+            monthlyTokenLimit: 1_000_000,
+            resetDayOfMonth: 1
+        )
+
+        let snapshot = await sourceService.monitoringSnapshot(for: plan)
+        XCTAssertEqual(snapshot.statusCode, "ok_store")
+        XCTAssertEqual(mockStore.latestRecordDayCallCount, 1)
+        XCTAssertEqual(mockStore.allMonthsCallCount, 0)
+        XCTAssertEqual(mockStore.dailyRecordsCallCount, 0)
+    }
+
     func testMonitoringSnapshotGeminiUnsupportedAuthType() async throws {
         let geminiRoot = tempDir.appendingPathComponent("gemini-monitoring-unsupported")
         try FileManager.default.createDirectory(at: geminiRoot, withIntermediateDirectories: true)

--- a/DochiTests/UsageDashboardTests.swift
+++ b/DochiTests/UsageDashboardTests.swift
@@ -180,6 +180,79 @@ final class UsageStoreTests: XCTestCase {
         XCTAssertEqual(records[0].entries.count, 1)
     }
 
+    func testLatestRecordDayPersistsAndReloads() async throws {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let earlier = try XCTUnwrap(formatter.date(from: "2026-02-02"))
+        let later = try XCTUnwrap(formatter.date(from: "2026-02-18"))
+
+        await store.record(ExchangeMetrics(
+            provider: "OpenAI",
+            model: "gpt-4o",
+            inputTokens: 100,
+            outputTokens: 50,
+            totalTokens: 150,
+            firstByteLatency: nil,
+            totalLatency: 1.0,
+            timestamp: earlier,
+            wasFallback: false
+        ))
+        await store.record(ExchangeMetrics(
+            provider: "openai",
+            model: "gpt-4o",
+            inputTokens: 120,
+            outputTokens: 80,
+            totalTokens: 200,
+            firstByteLatency: nil,
+            totalLatency: 1.0,
+            timestamp: later,
+            wasFallback: false
+        ))
+        await store.flushToDisk()
+
+        let latest = await store.latestRecordDay(for: "OPENAI")
+        XCTAssertEqual(latest.map { formatter.string(from: $0) }, "2026-02-18")
+
+        let reloaded = UsageStore(baseURL: tempDir)
+        let latestFromReload = await reloaded.latestRecordDay(for: "openai")
+        XCTAssertEqual(latestFromReload.map { formatter.string(from: $0) }, "2026-02-18")
+        let months = await reloaded.allMonths()
+        XCTAssertEqual(months, ["2026-02"])
+    }
+
+    func testLatestRecordDayRebuildsWhenIndexMissing() async throws {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let sampleDate = try XCTUnwrap(formatter.date(from: "2026-03-11"))
+
+        await store.record(ExchangeMetrics(
+            provider: "anthropic",
+            model: "claude-3-5-sonnet-20241022",
+            inputTokens: 90,
+            outputTokens: 30,
+            totalTokens: 120,
+            firstByteLatency: nil,
+            totalLatency: 1.0,
+            timestamp: sampleDate,
+            wasFallback: false
+        ))
+        await store.flushToDisk()
+
+        let indexURL = tempDir
+            .appendingPathComponent("usage", isDirectory: true)
+            .appendingPathComponent("provider-latest-index.json")
+        try? FileManager.default.removeItem(at: indexURL)
+
+        let rebuilt = UsageStore(baseURL: tempDir)
+        let latest = await rebuilt.latestRecordDay(for: "anthropic")
+        XCTAssertEqual(latest.map { formatter.string(from: $0) }, "2026-03-11")
+
+        await rebuilt.flushToDisk()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: indexURL.path))
+    }
+
     func testEmptyMonthReturnsEmptyRecords() async {
         let records = await store.dailyRecords(for: "2020-01")
         XCTAssertTrue(records.isEmpty)


### PR DESCRIPTION
## Summary
- added `latestRecordDay(for:)` to `UsageStoreProtocol`
- implemented provider latest-day index in `UsageStore` with disk persistence (`usage/provider-latest-index.json`)
- made month discovery ignore non-month JSON files to avoid index file pollution
- switched `ResourceOptimizerService` freshness lookup to index API (O(1) per provider) instead of month/day scans
- updated mocks/tests for the new API and added rebuild/persistence coverage

## Tests
- xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination "platform=macOS" -only-testing:DochiTests/ResourceOptimizerTests -only-testing:DochiTests/UsageStoreTests

Closes #484