### PR TITLE
feat: 내부 LLM 플래너 기반 프로액티브 제안 생성

### DIFF
--- a/Dochi/App/DochiApp.swift
+++ b/Dochi/App/DochiApp.swift
@@ -198,6 +198,17 @@ struct DochiApp: App {
         )
         self.toolService = toolService
 
+        let nativeAgentLoopService = NativeAgentLoopService(
+            adapters: [
+                AnthropicNativeLLMProviderAdapter(),
+                OpenAINativeLLMProviderAdapter(),
+                ZAINativeLLMProviderAdapter(),
+                OllamaNativeLLMProviderAdapter(),
+                LMStudioNativeLLMProviderAdapter()
+            ],
+            toolService: toolService
+        )
+
         let metricsCollector = MetricsCollector()
         metricsCollector.usageStore = usageStore
         metricsCollector.settings = settings
@@ -224,11 +235,17 @@ struct DochiApp: App {
         self.externalToolManager = externalToolManager
 
         // Proactive Suggestion Service (K-2)
+        let proactiveSuggestionLLMClient = NativeProactiveSuggestionLLMClient(
+            settings: settings,
+            keychainService: keychainService,
+            nativeAgentLoopService: nativeAgentLoopService
+        )
         let proactiveSuggestionService = ProactiveSuggestionService(
             settings: settings,
             contextService: contextService,
             conversationService: conversationService,
-            sessionContext: sessionContext
+            sessionContext: sessionContext,
+            llmClient: proactiveSuggestionLLMClient
         )
         self.proactiveSuggestionService = proactiveSuggestionService
 
@@ -270,7 +287,8 @@ struct DochiApp: App {
             soundService: soundService,
             settings: settings,
             sessionContext: sessionContext,
-            metricsCollector: metricsCollector
+            metricsCollector: metricsCollector,
+            nativeAgentLoopService: nativeAgentLoopService
         )
         _viewModel = State(initialValue: viewModel)
 

--- a/Dochi/Services/ProactiveSuggestionService.swift
+++ b/Dochi/Services/ProactiveSuggestionService.swift
@@ -19,6 +19,7 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
     private let contextService: ContextServiceProtocol
     private let conversationService: ConversationServiceProtocol
     private let sessionContext: SessionContext
+    private let llmClient: ProactiveSuggestionLLMClientProtocol?
 
     // MARK: - Telegram Relay (K-6)
 
@@ -40,6 +41,9 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
     private static let maxHistoryCount = 20
     private static let idleCheckIntervalSeconds: UInt64 = 30
     private static let duplicateCooldownHours: TimeInterval = 24 * 3600
+    private static let llmConversationLimit = 4
+    private static let llmKanbanCardLimit = 4
+    private static let llmMemorySnippetLimit = 280
 
     // MARK: - Init
 
@@ -47,12 +51,14 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
         settings: AppSettings,
         contextService: ContextServiceProtocol,
         conversationService: ConversationServiceProtocol,
-        sessionContext: SessionContext
+        sessionContext: SessionContext,
+        llmClient: ProactiveSuggestionLLMClientProtocol? = nil
     ) {
         self.settings = settings
         self.contextService = contextService
         self.conversationService = conversationService
         self.sessionContext = sessionContext
+        self.llmClient = llmClient
         todayDateString = Self.dateString(from: Date())
         Log.app.info("ProactiveSuggestionService initialized")
     }
@@ -189,16 +195,20 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
             return
         }
 
+        if let llmCandidate = await buildLLMCandidate(enabledTypes: enabledTypes) {
+            if isDuplicateSuggestion(llmCandidate) {
+                state = .idle
+                return
+            }
+            await publishSuggestion(llmCandidate)
+            return
+        }
+
         var candidates: [ProactiveSuggestion] = []
 
         for type in enabledTypes {
             if let candidate = buildCandidate(for: type) {
-                // Duplicate filter: skip if same title was suggested in last 24h
-                let isDuplicate = suggestionHistory.contains { record in
-                    record.title == candidate.title &&
-                    record.timestamp.timeIntervalSinceNow > -Self.duplicateCooldownHours
-                }
-                if !isDuplicate {
+                if !isDuplicateSuggestion(candidate) {
                     candidates.append(candidate)
                 }
             }
@@ -211,23 +221,7 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
 
         // Select by priority
         candidates.sort { $0.type.priority < $1.type.priority }
-        var selected = candidates[0]
-        selected.status = .shown
-
-        currentSuggestion = selected
-        todaySuggestionCount += 1
-        lastSuggestionDate = Date()
-        state = .hasSuggestion
-
-        // Add toast event
-        toastEvents.append(SuggestionToastEvent(suggestion: selected))
-
-        // Telegram relay (K-6)
-        if let telegramRelay {
-            await telegramRelay.sendSuggestion(selected)
-        }
-
-        Log.app.info("Suggestion generated: \(selected.type.rawValue) — \(selected.title)")
+        await publishSuggestion(candidates[0])
     }
 
     private func buildCandidate(for type: SuggestionType) -> ProactiveSuggestion? {
@@ -351,6 +345,10 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
         )
     }
 
+    func runSuggestionGenerationForTesting() async {
+        await generateSuggestion()
+    }
+
     // MARK: - Helpers
 
     private func activeTypes() -> [SuggestionType] {
@@ -389,6 +387,365 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
         }
     }
 
+    private func isDuplicateSuggestion(_ suggestion: ProactiveSuggestion) -> Bool {
+        suggestionHistory.contains { record in
+            record.title == suggestion.title &&
+            record.timestamp.timeIntervalSinceNow > -Self.duplicateCooldownHours
+        }
+    }
+
+    private func publishSuggestion(_ suggestion: ProactiveSuggestion) async {
+        var selected = suggestion
+        selected.status = .shown
+
+        currentSuggestion = selected
+        todaySuggestionCount += 1
+        lastSuggestionDate = Date()
+        state = .hasSuggestion
+        toastEvents.append(SuggestionToastEvent(suggestion: selected))
+
+        if let telegramRelay {
+            await telegramRelay.sendSuggestion(selected)
+        }
+
+        Log.app.info("Suggestion generated: \(selected.type.rawValue) — \(selected.title)")
+    }
+
+    // MARK: - LLM Suggestion
+
+    private struct LLMConversationSignal {
+        let id: UUID
+        let title: String
+        let lastUserMessage: String?
+    }
+
+    private struct LLMKanbanSignal {
+        let boardId: UUID
+        let boardName: String
+        let cardId: UUID
+        let cardTitle: String
+    }
+
+    private struct LLMContextSnapshot {
+        let conversations: [LLMConversationSignal]
+        let memorySnippet: String?
+        let memoryUserId: String?
+        let inProgressCards: [LLMKanbanSignal]
+        let recentSuggestionTitles: [String]
+    }
+
+    private struct LLMSuggestionPayload: Decodable {
+        let shouldSuggest: Bool?
+        let type: String
+        let title: String
+        let body: String
+        let suggestedPrompt: String
+        let sourceContext: String?
+    }
+
+    private func buildLLMCandidate(enabledTypes: [SuggestionType]) async -> ProactiveSuggestion? {
+        guard let llmClient else { return nil }
+
+        let snapshot = buildLLMContextSnapshot()
+        let systemPrompt = llmSystemPrompt()
+        let userPrompt = llmUserPrompt(enabledTypes: enabledTypes, snapshot: snapshot)
+
+        do {
+            let raw = try await llmClient.generateSuggestionJSON(
+                systemPrompt: systemPrompt,
+                userPrompt: userPrompt
+            )
+            guard let candidate = parseLLMResponse(
+                raw,
+                enabledTypes: enabledTypes,
+                snapshot: snapshot
+            ) else {
+                Log.llm.debug("Proactive suggestion LLM output was not actionable")
+                return nil
+            }
+            guard !isMetaInstructionSuggestion(candidate) else {
+                Log.llm.notice("Proactive suggestion LLM output rejected: meta instruction pattern")
+                return nil
+            }
+            return candidate
+        } catch {
+            Log.llm.debug("Proactive suggestion LLM generation failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func buildLLMContextSnapshot() -> LLMContextSnapshot {
+        let conversations = conversationService.list()
+            .prefix(Self.llmConversationLimit)
+            .map { conversation in
+                LLMConversationSignal(
+                    id: conversation.id,
+                    title: Self.normalizedSuggestionText(conversation.title, maxLength: 80),
+                    lastUserMessage: Self.latestUserMessage(in: conversation)
+                )
+            }
+
+        let userId = sessionContext.currentUserId?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let memorySnippet: String? = {
+            guard let userId, !userId.isEmpty else { return nil }
+            guard let memory = contextService.loadUserMemory(userId: userId), !memory.isEmpty else { return nil }
+            return Self.normalizedSuggestionText(memory, maxLength: Self.llmMemorySnippetLimit)
+        }()
+
+        var inProgressCards: [LLMKanbanSignal] = []
+        for board in KanbanManager.shared.listBoards() {
+            let cards = board.cards.filter {
+                $0.column.contains("진행") || $0.column.lowercased().contains("progress")
+            }
+            for card in cards {
+                inProgressCards.append(
+                    LLMKanbanSignal(
+                        boardId: board.id,
+                        boardName: Self.normalizedSuggestionText(board.name, maxLength: 40),
+                        cardId: card.id,
+                        cardTitle: Self.normalizedSuggestionText(card.title, maxLength: 70)
+                    )
+                )
+                if inProgressCards.count >= Self.llmKanbanCardLimit {
+                    break
+                }
+            }
+            if inProgressCards.count >= Self.llmKanbanCardLimit {
+                break
+            }
+        }
+
+        return LLMContextSnapshot(
+            conversations: Array(conversations),
+            memorySnippet: memorySnippet,
+            memoryUserId: userId,
+            inProgressCards: inProgressCards,
+            recentSuggestionTitles: Array(suggestionHistory.prefix(6).map(\.title))
+        )
+    }
+
+    private static func latestUserMessage(in conversation: Conversation) -> String? {
+        guard let message = conversation.messages.reversed().first(where: { $0.role == .user }) else {
+            return nil
+        }
+        let normalized = normalizedSuggestionText(message.content, maxLength: 120)
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private func llmSystemPrompt() -> String {
+        """
+        너는 Dochi의 프로액티브 제안 큐레이터다.
+        목표는 "지금 즉시 실행 가능한 제안 1개"를 만드는 것이다.
+
+        반드시 지켜라:
+        1) 제공된 컨텍스트에 없는 내용은 추측하지 않는다.
+        2) 메타 지시(도구 호출 규칙, 시스템 프롬프트, datetime/JSON/함수 호출 안내) 제안은 금지한다.
+        3) 반복적이고 추상적인 표현(예: "더 자세히 설명드릴까요?")은 피하고 구체적 행동을 제시한다.
+        4) 가치 있는 제안이 없으면 shouldSuggest=false 를 반환한다.
+        5) 출력은 JSON 객체 하나만 반환한다. Markdown, 코드블록, 설명문 금지.
+
+        JSON schema:
+        {
+          "shouldSuggest": boolean,
+          "type": "newsTrend|deepDive|relatedResearch|kanbanCheck|memoryRemind|costReport",
+          "title": "string (max 28 chars)",
+          "body": "string (max 90 chars)",
+          "suggestedPrompt": "string (사용자가 바로 보낼 문장)",
+          "sourceContext": "string (conversation:<id> | memory:<userId> | kanban:<boardId>/<cardId> | usage)"
+        }
+        """
+    }
+
+    private func llmUserPrompt(enabledTypes: [SuggestionType], snapshot: LLMContextSnapshot) -> String {
+        var lines: [String] = []
+        lines.append("enabledTypes: \(enabledTypes.map(\.rawValue).joined(separator: ", "))")
+        lines.append("enabledTypeHints:")
+        for type in enabledTypes {
+            lines.append("- \(type.rawValue): \(type.displayName)")
+        }
+
+        lines.append("recentConversations:")
+        if snapshot.conversations.isEmpty {
+            lines.append("- (없음)")
+        } else {
+            for item in snapshot.conversations {
+                if let lastUserMessage = item.lastUserMessage, !lastUserMessage.isEmpty {
+                    lines.append("- id=\(item.id.uuidString) title=\(item.title) lastUser=\(lastUserMessage)")
+                } else {
+                    lines.append("- id=\(item.id.uuidString) title=\(item.title)")
+                }
+            }
+        }
+
+        lines.append("memorySnippet:")
+        lines.append(snapshot.memorySnippet ?? "(없음)")
+
+        lines.append("kanbanInProgress:")
+        if snapshot.inProgressCards.isEmpty {
+            lines.append("- (없음)")
+        } else {
+            for item in snapshot.inProgressCards {
+                lines.append("- boardId=\(item.boardId.uuidString) board=\(item.boardName) cardId=\(item.cardId.uuidString) card=\(item.cardTitle)")
+            }
+        }
+
+        lines.append("recentSuggestionTitles:")
+        if snapshot.recentSuggestionTitles.isEmpty {
+            lines.append("- (없음)")
+        } else {
+            for title in snapshot.recentSuggestionTitles {
+                lines.append("- \(Self.normalizedSuggestionText(title, maxLength: 60))")
+            }
+        }
+
+        lines.append("JSON only.")
+        return lines.joined(separator: "\n")
+    }
+
+    private func parseLLMResponse(
+        _ response: String,
+        enabledTypes: [SuggestionType],
+        snapshot: LLMContextSnapshot
+    ) -> ProactiveSuggestion? {
+        guard let jsonText = Self.extractFirstJSONObject(from: response) else { return nil }
+        guard let data = jsonText.data(using: .utf8) else { return nil }
+        guard let payload = try? JSONDecoder().decode(LLMSuggestionPayload.self, from: data) else {
+            return nil
+        }
+
+        if payload.shouldSuggest == false {
+            return nil
+        }
+
+        guard let type = SuggestionType(rawValue: payload.type),
+              enabledTypes.contains(type),
+              isContextAvailable(for: type, snapshot: snapshot) else {
+            return nil
+        }
+
+        let title = Self.normalizedSuggestionText(payload.title, maxLength: 40)
+        let body = Self.normalizedSuggestionText(payload.body, maxLength: 160)
+        let suggestedPrompt = Self.normalizedSuggestionText(payload.suggestedPrompt, maxLength: 220)
+        guard !title.isEmpty, !body.isEmpty, !suggestedPrompt.isEmpty else {
+            return nil
+        }
+
+        let sourceContext = normalizedSourceContext(
+            payload.sourceContext,
+            type: type,
+            snapshot: snapshot
+        )
+
+        return ProactiveSuggestion(
+            type: type,
+            title: title,
+            body: body,
+            suggestedPrompt: suggestedPrompt,
+            sourceContext: sourceContext
+        )
+    }
+
+    private func isContextAvailable(for type: SuggestionType, snapshot: LLMContextSnapshot) -> Bool {
+        switch type {
+        case .newsTrend, .deepDive, .relatedResearch:
+            return !snapshot.conversations.isEmpty
+        case .kanbanCheck:
+            return !snapshot.inProgressCards.isEmpty
+        case .memoryRemind:
+            return snapshot.memorySnippet != nil
+        case .costReport:
+            return true
+        }
+    }
+
+    private func normalizedSourceContext(
+        _ sourceContext: String?,
+        type: SuggestionType,
+        snapshot: LLMContextSnapshot
+    ) -> String {
+        let normalized = Self.normalizedSuggestionText(sourceContext ?? "", maxLength: 120)
+        if !normalized.isEmpty {
+            return normalized
+        }
+
+        switch type {
+        case .newsTrend, .deepDive, .relatedResearch:
+            if let first = snapshot.conversations.first {
+                return "conversation:\(first.id)"
+            }
+            return "conversation:recent"
+        case .kanbanCheck:
+            if let first = snapshot.inProgressCards.first {
+                return "kanban:\(first.boardId)/\(first.cardId)"
+            }
+            return "kanban"
+        case .memoryRemind:
+            if let userId = snapshot.memoryUserId, !userId.isEmpty {
+                return "memory:\(userId)"
+            }
+            return "memory"
+        case .costReport:
+            return "usage"
+        }
+    }
+
+    private func isMetaInstructionSuggestion(_ suggestion: ProactiveSuggestion) -> Bool {
+        let combined = [
+            suggestion.title,
+            suggestion.body,
+            suggestion.suggestedPrompt,
+        ].joined(separator: " ").lowercased()
+
+        let bannedPatterns = [
+            "시스템 프롬프트",
+            "system prompt",
+            "도구 호출",
+            "tool call",
+            "함수 호출",
+            "function call",
+            "datetime 도구",
+            "json schema",
+            "prompt injection",
+        ]
+
+        return bannedPatterns.contains { combined.contains($0) }
+    }
+
+    private static func extractFirstJSONObject(from text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if trimmed.hasPrefix("{"), trimmed.hasSuffix("}") {
+            return trimmed
+        }
+
+        guard let start = trimmed.firstIndex(of: "{"),
+              let end = trimmed.lastIndex(of: "}") else {
+            return nil
+        }
+        return String(trimmed[start...end])
+    }
+
+    private static func normalizedSuggestionText(_ text: String, maxLength: Int) -> String {
+        let collapsedWhitespace = text
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard collapsedWhitespace.count > maxLength else {
+            return collapsedWhitespace
+        }
+
+        let index = collapsedWhitespace.index(
+            collapsedWhitespace.startIndex,
+            offsetBy: max(0, maxLength)
+        )
+        return String(collapsedWhitespace[..<index]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private func hasReachedDailyCap() -> Bool {
         let cap = max(settings.proactiveDailyCap, 0)
         return todaySuggestionCount >= cap
@@ -402,5 +759,182 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
 
     private static func dateString(from date: Date) -> String {
         dayFormatter.string(from: date)
+    }
+}
+
+@MainActor
+protocol ProactiveSuggestionLLMClientProtocol {
+    func generateSuggestionJSON(systemPrompt: String, userPrompt: String) async throws -> String
+}
+
+@MainActor
+final class NativeProactiveSuggestionLLMClient: ProactiveSuggestionLLMClientProtocol {
+    private let settings: AppSettings
+    private let keychainService: KeychainServiceProtocol
+    private let nativeAgentLoopService: NativeAgentLoopService
+
+    init(
+        settings: AppSettings,
+        keychainService: KeychainServiceProtocol,
+        nativeAgentLoopService: NativeAgentLoopService
+    ) {
+        self.settings = settings
+        self.keychainService = keychainService
+        self.nativeAgentLoopService = nativeAgentLoopService
+    }
+
+    func generateSuggestionJSON(systemPrompt: String, userPrompt: String) async throws -> String {
+        let provider = settings.currentProvider
+        let model = resolvedModel(for: provider)
+        guard !model.isEmpty else {
+            throw NativeLLMError(
+                code: .modelNotFound,
+                message: "No configured model for proactive suggestion",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        let apiKey = loadNativeAPIKey(for: provider)
+        if provider.requiresAPIKey, apiKey == nil {
+            throw NativeLLMError(
+                code: .authentication,
+                message: "API key is not configured for \(provider.rawValue)",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+
+        let request = NativeLLMRequest(
+            provider: provider,
+            model: model,
+            apiKey: apiKey,
+            systemPrompt: systemPrompt,
+            messages: [NativeLLMMessage(role: .user, text: userPrompt)],
+            tools: [],
+            maxTokens: 400,
+            temperature: 0.2,
+            endpointURL: nativeEndpointURL(for: provider),
+            timeoutSeconds: 20
+        )
+
+        var accumulated = ""
+        var doneText: String?
+
+        for try await event in nativeAgentLoopService.run(request: request) {
+            switch event.kind {
+            case .partial:
+                if let delta = event.text {
+                    accumulated += delta
+                }
+            case .done:
+                doneText = event.text ?? accumulated
+            case .error:
+                if let error = event.error {
+                    throw error
+                }
+                throw NativeLLMError(
+                    code: .unknown,
+                    message: "Native loop returned error event without payload",
+                    statusCode: nil,
+                    retryAfterSeconds: nil
+                )
+            case .toolUse, .toolResult:
+                continue
+            }
+        }
+
+        let text = (doneText ?? accumulated).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw NativeLLMError(
+                code: .invalidResponse,
+                message: "Native loop returned empty suggestion response",
+                statusCode: nil,
+                retryAfterSeconds: nil
+            )
+        }
+        return text
+    }
+
+    private func resolvedModel(for provider: LLMProvider) -> String {
+        let configured = settings.llmModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !configured.isEmpty {
+            return configured
+        }
+        return provider.models.first ?? provider.onboardingDefaultModel
+    }
+
+    private func loadNativeAPIKey(for provider: LLMProvider) -> String? {
+        guard provider.requiresAPIKey else { return nil }
+
+        if let key = keychainService.load(account: provider.keychainAccount)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !key.isEmpty {
+            return key
+        }
+
+        if let legacyAccount = provider.legacyAPIKeyAccount,
+           let legacy = keychainService.load(account: legacyAccount)?
+           .trimmingCharacters(in: .whitespacesAndNewlines),
+           !legacy.isEmpty {
+            return legacy
+        }
+
+        return nil
+    }
+
+    private func nativeEndpointURL(for provider: LLMProvider) -> URL? {
+        switch provider {
+        case .ollama:
+            return localChatCompletionsEndpoint(
+                baseURLString: settings.ollamaBaseURL,
+                fallback: provider.apiURL
+            )
+        case .lmStudio:
+            return localChatCompletionsEndpoint(
+                baseURLString: settings.lmStudioBaseURL,
+                fallback: provider.apiURL
+            )
+        default:
+            return nil
+        }
+    }
+
+    private func localChatCompletionsEndpoint(baseURLString: String, fallback: URL) -> URL {
+        let trimmed = baseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let baseURL = URL(string: trimmed) else {
+            return fallback
+        }
+
+        let normalizedPath = baseURL.path.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if normalizedPath.hasSuffix("v1/chat/completions") {
+            return baseURL
+        }
+        if normalizedPath.hasSuffix("chat/completions") {
+            return baseURL
+        }
+        if normalizedPath.hasSuffix("v1/models") {
+            return baseURL
+                .deletingLastPathComponent()
+                .appendingPathComponent("chat")
+                .appendingPathComponent("completions")
+        }
+        if normalizedPath.hasSuffix("v1") {
+            return baseURL
+                .appendingPathComponent("chat")
+                .appendingPathComponent("completions")
+        }
+        if normalizedPath.hasSuffix("api/tags") {
+            return baseURL
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("v1")
+                .appendingPathComponent("chat")
+                .appendingPathComponent("completions")
+        }
+        return baseURL
+            .appendingPathComponent("v1")
+            .appendingPathComponent("chat")
+            .appendingPathComponent("completions")
     }
 }

--- a/Dochi/Services/ProactiveSuggestionService.swift
+++ b/Dochi/Services/ProactiveSuggestionService.swift
@@ -614,7 +614,7 @@ final class ProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
             return nil
         }
 
-        if payload.shouldSuggest == false {
+        guard payload.shouldSuggest == true else {
             return nil
         }
 

--- a/DochiTests/Mocks/MockServices.swift
+++ b/DochiTests/Mocks/MockServices.swift
@@ -957,6 +957,38 @@ final class MockProactiveSuggestionService: ProactiveSuggestionServiceProtocol {
     }
 }
 
+// MARK: - MockProactiveSuggestionLLMClient
+
+@MainActor
+final class MockProactiveSuggestionLLMClient: ProactiveSuggestionLLMClientProtocol {
+    enum MockError: Error {
+        case noStubbedResponse
+    }
+
+    var callCount = 0
+    var lastSystemPrompt: String?
+    var lastUserPrompt: String?
+    var responses: [Result<String, Error>] = []
+
+    func generateSuggestionJSON(systemPrompt: String, userPrompt: String) async throws -> String {
+        callCount += 1
+        lastSystemPrompt = systemPrompt
+        lastUserPrompt = userPrompt
+
+        guard !responses.isEmpty else {
+            throw MockError.noStubbedResponse
+        }
+
+        let result = responses.removeFirst()
+        switch result {
+        case .success(let text):
+            return text
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
 // MARK: - MockExternalToolSessionManager (K-4)
 
 @MainActor

--- a/DochiTests/ProactiveSuggestionTests.swift
+++ b/DochiTests/ProactiveSuggestionTests.swift
@@ -301,7 +301,8 @@ final class ProactiveSuggestionServiceTests: XCTestCase {
     private func makeService(
         enabled: Bool = true,
         idleMinutes: Int = 30,
-        cooldownMinutes: Int = 60
+        cooldownMinutes: Int = 60,
+        llmClient: ProactiveSuggestionLLMClientProtocol? = nil
     ) -> (ProactiveSuggestionService, AppSettings, MockContextService, MockConversationService) {
         let settings = AppSettings()
         settings.proactiveSuggestionEnabled = enabled
@@ -326,7 +327,8 @@ final class ProactiveSuggestionServiceTests: XCTestCase {
             settings: settings,
             contextService: contextService,
             conversationService: conversationService,
-            sessionContext: sessionContext
+            sessionContext: sessionContext,
+            llmClient: llmClient
         )
 
         return (service, settings, contextService, conversationService)
@@ -554,6 +556,54 @@ final class ProactiveSuggestionServiceTests: XCTestCase {
         XCTAssertEqual(service.suggestionHistory[1].status, .deferred)
         XCTAssertEqual(service.suggestionHistory[2].title, "S1")
         XCTAssertEqual(service.suggestionHistory[2].status, .accepted)
+    }
+
+    // MARK: - LLM-backed generation
+
+    func testLLMCandidateIsUsedWhenValid() async {
+        let llmClient = MockProactiveSuggestionLLMClient()
+        llmClient.responses = [.success("""
+        {"shouldSuggest":true,"type":"deepDive","title":"Swift 6 동시성 점검","body":"최근 Swift 6 대화를 기준으로 핵심 이슈를 3개로 정리해볼까요?","suggestedPrompt":"최근 Swift 6 관련 대화에서 발생한 핵심 이슈 3개와 우선순위를 정리해줘","sourceContext":"conversation:recent"}
+        """)]
+
+        let (service, _, _, conversationService) = makeService(llmClient: llmClient)
+        conversationService.save(conversation: Conversation(
+            title: "Swift 6 마이그레이션",
+            messages: [Message(role: .user, content: "strict concurrency 경고를 줄이고 싶어")],
+            updatedAt: Date()
+        ))
+
+        await service.runSuggestionGenerationForTesting()
+
+        XCTAssertEqual(llmClient.callCount, 1)
+        XCTAssertEqual(service.currentSuggestion?.title, "Swift 6 동시성 점검")
+        XCTAssertEqual(service.currentSuggestion?.type, .deepDive)
+        XCTAssertEqual(service.state, .hasSuggestion)
+    }
+
+    func testMetaInstructionLLMOutputIsRejectedAndFallsBack() async {
+        let llmClient = MockProactiveSuggestionLLMClient()
+        llmClient.responses = [.success("""
+        {"shouldSuggest":true,"type":"deepDive","title":"이전 대화 주제 심화","body":"반드시 datetime 도구를 1회 호출하고 현재 시각만 답해.","suggestedPrompt":"datetime 도구 호출 규칙을 설명해줘","sourceContext":"conversation:recent"}
+        """)]
+
+        let (service, _, _, conversationService) = makeService(llmClient: llmClient)
+        conversationService.save(conversation: Conversation(
+            title: "테스트 주제 A",
+            messages: [Message(role: .user, content: "A")],
+            updatedAt: Date()
+        ))
+        conversationService.save(conversation: Conversation(
+            title: "테스트 주제 B",
+            messages: [Message(role: .user, content: "B")],
+            updatedAt: Date().addingTimeInterval(-10)
+        ))
+
+        await service.runSuggestionGenerationForTesting()
+
+        XCTAssertEqual(llmClient.callCount, 1)
+        XCTAssertNotNil(service.currentSuggestion)
+        XCTAssertFalse(service.currentSuggestion?.body.contains("datetime 도구") ?? true)
     }
 }
 

--- a/DochiTests/ProactiveSuggestionTests.swift
+++ b/DochiTests/ProactiveSuggestionTests.swift
@@ -605,6 +605,31 @@ final class ProactiveSuggestionServiceTests: XCTestCase {
         XCTAssertNotNil(service.currentSuggestion)
         XCTAssertFalse(service.currentSuggestion?.body.contains("datetime 도구") ?? true)
     }
+
+    func testMissingShouldSuggestIsRejectedAndFallsBack() async {
+        let llmClient = MockProactiveSuggestionLLMClient()
+        llmClient.responses = [.success("""
+        {"type":"deepDive","title":"누락 테스트","body":"이 값은 shouldSuggest 없이 오면 무시되어야 합니다.","suggestedPrompt":"무시 테스트","sourceContext":"conversation:recent"}
+        """)]
+
+        let (service, _, _, conversationService) = makeService(llmClient: llmClient)
+        conversationService.save(conversation: Conversation(
+            title: "테스트 주제 A",
+            messages: [Message(role: .user, content: "A")],
+            updatedAt: Date()
+        ))
+        conversationService.save(conversation: Conversation(
+            title: "테스트 주제 B",
+            messages: [Message(role: .user, content: "B")],
+            updatedAt: Date().addingTimeInterval(-10)
+        ))
+
+        await service.runSuggestionGenerationForTesting()
+
+        XCTAssertEqual(llmClient.callCount, 1)
+        XCTAssertNotNil(service.currentSuggestion)
+        XCTAssertNotEqual(service.currentSuggestion?.title, "누락 테스트")
+    }
 }
 
 // MARK: - Activity Signal Expansion (B2)


### PR DESCRIPTION
## Summary
- ProactiveSuggestionService에 내부 운영 LLM 기반 제안 생성 경로를 추가했습니다.
- LLM 출력(JSON) 파싱 + 메타 지시문 차단 + 정책 게이트(중복/일일 cap) 적용 후 노출하도록 구현했습니다.
- LLM 실패/무효 응답 시 기존 규칙 기반 후보 생성으로 안전하게 fallback 하도록 유지했습니다.
- DochiApp에서 Native LLM 클라이언트를 주입해 내부 LLM 경로를 wiring 했습니다.
- LLM 경로 테스트를 위한 mock client 및 단위테스트를 추가했습니다.

## Spec Impact
- `spec/ux/k2-proactive-suggestions.md`의 "맥락 기반 제안/피로 방지" 목표를 구현 경로에서 강화합니다.
- UI 구조 변경 없이 제안 품질과 노이즈 억제를 개선합니다.

## Test Evidence
- `xcodebuild test -project Dochi.xcodeproj -scheme Dochi -destination 'platform=macOS' -only-testing:DochiTests/ProactiveSuggestionServiceTests -only-testing:DochiTests/ProactiveSuggestionTests`

Fixes #491
